### PR TITLE
add posthog error tracking across api, worker, and proxy

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,7 +14,16 @@ import (
 	"github.com/ziraloop/ziraloop/internal/enqueue"
 	"github.com/ziraloop/ziraloop/internal/goroutine"
 	"github.com/ziraloop/ziraloop/internal/logging"
+	"github.com/ziraloop/ziraloop/internal/middleware"
+	posthogobs "github.com/ziraloop/ziraloop/internal/observability/posthog"
 )
+
+func init() {
+	// Wire the middleware-based distinct ID extractor into the posthog
+	// package. Done at init so background goroutines that start before
+	// run() (e.g. memguard) still have a valid extractor installed.
+	posthogobs.SetDistinctIDExtractor(middleware.DistinctID)
+}
 
 // @title ZiraLoop API
 // @version 1.0
@@ -50,7 +59,9 @@ func main() {
 	}
 
 	if err := run(cmd); err != nil {
-		slog.Error("fatal", "error", err)
+		// run() already logs the fatal via slog.Error BEFORE deps.Close
+		// runs, so any wrapped PostHog client will have captured it. Here
+		// we only need to flag the exit code — no log needed.
 		os.Exit(1)
 	}
 }
@@ -60,6 +71,7 @@ func run(cmd string) error {
 	// Logging must be initialized first.
 	cfg, err := loadConfigForLogging()
 	if err != nil {
+		slog.Error("fatal", "error", err)
 		return err
 	}
 	logging.Init(cfg.LogLevel, cfg.LogFormat)
@@ -70,10 +82,43 @@ func run(cmd string) error {
 
 	deps, err := bootstrap.New(ctx)
 	if err != nil {
+		// No PostHog client yet — log to stdout only.
+		slog.Error("bootstrap failed", "error", err)
 		return err
 	}
 	defer deps.Close()
 
+	// Wrap the global slog handler so every Error-level log mirrors to
+	// PostHog error tracking. This is a no-op when PostHog is disabled.
+	// Must happen AFTER bootstrap.New so the PostHog client exists, but
+	// BEFORE runServe/runWork so all subsequent errors are captured.
+	if deps.PostHog != nil {
+		wrapped := posthogobs.WrapSlogHandler(slog.Default().Handler(), deps.PostHog)
+		slog.SetDefault(slog.New(wrapped))
+	}
+
+	posthogobs.CaptureEvent(deps.PostHog, ctx, "service_started", map[string]any{
+		"mode":    cmd,
+		"version": version,
+		"commit":  commit,
+	})
+
+	runErr := dispatch(ctx, cmd, deps)
+	if runErr != nil {
+		// Log the fatal through the wrapped slog handler BEFORE deps.Close
+		// flushes the PostHog client, so the exception is captured.
+		slog.Error("service exited with error", "mode", cmd, "error", runErr)
+	}
+
+	posthogobs.CaptureEvent(deps.PostHog, ctx, "service_stopped", map[string]any{
+		"mode":   cmd,
+		"errored": runErr != nil,
+	})
+
+	return runErr
+}
+
+func dispatch(ctx context.Context, cmd string, deps *bootstrap.Deps) error {
 	switch cmd {
 	case "serve":
 		enqueuer := enqueue.NewClient(deps.Config.AsynqRedisOpt())

--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ziraloop/ziraloop/internal/subscriptions"
 	"github.com/ziraloop/ziraloop/internal/mcpserver"
 	"github.com/ziraloop/ziraloop/internal/middleware"
+	posthogobs "github.com/ziraloop/ziraloop/internal/observability/posthog"
 	"github.com/ziraloop/ziraloop/internal/proxy"
 )
 
@@ -148,7 +149,7 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 	// Global middleware
 	r.Use(chimw.RequestID)
 	r.Use(chimw.RealIP)
-	r.Use(chimw.Recoverer)
+	r.Use(posthogobs.Recoverer(deps.PostHog))
 	r.Use(middleware.SecurityHeaders())
 	r.Use(middleware.CORS(cfg.CORSOrigins))
 	r.Use(middleware.RequestLog(logger))
@@ -574,6 +575,7 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 0,
 		IdleTimeout:  120 * time.Second,
+		ErrorLog:     posthogobs.NewStdlogBridge("api_server"),
 	}
 
 	goroutine.Go(func() {
@@ -587,7 +589,7 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 	mcpRouter := chi.NewRouter()
 	mcpRouter.Use(chimw.RequestID)
 	mcpRouter.Use(chimw.RealIP)
-	mcpRouter.Use(chimw.Recoverer)
+	mcpRouter.Use(posthogobs.Recoverer(deps.PostHog))
 	mcpRouter.Use(middleware.RequestLog(logger))
 
 
@@ -621,6 +623,7 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 0,
 		IdleTimeout:  120 * time.Second,
+		ErrorLog:     posthogobs.NewStdlogBridge("mcp_server"),
 	}
 
 	mcpHandler.ServerCache.StartCleanup(ctx, 5*time.Minute)

--- a/cmd/server/worker.go
+++ b/cmd/server/worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ziraloop/ziraloop/internal/email"
 	"github.com/ziraloop/ziraloop/internal/enqueue"
 	"github.com/ziraloop/ziraloop/internal/goroutine"
+	posthogobs "github.com/ziraloop/ziraloop/internal/observability/posthog"
 	"github.com/ziraloop/ziraloop/internal/skills"
 	subagents "github.com/ziraloop/ziraloop/internal/sub-agents"
 	"github.com/ziraloop/ziraloop/internal/tasks"
@@ -74,6 +75,10 @@ func runWork(ctx context.Context, deps *bootstrap.Deps) error {
 		},
 		Logger:          newAsynqLogger(),
 		ShutdownTimeout: cfg.AsynqShutdownTimeout,
+		// ErrorHandler fires on EVERY task failure (before retry is scheduled).
+		// This is how we capture task-handler panics and errors to PostHog —
+		// asynq recovers panics internally and surfaces them as errors here.
+		ErrorHandler: posthogobs.AsynqErrorHandler(deps.PostHog),
 	})
 
 	// Start Asynq server in background
@@ -144,8 +149,9 @@ func runWork(ctx context.Context, deps *bootstrap.Deps) error {
 	slog.Info("asynq dashboard enabled at /asynq")
 
 	healthSrv := &http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.WorkerHealthPort),
-		Handler: healthMux,
+		Addr:     fmt.Sprintf(":%d", cfg.WorkerHealthPort),
+		Handler:  healthMux,
+		ErrorLog: posthogobs.NewStdlogBridge("worker_health_server"),
 	}
 	goroutine.Go(func() {
 		slog.Info("worker health server starting", "port", cfg.WorkerHealthPort)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ziraloop/ziraloop
 go 1.25.4
 
 require (
+	github.com/anthropics/anthropic-sdk-go v1.35.0
 	github.com/awnumar/memguard v0.23.0
 	github.com/aws/aws-sdk-go-v2 v1.41.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.5
@@ -18,13 +19,16 @@ require (
 	github.com/hashicorp/go-kms-wrapping/wrappers/transit/v2 v2.0.13
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hibiken/asynq v0.26.0
+	github.com/hibiken/asynqmon v0.7.2
 	github.com/lib/pq v1.11.2
 	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/oapi-codegen/runtime v1.3.1
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pb33f/libopenapi v0.34.3
 	github.com/polarsource/polar-go v0.16.0
+	github.com/posthog/posthog-go v1.11.3
 	github.com/redis/go-redis/v9 v9.18.0
+	github.com/sashabaranov/go-openai v1.41.2
 	github.com/sourcegraph/conc v0.3.0
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260309172517-425968d811b9
 	github.com/swaggo/swag v1.16.6
@@ -43,7 +47,6 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/anthropics/anthropic-sdk-go v1.35.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/awnumar/memcall v0.4.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.5 // indirect
@@ -73,6 +76,7 @@ require (
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
@@ -90,7 +94,6 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.10.0 // indirect
-	github.com/hibiken/asynqmon v0.7.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect
@@ -110,7 +113,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
-	github.com/sashabaranov/go-openai v1.41.2 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdb
 github.com/bsm/gomega v1.26.0/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/caarlos0/env/v11 v11.4.0 h1:Kcb6t5kIIr4XkoQC9AF2j+8E1Jsrl3Wz/hhm1LtoGAc=
@@ -92,6 +90,8 @@ github.com/daytonaio/daytona/libs/toolbox-api-client-go v0.159.0 h1:wjHo6B79hbgI
 github.com/daytonaio/daytona/libs/toolbox-api-client-go v0.159.0/go.mod h1:Y/IJdiDMtmm3Nz6NBiTRJ3uEiRUqNAvEZPNNCFdgkzo=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -135,6 +135,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
@@ -329,6 +331,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polarsource/polar-go v0.16.0 h1:0YB4+DB0vsuvdxNVOvJpju5yKkMCHt6vmBRp9W2sKeo=
 github.com/polarsource/polar-go v0.16.0/go.mod h1:FB11Q4m2n3wIk6l/POOkz0MVOUx1o0Yt4Y97MnQfe0c=
+github.com/posthog/posthog-go v1.11.3 h1:5rFFJxILDBBZa+sSvHZKIROaDUGi+vQHAQjSWlibXJY=
+github.com/posthog/posthog-go v1.11.3/go.mod h1:xsVOW9YImilUcazwPNEq4PJDqEZf2KeCS758zXjwkPg=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=

--- a/internal/bootstrap/deps.go
+++ b/internal/bootstrap/deps.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"time"
 
+	ph "github.com/posthog/posthog-go"
 	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 
@@ -30,6 +31,8 @@ import (
 	"github.com/ziraloop/ziraloop/internal/turso"
 
 	polargo "github.com/polarsource/polar-go"
+
+	posthogobs "github.com/ziraloop/ziraloop/internal/observability/posthog"
 )
 
 // Deps holds all shared dependencies initialized during bootstrap.
@@ -58,6 +61,7 @@ type Deps struct {
 	ToolUsageWriter *middleware.ToolUsageWriter // nil if spider not configured
 	PolarClient     *polargo.Polar             // nil if POLAR_ACCESS_TOKEN not set
 	S3Client        *storage.S3Client          // nil if AWS_S3_BUCKET_NAME not set
+	PostHog         ph.Client                  // nil if PostHog disabled
 }
 
 // New initializes all shared dependencies. The caller is responsible for
@@ -250,6 +254,21 @@ func New(ctx context.Context) (*Deps, error) {
 		slog.Info("s3 storage ready", "bucket", cfg.S3Bucket)
 	}
 
+	// 19. PostHog error tracking (optional — disabled when POSTHOG_ENABLED=false
+	// or POSTHOG_API_KEY is empty). NewClient returns (nil, nil) in that case.
+	// The caller (main.go) is responsible for wrapping the slog handler once
+	// the service name is known (api vs worker vs proxy).
+	postHogClient, err := posthogobs.NewClient(cfg, posthogobs.ClientOptions{
+		ServiceName: "platform",
+		Environment: cfg.Environment,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("initializing posthog client: %w", err)
+	}
+	if postHogClient != nil {
+		slog.Info("posthog error tracking ready", "endpoint", cfg.PostHogEndpoint)
+	}
+
 	return &Deps{
 		Config:          cfg,
 		DB:              database,
@@ -274,15 +293,18 @@ func New(ctx context.Context) (*Deps, error) {
 		ToolUsageWriter: toolUsageWriter,
 		PolarClient:     polarClient,
 		S3Client:        s3Client,
+		PostHog:         postHogClient,
 	}, nil
 }
 
-// Close releases all resources held by Deps.
+// Close releases all resources held by Deps. PostHog is closed LAST so it can
+// capture any errors produced by the other subsystems shutting down.
 func (d *Deps) Close() {
 	d.CacheManager.Memory().Purge()
 	if sqlDB, err := d.DB.DB(); err == nil {
 		_ = sqlDB.Close()
 	}
 	_ = d.Redis.Close()
+	posthogobs.Close(d.PostHog)
 	slog.Info("deps closed")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,11 @@ type Config struct {
 	WorkerHealthPort      int           `env:"WORKER_HEALTH_PORT" envDefault:"8090"`
 	AsynqConcurrency      int           `env:"ASYNQ_CONCURRENCY" envDefault:"30"`
 	AsynqShutdownTimeout  time.Duration `env:"ASYNQ_SHUTDOWN_TIMEOUT" envDefault:"120s"`
+
+	// PostHog error tracking (empty POSTHOG_API_KEY disables capture)
+	PostHogAPIKey   string `env:"POSTHOG_API_KEY"`
+	PostHogEndpoint string `env:"POSTHOG_ENDPOINT" envDefault:"https://us.i.posthog.com"`
+	PostHogEnabled  bool   `env:"POSTHOG_ENABLED" envDefault:"false"`
 }
 
 func Load() (*Config, error) {

--- a/internal/goroutine/safe.go
+++ b/internal/goroutine/safe.go
@@ -1,23 +1,36 @@
 package goroutine
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"runtime/debug"
+
+	posthogobs "github.com/ziraloop/ziraloop/internal/observability/posthog"
 )
 
 // Go runs fn in a new goroutine with panic recovery.
-// If fn panics, the panic value and stack trace are logged via slog.Error.
+// If fn panics, the panic value and stack trace are logged via slog.Error
+// and explicitly captured to PostHog (so the exception has a full, untruncated
+// stack trace rather than the shallow one from the slog capture handler).
 // This is intended for singleton background goroutines (cleanup loops, flushers, subscribers).
 // For fan-out work (parallel queries, batch processing), use sourcegraph/conc pools instead.
 func Go(fn func()) {
 	go func() {
 		defer func() {
-			if r := recover(); r != nil {
-				slog.Error("goroutine panicked",
-					"panic", r,
-					"stack", string(debug.Stack()),
-				)
+			recovered := recover()
+			if recovered == nil {
+				return
 			}
+			stack := debug.Stack()
+			slog.Error("goroutine panicked",
+				"panic", recovered,
+				"stack", string(stack),
+			)
+			posthogobs.CaptureException(posthogobs.Default(), context.Background(),
+				fmt.Sprintf("goroutine panic: %v", recovered),
+				fmt.Sprintf("%v\n\n%s", recovered, stack),
+			)
 		}()
 		fn()
 	}()

--- a/internal/middleware/context.go
+++ b/internal/middleware/context.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"net/http"
 
+	chimw "github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
+
 	"github.com/ziraloop/ziraloop/internal/model"
 )
 
@@ -99,4 +102,49 @@ func SetAdminAuditChanges(r *http.Request, changes AdminAuditChanges) {
 	if bucket := AdminAuditBucketFromContext(r.Context()); bucket != nil {
 		bucket.Changes = changes
 	}
+}
+
+// DistinctID resolves a stable identifier for observability (error tracking,
+// analytics). The resolution order is:
+//
+//  1. Authenticated user (UserFromContext).
+//  2. Auth JWT claims (AuthClaimsFromContext).
+//  3. Resolved org (OrgFromContext) — prefixed "org:".
+//  4. Sandbox proxy token claims (ClaimsFromContext) — prefixed "org:".
+//  5. API key claims (APIKeyClaimsFromContext) — prefixed "org:".
+//  6. Chi request ID — prefixed "req:".
+//  7. Empty string.
+//
+// Returns "" when nothing is available so the caller can decide whether to
+// use "system" or skip the observation entirely.
+func DistinctID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+
+	if user, ok := UserFromContext(ctx); ok && user != nil && user.ID != uuid.Nil {
+		return user.ID.String()
+	}
+
+	if claims, ok := AuthClaimsFromContext(ctx); ok && claims != nil && claims.UserID != "" {
+		return claims.UserID
+	}
+
+	if org, ok := OrgFromContext(ctx); ok && org != nil && org.ID != uuid.Nil {
+		return "org:" + org.ID.String()
+	}
+
+	if claims, ok := ClaimsFromContext(ctx); ok && claims != nil && claims.OrgID != "" {
+		return "org:" + claims.OrgID
+	}
+
+	if claims, ok := APIKeyClaimsFromContext(ctx); ok && claims != nil && claims.OrgID != "" {
+		return "org:" + claims.OrgID
+	}
+
+	if requestID := chimw.GetReqID(ctx); requestID != "" {
+		return "req:" + requestID
+	}
+
+	return ""
 }

--- a/internal/observability/posthog/asynq.go
+++ b/internal/observability/posthog/asynq.go
@@ -1,0 +1,42 @@
+package posthog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/hibiken/asynq"
+	ph "github.com/posthog/posthog-go"
+)
+
+// AsynqErrorHandler returns an asynq.ErrorHandler that logs and captures every
+// task failure to PostHog. The worker's retry logic still runs — this is
+// purely for observability.
+//
+// Safe to use with a nil client; when client is nil the handler only logs.
+func AsynqErrorHandler(client ph.Client) asynq.ErrorHandler {
+	return asynq.ErrorHandlerFunc(func(ctx context.Context, task *asynq.Task, taskErr error) {
+		taskID, _ := asynq.GetTaskID(ctx)
+		retryCount, _ := asynq.GetRetryCount(ctx)
+		maxRetry, _ := asynq.GetMaxRetry(ctx)
+		queue, _ := asynq.GetQueueName(ctx)
+
+		slog.Error("asynq task failed",
+			"task_type", task.Type(),
+			"task_id", taskID,
+			"queue", queue,
+			"retry_count", retryCount,
+			"max_retry", maxRetry,
+			"error", taskErr,
+		)
+
+		if client == nil {
+			return
+		}
+
+		title := fmt.Sprintf("asynq task failed: %s", task.Type())
+		description := fmt.Sprintf("task_id=%s queue=%s retry=%d/%d error=%v",
+			taskID, queue, retryCount, maxRetry, taskErr)
+		CaptureException(client, ctx, title, description)
+	})
+}

--- a/internal/observability/posthog/client.go
+++ b/internal/observability/posthog/client.go
@@ -1,0 +1,162 @@
+// Package posthog wires the posthog-go SDK into the ziraloop platform for
+// error tracking across the HTTP API, the LLM proxy, Asynq workers, and
+// long-running background goroutines. See internal/config.Config for the
+// environment knobs (POSTHOG_API_KEY, POSTHOG_ENDPOINT, POSTHOG_ENABLED).
+package posthog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"time"
+
+	ph "github.com/posthog/posthog-go"
+
+	"github.com/ziraloop/ziraloop/internal/config"
+)
+
+// ClientOptions controls the behavior of the PostHog client created by
+// NewClient. The zero value is valid and produces a client with sensible
+// defaults matching the posthog-go documentation for Go error tracking.
+type ClientOptions struct {
+	// ServiceName is attached as a default property ($service) on every event.
+	// Typical values: "api", "worker", "proxy", "mcp".
+	ServiceName string
+
+	// Environment is attached as a default property ($environment) on every
+	// event. Typical values: "development", "production".
+	Environment string
+
+	// Hostname is attached as a default property ($hostname) on every event.
+	// If empty, os.Hostname is used.
+	Hostname string
+}
+
+// NewClient returns a PostHog client based on the supplied config. The client
+// is a no-op (nil ph.Client) when PostHog is disabled or the API key is empty,
+// so callers can always defer Close and Enqueue without nil checks via the
+// helpers exposed in this package.
+func NewClient(cfg *config.Config, opts ClientOptions) (ph.Client, error) {
+	if cfg == nil || !cfg.PostHogEnabled || cfg.PostHogAPIKey == "" {
+		return nil, nil
+	}
+
+	hostname := opts.Hostname
+	if hostname == "" {
+		if h, err := os.Hostname(); err == nil {
+			hostname = h
+		}
+	}
+
+	defaults := ph.NewProperties()
+	if opts.ServiceName != "" {
+		defaults.Set("$service", opts.ServiceName)
+	}
+	if opts.Environment != "" {
+		defaults.Set("$environment", opts.Environment)
+	}
+	if hostname != "" {
+		defaults.Set("$hostname", hostname)
+	}
+
+	client, err := ph.NewWithConfig(cfg.PostHogAPIKey, ph.Config{
+		Endpoint:               cfg.PostHogEndpoint,
+		DefaultEventProperties: defaults,
+		// Posthog's default of 5s is fine for server events; shutdown timeout
+		// guarantees Close() doesn't hang the process if the network is down.
+		ShutdownTimeout: 10 * time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("posthog: initialize client: %w", err)
+	}
+
+	setDefault(client)
+	return client, nil
+}
+
+// defaultClient is the package-level client used by helpers that cannot take a
+// client parameter (most notably goroutine.Go recover, which is called from
+// packages that cannot depend on the observability wiring). It is set once by
+// NewClient. Never replace the value once set non-nil.
+var defaultClient atomic.Pointer[ph.Client]
+
+func setDefault(client ph.Client) {
+	if client == nil {
+		return
+	}
+	defaultClient.Store(&client)
+}
+
+// Default returns the package-level client set by NewClient. May be nil if
+// PostHog is disabled or NewClient has not yet been called. Callers MUST
+// nil-check before using the returned value.
+func Default() ph.Client {
+	if p := defaultClient.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// Close flushes any pending events and shuts down the supplied client. Safe
+// to call with a nil client.
+func Close(client ph.Client) {
+	if client == nil {
+		return
+	}
+	if err := client.Close(); err != nil {
+		slog.Warn("posthog: close failed", "error", err)
+	}
+}
+
+// CaptureException enqueues an exception event with the supplied title and
+// description. Safe to call with a nil client or empty distinct ID (both
+// become no-ops). Properties map is attached verbatim to the exception item.
+func CaptureException(client ph.Client, ctx context.Context, title, description string) {
+	if client == nil {
+		return
+	}
+	distinctID := DistinctID(ctx)
+	if distinctID == "" {
+		distinctID = "system"
+	}
+	exception := ph.NewDefaultException(time.Now(), distinctID, title, description)
+	if err := client.Enqueue(exception); err != nil {
+		slog.Warn("posthog: enqueue exception failed", "error", err)
+	}
+}
+
+// CaptureError is a convenience wrapper that calls CaptureException with the
+// error's message as the description. Safe to call with a nil client or nil
+// error (both become no-ops).
+func CaptureError(client ph.Client, ctx context.Context, title string, err error) {
+	if err == nil {
+		return
+	}
+	CaptureException(client, ctx, title, err.Error())
+}
+
+// CaptureEvent enqueues a non-exception event. Useful for lifecycle events
+// like "startup" and "shutdown". Safe to call with a nil client.
+func CaptureEvent(client ph.Client, ctx context.Context, event string, properties map[string]any) {
+	if client == nil {
+		return
+	}
+	distinctID := DistinctID(ctx)
+	if distinctID == "" {
+		distinctID = "system"
+	}
+	props := ph.NewProperties()
+	for key, value := range properties {
+		props.Set(key, value)
+	}
+	capture := ph.Capture{
+		DistinctId: distinctID,
+		Event:      event,
+		Properties: props,
+	}
+	if err := client.Enqueue(capture); err != nil {
+		slog.Warn("posthog: enqueue event failed", "event", event, "error", err)
+	}
+}

--- a/internal/observability/posthog/distinct.go
+++ b/internal/observability/posthog/distinct.go
@@ -1,0 +1,39 @@
+package posthog
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// DistinctIDExtractor extracts a stable identifier from a request context for
+// attributing captured errors to users/orgs/requests. Implementations should
+// return an empty string when nothing is available, so the caller can fall
+// back to "system" or skip capture.
+type DistinctIDExtractor func(ctx context.Context) string
+
+var distinctIDExtractor atomic.Pointer[DistinctIDExtractor]
+
+// SetDistinctIDExtractor installs a package-level extractor used by DistinctID.
+// This allows the observability/posthog package to avoid importing the
+// middleware package directly (which would create an import cycle via
+// internal/goroutine.Go). Call this once during main() startup.
+func SetDistinctIDExtractor(fn DistinctIDExtractor) {
+	if fn == nil {
+		return
+	}
+	distinctIDExtractor.Store(&fn)
+}
+
+// DistinctID returns the distinct ID for the supplied context by delegating
+// to the extractor installed via SetDistinctIDExtractor. Returns "" when no
+// extractor is installed or the extractor finds nothing.
+func DistinctID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	extractor := distinctIDExtractor.Load()
+	if extractor == nil {
+		return ""
+	}
+	return (*extractor)(ctx)
+}

--- a/internal/observability/posthog/recoverer.go
+++ b/internal/observability/posthog/recoverer.go
@@ -1,0 +1,57 @@
+package posthog
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+
+	ph "github.com/posthog/posthog-go"
+)
+
+// Recoverer is a drop-in replacement for chi's built-in Recoverer middleware
+// that also captures the panic value and stack trace to PostHog. It mirrors
+// the behavior of chi middleware.Recoverer — returning a 500 on panic while
+// letting http.ErrAbortHandler propagate — and adds explicit error capture
+// on top.
+//
+// Safe to use with a nil client; when client is nil it behaves identically
+// to chi's Recoverer without any capture.
+func Recoverer(client ph.Client) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			defer func() {
+				recovered := recover()
+				if recovered == nil {
+					return
+				}
+				// Re-panic on http.ErrAbortHandler so the server can abort
+				// cleanly — matches chi middleware.Recoverer behavior.
+				if recovered == http.ErrAbortHandler {
+					panic(recovered)
+				}
+
+				stack := debug.Stack()
+				description := fmt.Sprintf("%v\n\n%s", recovered, stack)
+
+				slog.Error("panic recovered in HTTP handler",
+					"panic", recovered,
+					"method", request.Method,
+					"path", request.URL.Path,
+					"stack", string(stack),
+				)
+
+				if client != nil {
+					CaptureException(client, request.Context(),
+						fmt.Sprintf("panic: %v", recovered),
+						description,
+					)
+				}
+
+				writer.WriteHeader(http.StatusInternalServerError)
+			}()
+
+			next.ServeHTTP(writer, request)
+		})
+	}
+}

--- a/internal/observability/posthog/slog.go
+++ b/internal/observability/posthog/slog.go
@@ -1,0 +1,33 @@
+package posthog
+
+import (
+	"context"
+	"log/slog"
+
+	ph "github.com/posthog/posthog-go"
+)
+
+// WrapSlogHandler mirrors every slog record at level Error or above to PostHog
+// exception tracking. The returned handler forwards records to the supplied
+// base handler unchanged, so normal structured logging keeps working.
+//
+// Records without an identifiable user/org/request are tagged with the
+// "system" distinct ID so they still appear in the PostHog UI. This way
+// background goroutines and worker tasks that don't have a request context
+// are not silently dropped.
+func WrapSlogHandler(base slog.Handler, client ph.Client) slog.Handler {
+	if client == nil {
+		return base
+	}
+	return ph.NewSlogCaptureHandler(
+		base,
+		client,
+		ph.WithMinCaptureLevel(slog.LevelError),
+		ph.WithDistinctIDFn(func(ctx context.Context, _ slog.Record) string {
+			if id := DistinctID(ctx); id != "" {
+				return id
+			}
+			return "system"
+		}),
+	)
+}

--- a/internal/observability/posthog/stdlog.go
+++ b/internal/observability/posthog/stdlog.go
@@ -1,0 +1,36 @@
+package posthog
+
+import (
+	stdlog "log"
+	"log/slog"
+)
+
+// NewStdlogBridge returns a *log.Logger that forwards its writes to slog at
+// Error level. Useful for injecting into http.Server.ErrorLog so stdlib HTTP
+// server errors (connection accept failures, TLS handshake failures, etc.)
+// are captured by the wrapped slog handler and mirrored to PostHog.
+//
+// The returned logger strips the stdlib prefix/flags so the slog record gets
+// a clean message.
+func NewStdlogBridge(component string) *stdlog.Logger {
+	writer := slogWriter{
+		logger:    slog.Default(),
+		component: component,
+	}
+	return stdlog.New(writer, "", 0)
+}
+
+type slogWriter struct {
+	logger    *slog.Logger
+	component string
+}
+
+func (sw slogWriter) Write(payload []byte) (int, error) {
+	// stdlib log.Logger appends a trailing newline — strip it.
+	message := string(payload)
+	if length := len(message); length > 0 && message[length-1] == '\n' {
+		message = message[:length-1]
+	}
+	sw.logger.Error(sw.component+" stdlog", "message", message)
+	return len(payload), nil
+}

--- a/internal/proxy/capture.go
+++ b/internal/proxy/capture.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -33,6 +34,16 @@ func (ct *CaptureTransport) RoundTrip(req *http.Request) (*http.Response, error)
 			captured.ErrorType = classifyTransportError(err)
 			captured.ErrorMessage = err.Error()
 		}
+		// Log via slog — the wrapped handler mirrors this to PostHog. Upstream
+		// failures are operationally important; currently they were only
+		// recorded in the captured-data struct and never surfaced to alerts.
+		slog.Error("proxy upstream transport error",
+			"method", req.Method,
+			"host", req.URL.Host,
+			"path", req.URL.Path,
+			"duration_ms", totalMs,
+			"error", err,
+		)
 		return nil, err
 	}
 
@@ -59,6 +70,19 @@ func (ct *CaptureTransport) RoundTrip(req *http.Request) (*http.Response, error)
 				captured.ErrorMessage = string(snippet[:n])
 				resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(snippet[:n]), resp.Body))
 			}
+		}
+		// Surface 5xx upstream errors via slog (mirrored to PostHog). 4xx are
+		// normal user-facing errors and don't warrant a capture — they already
+		// show up in the usage/audit tables.
+		if resp.StatusCode >= 500 {
+			slog.Error("proxy upstream 5xx response",
+				"method", req.Method,
+				"host", req.URL.Host,
+				"path", req.URL.Path,
+				"status", resp.StatusCode,
+				"duration_ms", captured.TotalMs,
+				"snippet", captured.ErrorMessage,
+			)
 		}
 		return resp, nil
 	}

--- a/internal/proxy/director.go
+++ b/internal/proxy/director.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -24,24 +25,41 @@ func NewDirector(cacheManager *cache.Manager) func(req *http.Request) {
 		if !ok {
 			// TokenAuth middleware should have rejected this already.
 			// Set a sentinel header so the error handler can detect it.
+			slog.Error("proxy director: missing claims on request",
+				"path", req.URL.Path,
+			)
 			req.Header.Set("X-Proxy-Error", "missing claims")
 			return
 		}
 
 		orgID, err := uuid.Parse(claims.OrgID)
 		if err != nil {
+			slog.Error("proxy director: invalid org_id in claims",
+				"org_id", claims.OrgID,
+				"error", err,
+			)
 			req.Header.Set("X-Proxy-Error", "invalid org_id")
 			return
 		}
 
 		cred, err := cacheManager.GetDecryptedCredential(req.Context(), claims.CredentialID, orgID)
 		if err != nil {
+			slog.Error("proxy director: credential lookup failed",
+				"credential_id", claims.CredentialID,
+				"org_id", claims.OrgID,
+				"error", err,
+			)
 			req.Header.Set("X-Proxy-Error", fmt.Sprintf("credential error: %v", err))
 			return
 		}
 
 		// SSRF hardening: validate destination BaseURL and drop metadata-related headers
 		if err := ValidateBaseURL(cred.BaseURL); err != nil {
+			slog.Error("proxy director: disallowed upstream base URL",
+				"base_url", cred.BaseURL,
+				"org_id", claims.OrgID,
+				"error", err,
+			)
 			req.Header.Set("X-Proxy-Error", fmt.Sprintf("disallowed upstream: %v", err))
 			return
 		}


### PR DESCRIPTION
## Summary
- Wires the `posthog-go` SDK into the platform so panics, `slog.Error` records, asynq task failures, and stdlib `http.Server` errors are captured for alerting.
- Adds a chi-compatible `Recoverer`, an asynq `ErrorHandler`, an `http.Server.ErrorLog` stdlog bridge, and a slog handler that mirrors `Error+` records — all no-ops when `POSTHOG_ENABLED=false` or `POSTHOG_API_KEY` is empty.
- Resolves distinct ID (user ➜ org ➜ request) via a new `middleware.DistinctID` helper, exposed to the posthog package through a package-level extractor to avoid an import cycle with `internal/goroutine`.

## Test plan
- [ ] Boot `serve` with `POSTHOG_ENABLED=false`: confirm no PostHog network calls and no behavior change in chi recoverer / asynq error handling.
- [ ] Boot `serve` with `POSTHOG_ENABLED=true` + valid key: trigger a handler panic, an `slog.Error`, and a forced asynq task failure; verify each shows up in PostHog with the expected distinct ID.
- [ ] Verify `http.Server.ErrorLog` writes (e.g. TLS handshake error) get captured via the stdlog bridge.
- [ ] Verify `goroutine.Go` panics still log a stack trace AND capture an exception with the full untruncated stack.
- [ ] Confirm `service_started` / `service_stopped` lifecycle events appear when the process boots and shuts down cleanly.