### PR TITLE
feat(sse): single-tap fan-out + history endpoint + hardening

### DIFF
--- a/.github/workflows/publish-api-image.yml
+++ b/.github/workflows/publish-api-image.yml
@@ -30,7 +30,7 @@ jobs:
       - name: determine tags
         id: tags
         run: |
-          IMAGE=ghcr.io/hiveloop/hiveloop
+          IMAGE=ghcr.io/usehiveloop/hiveloop
           COMMIT=${GITHUB_SHA::7}
 
           if [[ "${{ github.event_name }}" == "release" ]]; then

--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -154,7 +154,43 @@ jobs:
         if: always()
         run: docker compose down -v --remove-orphans 2>/dev/null || true
 
+  # Sharded internal unit tests with -race. Total wall-clock target: <4 min.
+  # Packages are distributed round-robin (NR % N) across shards; imbalance is
+  # acceptable because the heavy packages (handler, streaming, proxy, sandbox)
+  # land in different shards by chance of alphabetical ordering.
   test-core:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache: true
+      - name: Generate auth RSA key
+        run: |
+          openssl genrsa 2048 2>/dev/null | base64 | tr -d '\n' > /tmp/auth_key_b64
+          echo "AUTH_RSA_PRIVATE_KEY=$(cat /tmp/auth_key_b64)" >> $GITHUB_ENV
+      - name: start infrastructure
+        run: make test-setup
+        timeout-minutes: 5
+      - name: run internal tests (shard ${{ matrix.shard }}/4)
+        run: |
+          PACKAGES=$(go list ./internal/... | awk -v s=${{ matrix.shard }} -v n=4 'NR % n == s')
+          echo "Running shard ${{ matrix.shard }} packages:"
+          echo "$PACKAGES"
+          go test $PACKAGES -race -count=1
+        timeout-minutes: 5
+      - name: cleanup
+        if: always()
+        run: docker compose down -v --remove-orphans 2>/dev/null || true
+
+  # Remaining e2e tests not already covered by the dedicated e2e jobs
+  # (test-auth, test-nango, test-proxy, test-connect, test-vault).
+  test-e2e-core:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -169,18 +205,27 @@ jobs:
       - name: start infrastructure
         run: make test-setup
         timeout-minutes: 5
-      - name: run internal + core e2e tests
+      - name: run remaining e2e tests
         run: |
-          go test ./internal/... -v -race -count=1
-          go test ./e2e/... -v -count=1 -timeout=5m
-        timeout-minutes: 10
+          go test ./e2e/... -count=1 -timeout=5m \
+            -skip '^(TestOrg|TestE2E_Integration|TestE2E_Proxy|TestE2E_Fireworks|TestE2E_Connect|TestVaultE2E)'
+        timeout-minutes: 5
       - name: cleanup
         if: always()
         run: docker compose down -v --remove-orphans 2>/dev/null || true
 
   results:
     if: always()
-    needs: [test-auth, test-nango, test-proxy, test-connect, test-vault, test-core]
+    needs:
+      [
+        test-auth,
+        test-nango,
+        test-proxy,
+        test-connect,
+        test-vault,
+        test-core,
+        test-e2e-core,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: check results
@@ -190,7 +235,8 @@ jobs:
              [ "${{ needs.test-proxy.result }}" != "success" ] || \
              [ "${{ needs.test-connect.result }}" != "success" ] || \
              [ "${{ needs.test-vault.result }}" != "success" ] || \
-             [ "${{ needs.test-core.result }}" != "success" ]; then
+             [ "${{ needs.test-core.result }}" != "success" ] || \
+             [ "${{ needs.test-e2e-core.result }}" != "success" ]; then
             echo "One or more test jobs failed"
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
-IMAGE   ?= hiveloop/hiveloop
+IMAGE   ?= usehiveloop/hiveloop
 
 # Generate base64-encoded RSA private key for AUTH_RSA_PRIVATE_KEY env var
 generate-auth-keys:

--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -377,6 +377,7 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 						r.Delete("/", conversationHandler.End)
 						r.Post("/messages", conversationHandler.SendMessage)
 						r.Get("/stream", conversationHandler.Stream)
+						r.Get("/history", conversationHandler.History)
 						r.Post("/abort", conversationHandler.Abort)
 						r.Get("/approvals", conversationHandler.ListApprovals)
 						r.Post("/approvals/{requestID}", conversationHandler.ResolveApproval)

--- a/internal/bootstrap/deps.go
+++ b/internal/bootstrap/deps.go
@@ -122,11 +122,27 @@ func New(ctx context.Context) (*Deps, error) {
 			DB:       cfg.RedisDB,
 		}
 	}
+	// Explicit pool sizing: the SSE fan-out holds one blocked XREAD
+	// connection per active conversation per pod. Default (10 * GOMAXPROCS)
+	// starves under multi-tenant load. Callers can override via
+	// REDIS_POOL_SIZE env var through config.
+	if redisOpts.PoolSize == 0 {
+		redisOpts.PoolSize = 500
+	}
+	if redisOpts.MinIdleConns == 0 {
+		redisOpts.MinIdleConns = 20
+	}
+	if redisOpts.PoolTimeout == 0 {
+		redisOpts.PoolTimeout = 4 * time.Second
+	}
 	redisClient := redis.NewClient(redisOpts)
 	if err := redisClient.Ping(context.Background()).Err(); err != nil {
 		return nil, fmt.Errorf("connecting to redis: %w", err)
 	}
-	slog.Info("redis ready")
+	slog.Info("redis ready",
+		"pool_size", redisOpts.PoolSize,
+		"min_idle_conns", redisOpts.MinIdleConns,
+	)
 
 	// 6. Cache manager
 	apiKeyCache := cache.NewAPIKeyCache(5000, 5*time.Minute)

--- a/internal/handler/conversations.go
+++ b/internal/handler/conversations.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	bridgepkg "github.com/usehiveloop/hiveloop/internal/bridge"
@@ -62,6 +64,19 @@ type conversationEventResponse struct {
 	SequenceNumber       int64           `json:"sequence_number"`
 	Data                 json.RawMessage `json:"data"`
 	CreatedAt            string          `json:"created_at"`
+}
+
+// conversationHistoryResponse is the payload shape for GET /conversations/{id}/history.
+// It returns events in chronological order so the frontend can render them
+// directly before opening the SSE stream.
+type conversationHistoryResponse struct {
+	ConversationID string                      `json:"conversation_id"`
+	Events         []conversationEventResponse `json:"events"`
+	// LastEventID is the event_id of the last event in this page. Clients
+	// can pass it as the `Last-Event-ID` header when opening the SSE stream
+	// to resume from exactly where history ended.
+	LastEventID string `json:"last_event_id,omitempty"`
+	HasMore     bool   `json:"has_more"`
 }
 
 // Create handles POST /v1/agents/{agentID}/conversations.
@@ -383,7 +398,7 @@ func (h *ConversationHandler) SendMessage(w http.ResponseWriter, r *http.Request
 
 // Stream handles GET /v1/conversations/{convID}/stream (SSE proxy).
 // @Summary Stream conversation events (SSE)
-// @Description Opens a Server-Sent Events stream for real-time agent responses. Events include message_start, content_delta, tool_call_start, tool_call_result, message_end, done.
+// @Description Opens a Server-Sent Events stream for real-time agent responses. Defaults to live-only (cursor "$"); clients that want history should hydrate via GET /v1/conversations/{convID}/history first. Resumes from Last-Event-ID when provided.
 // @Tags conversations
 // @Produce text/event-stream
 // @Param convID path string true "Conversation ID"
@@ -400,15 +415,42 @@ func (h *ConversationHandler) Stream(w http.ResponseWriter, r *http.Request) {
 	h.streamFromRedis(w, r, conv)
 }
 
+// Stream handler tuning constants.
+const (
+	// sseWriteDeadline bounds each individual SSE frame write. Slow clients
+	// that can't accept a frame within this window are disconnected to
+	// prevent them from holding a tap subscriber slot indefinitely.
+	sseWriteDeadline = 10 * time.Second
+
+	// sseMaxAge caps the lifetime of a single SSE connection. Browsers'
+	// EventSource reconnects automatically with Last-Event-ID, so this is
+	// transparent to users but makes deploys and long-running connection
+	// tracking much cleaner.
+	sseMaxAge = 1 * time.Hour
+
+	// sseAuthRecheckInterval controls how often an active SSE stream
+	// re-verifies that the caller still has access to the conversation.
+	// The re-check reuses the same DB lookup as the initial auth, so the
+	// auth cache's TTL gates the worst-case revocation latency.
+	sseAuthRecheckInterval = 60 * time.Second
+
+	// ssePingInterval is the interval at which we emit an SSE keep-alive
+	// comment to keep intermediaries from idling the connection out.
+	ssePingInterval = 15 * time.Second
+)
+
 // streamFromRedis streams events from Redis Streams (multi-subscriber, resumable).
 func (h *ConversationHandler) streamFromRedis(w http.ResponseWriter, r *http.Request, conv *model.AgentConversation) {
-	// Parse Last-Event-ID for resume support
+	// Parse Last-Event-ID for resume support. Default is live-only ("$"):
+	// clients should hydrate history via GET /history first, then open the
+	// stream. Replaying the entire retained window on every connect is
+	// wasteful and inconsistent with the DB (which keeps everything).
 	cursor := r.Header.Get("Last-Event-ID")
 	if cursor == "" {
-		cursor = "0" // replay all available events
+		cursor = "$"
 	}
 
-	// Set SSE headers
+	// Set SSE headers.
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -416,46 +458,127 @@ func (h *ConversationHandler) streamFromRedis(w http.ResponseWriter, r *http.Req
 	w.WriteHeader(http.StatusOK)
 
 	rc := http.NewResponseController(w)
-	h.db.Model(&conv.Sandbox).Update("last_active_at", time.Now())
 
-	// Subscribe to the conversation's Redis Stream
-	events := h.eventBus.Subscribe(r.Context(), conv.ID.String(), cursor)
+	// Tell EventSource to wait 5s before reconnecting on disconnect (default
+	// is 3s; a bit of backoff smooths deploy rollouts).
+	if err := writeSSEFrame(w, rc, "retry: 5000\n\n"); err != nil {
+		return
+	}
+	// Synthetic "ready" so the frontend can distinguish "connected but no
+	// events yet" from "still connecting".
+	if err := writeSSEFrame(w, rc, "event: ready\ndata: {}\n\n"); err != nil {
+		return
+	}
 
-	// Keep-alive ping ticker
-	pingTicker := time.NewTicker(15 * time.Second)
+	// Subscribe to the conversation's Redis Stream. The EventBus is shared
+	// across all SSE subscribers on this pod via a single per-conversation
+	// tap goroutine — see internal/streaming/bus.go.
+	streamCtx, cancelStream := context.WithCancel(r.Context())
+	defer cancelStream()
+	events := h.eventBus.Subscribe(streamCtx, conv.ID.String(), cursor)
+
+	// Keep-alive, auth recheck, and max age timers.
+	pingTicker := time.NewTicker(ssePingInterval)
 	defer pingTicker.Stop()
+	authTicker := time.NewTicker(sseAuthRecheckInterval)
+	defer authTicker.Stop()
+	maxAge := time.NewTimer(sseMaxAge)
+	defer maxAge.Stop()
+
+	convID := conv.ID
+	orgID := conv.OrgID
 
 	for {
 		select {
 		case event, ok := <-events:
 			if !ok {
-				return // channel closed
+				return // upstream closed (ctx cancelled, tap stopped, or evicted)
 			}
 
-			// Write SSE frame: id, event, data
+			// Strip redundant envelope fields for over-the-wire efficiency.
+			// The browser already knows conversation_id (from URL) and
+			// agent_id (from conversation metadata); they stay in Redis/DB
+			// for the flusher and history endpoint.
+			trimmed := trimSSEEnvelope(event.Data)
+
 			frame := fmt.Sprintf("id: %s\nevent: %s\ndata: %s\n\n",
-				event.ID, event.EventType, string(event.Data))
-
-			if _, err := w.Write([]byte(frame)); err != nil {
-				slog.Debug("SSE client disconnected", "conversation_id", conv.ID)
-				return
-			}
-			if err := rc.Flush(); err != nil {
+				event.ID, event.EventType, string(trimmed))
+			if err := writeSSEFrame(w, rc, frame); err != nil {
+				slog.Debug("SSE client disconnected", "conversation_id", convID)
 				return
 			}
 
 		case <-pingTicker.C:
-			if _, err := w.Write([]byte(": ping\n\n")); err != nil {
+			if err := writeSSEFrame(w, rc, ": ping\n\n"); err != nil {
 				return
 			}
-			if err := rc.Flush(); err != nil {
+
+		case <-authTicker.C:
+			// Re-verify that the caller still owns this conversation.
+			// Drops silently if membership/key was revoked since connect.
+			if !h.stillAuthorized(r.Context(), convID, orgID) {
+				slog.Info("SSE auth recheck failed, closing stream",
+					"conversation_id", convID)
 				return
 			}
+
+		case <-maxAge.C:
+			slog.Debug("SSE max age reached, closing for reconnect",
+				"conversation_id", convID)
+			return
 
 		case <-r.Context().Done():
 			return
 		}
 	}
+}
+
+// writeSSEFrame writes a single SSE frame with a bounded write deadline and
+// flushes. Any error causes the caller to tear the stream down.
+func writeSSEFrame(w http.ResponseWriter, rc *http.ResponseController, frame string) error {
+	if err := rc.SetWriteDeadline(time.Now().Add(sseWriteDeadline)); err != nil && err != http.ErrNotSupported {
+		return err
+	}
+	if _, err := w.Write([]byte(frame)); err != nil {
+		return err
+	}
+	return rc.Flush()
+}
+
+// trimSSEEnvelope removes fields from the event envelope that the browser
+// already knows from context (conversation_id from URL, agent_id from
+// conversation metadata). The original envelope is preserved in Redis and
+// Postgres for history / debugging. On parse error, returns the original
+// bytes unchanged.
+func trimSSEEnvelope(data json.RawMessage) json.RawMessage {
+	if len(data) == 0 {
+		return data
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	delete(obj, "conversation_id")
+	delete(obj, "agent_id")
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return out
+}
+
+// stillAuthorized re-checks that the conversation exists, belongs to the
+// given org, and is still active. Returns false on any lookup failure so
+// we err on the side of dropping the stream when auth state is uncertain.
+func (h *ConversationHandler) stillAuthorized(ctx context.Context, convID uuid.UUID, orgID uuid.UUID) bool {
+	var count int64
+	if err := h.db.WithContext(ctx).
+		Model(&model.AgentConversation{}).
+		Where("id = ? AND org_id = ? AND status = ?", convID, orgID, "active").
+		Count(&count).Error; err != nil {
+		return false
+	}
+	return count == 1
 }
 
 
@@ -683,6 +806,109 @@ func (h *ConversationHandler) ListEvents(w http.ResponseWriter, r *http.Request)
 		result.NextCursor = &c
 	}
 	writeJSON(w, http.StatusOK, result)
+}
+
+// History handles GET /v1/conversations/{convID}/history.
+// @Summary Hydrate conversation history
+// @Description Returns persisted conversation events in chronological order, intended for hydrating a UI before opening the SSE stream. Paginated via since=<event_id>. Unlike GET /events, this endpoint sorts events ASC by sequence_number so the caller can render in order.
+// @Tags conversations
+// @Produce json
+// @Param convID path string true "Conversation ID"
+// @Param since query string false "Return events with sequence_number greater than this event_id"
+// @Param limit query int false "Page size (default 200, max 1000)"
+// @Success 200 {object} conversationHistoryResponse
+// @Failure 404 {object} errorResponse
+// @Security BearerAuth
+// @Router /v1/conversations/{convID}/history [get]
+func (h *ConversationHandler) History(w http.ResponseWriter, r *http.Request) {
+	org, ok := middleware.OrgFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing org context"})
+		return
+	}
+
+	convID := chi.URLParam(r, "convID")
+	var conv model.AgentConversation
+	if err := h.db.Where("id = ? AND org_id = ?", convID, org.ID).First(&conv).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "conversation not found"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load conversation"})
+		return
+	}
+
+	limit := 200
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if n, err := strconvAtoiPositive(l); err == nil {
+			if n > 1000 {
+				n = 1000
+			}
+			limit = n
+		}
+	}
+
+	q := h.db.Where("conversation_id = ?", conv.ID).Order("sequence_number ASC, created_at ASC").Limit(limit + 1)
+	if since := r.URL.Query().Get("since"); since != "" {
+		// Find the anchor event's sequence number, then return everything after it.
+		var anchor model.ConversationEvent
+		if err := h.db.Where("conversation_id = ? AND event_id = ?", conv.ID, since).
+			First(&anchor).Error; err == nil {
+			q = q.Where("sequence_number > ?", anchor.SequenceNumber)
+		}
+	}
+
+	var events []model.ConversationEvent
+	if err := q.Find(&events).Error; err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load history"})
+		return
+	}
+
+	hasMore := len(events) > limit
+	if hasMore {
+		events = events[:limit]
+	}
+
+	resp := conversationHistoryResponse{
+		ConversationID: conv.ID.String(),
+		HasMore:        hasMore,
+		Events:         make([]conversationEventResponse, len(events)),
+	}
+	for i, e := range events {
+		resp.Events[i] = conversationEventResponse{
+			ID:                   e.ID.String(),
+			EventID:              e.EventID,
+			EventType:            e.EventType,
+			AgentID:              e.AgentID,
+			BridgeConversationID: e.BridgeConversationID,
+			Timestamp:            e.Timestamp.Format(time.RFC3339),
+			SequenceNumber:       e.SequenceNumber,
+			Data:                 json.RawMessage(e.Data),
+			CreatedAt:            e.CreatedAt.Format(time.RFC3339),
+		}
+	}
+	if len(events) > 0 {
+		resp.LastEventID = events[len(events)-1].EventID
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// strconvAtoiPositive parses a positive integer. Returns an error on non-positive values.
+func strconvAtoiPositive(s string) (int, error) {
+	n := 0
+	if len(s) == 0 {
+		return 0, fmt.Errorf("empty")
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("not a number")
+		}
+		n = n*10 + int(c-'0')
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("not positive")
+	}
+	return n, nil
 }
 
 // --- helpers ---

--- a/internal/handler/conversations_sse_test.go
+++ b/internal/handler/conversations_sse_test.go
@@ -1,0 +1,93 @@
+package handler
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTrimSSEEnvelope_StripsConversationIDAndAgentID(t *testing.T) {
+	in := json.RawMessage(`{"event_id":"e1","agent_id":"a1","conversation_id":"c1","data":{"x":1}}`)
+	out := trimSSEEnvelope(in)
+
+	var obj map[string]any
+	if err := json.Unmarshal(out, &obj); err != nil {
+		t.Fatalf("invalid JSON out: %v (%s)", err, out)
+	}
+	if _, ok := obj["conversation_id"]; ok {
+		t.Errorf("conversation_id should be stripped, got %s", out)
+	}
+	if _, ok := obj["agent_id"]; ok {
+		t.Errorf("agent_id should be stripped, got %s", out)
+	}
+	if obj["event_id"] != "e1" {
+		t.Errorf("event_id missing or wrong: %s", out)
+	}
+	if _, ok := obj["data"]; !ok {
+		t.Errorf("data should be preserved, got %s", out)
+	}
+}
+
+func TestTrimSSEEnvelope_EmptyInput(t *testing.T) {
+	if got := trimSSEEnvelope(nil); len(got) != 0 {
+		t.Errorf("nil input should return empty, got %s", got)
+	}
+	if got := trimSSEEnvelope(json.RawMessage{}); len(got) != 0 {
+		t.Errorf("empty input should return empty, got %s", got)
+	}
+}
+
+func TestTrimSSEEnvelope_InvalidJSONReturnsOriginal(t *testing.T) {
+	in := json.RawMessage(`{not valid`)
+	got := trimSSEEnvelope(in)
+	if string(got) != string(in) {
+		t.Errorf("on parse error should return original bytes; got %s", got)
+	}
+}
+
+func TestTrimSSEEnvelope_NonObjectReturnsOriginal(t *testing.T) {
+	in := json.RawMessage(`[1,2,3]`)
+	got := trimSSEEnvelope(in)
+	if string(got) != string(in) {
+		t.Errorf("array input should be returned unchanged; got %s", got)
+	}
+}
+
+func TestTrimSSEEnvelope_PreservesOtherFields(t *testing.T) {
+	in := json.RawMessage(`{"conversation_id":"c1","agent_id":"a1","timestamp":"2025-01-01T00:00:00Z","sequence_number":42,"event_type":"msg","data":{"content":"hi"}}`)
+	out := trimSSEEnvelope(in)
+	if strings.Contains(string(out), "conversation_id") || strings.Contains(string(out), "agent_id") {
+		t.Errorf("stripped fields still present: %s", out)
+	}
+	for _, field := range []string{"timestamp", "sequence_number", "event_type", "data"} {
+		if !strings.Contains(string(out), field) {
+			t.Errorf("field %q missing after trim: %s", field, out)
+		}
+	}
+}
+
+func TestStrconvAtoiPositive(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"1", 1, false},
+		{"200", 200, false},
+		{"999", 999, false},
+		{"0", 0, true},
+		{"-5", 0, true},
+		{"", 0, true},
+		{"abc", 0, true},
+		{"12a", 0, true},
+	}
+	for _, c := range cases {
+		got, err := strconvAtoiPositive(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("%q: wantErr=%v got err=%v", c.in, c.wantErr, err)
+		}
+		if !c.wantErr && got != c.want {
+			t.Errorf("%q: got %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/streaming/bus.go
+++ b/internal/streaming/bus.go
@@ -1,14 +1,29 @@
 // Package streaming provides real-time event delivery via Redis Streams.
 // Events are published by webhook handlers and consumed by SSE subscribers
 // and a background DB flusher.
+//
+// Subscriber fan-out:
+//
+// Each pod runs at most one XREAD BLOCK loop per conversation, regardless of
+// how many SSE subscribers are watching that conversation. Subscribers attach
+// to an in-process "tap" that forwards every new event to every attached
+// subscriber. This keeps Redis connections bounded by the number of active
+// conversations viewed on the pod, not by the number of viewers.
+//
+// Each subscriber still gets correct backfill from its requested cursor via a
+// synchronous XRANGE up to the tap's cursor at attach time; the tap only
+// forwards events that arrive after the subscriber attached. There are no
+// duplicates and no gaps.
 package streaming
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -21,10 +36,34 @@ type StreamEvent struct {
 	Data      json.RawMessage // Raw JSON payload
 }
 
+// subscriber is one attached consumer of a convTap.
+type subscriber struct {
+	ch      chan StreamEvent // tap -> subscriber drain goroutine
+	evicted chan struct{}    // closed by tap when subscriber is dropped (slow consumer)
+}
+
+// convTap is the single XREAD BLOCK loop for one conversation on this pod.
+// Multiple subscribers can attach; each receives every new event.
+type convTap struct {
+	bus         *EventBus
+	convID      string
+	streamKey   string
+	stopCtx     context.Context
+	cancel      context.CancelFunc
+	done        chan struct{}
+
+	mu          sync.Mutex
+	cursor      string                      // last entry ID the tap has read (advances monotonically)
+	subscribers map[*subscriber]struct{}
+}
+
 // EventBus publishes and subscribes to conversation events via Redis Streams.
 type EventBus struct {
 	redis  *redis.Client
 	prefix string // stream key prefix, e.g., "conv:"
+
+	tapsMu sync.Mutex
+	taps   map[string]*convTap
 }
 
 // NewEventBus creates a new EventBus.
@@ -32,6 +71,7 @@ func NewEventBus(redisClient *redis.Client) *EventBus {
 	return &EventBus{
 		redis:  redisClient,
 		prefix: "conv:",
+		taps:   make(map[string]*convTap),
 	}
 }
 
@@ -69,13 +109,24 @@ func (b *EventBus) Publish(ctx context.Context, convID string, eventType string,
 
 // Subscribe returns a channel that yields events from a conversation stream.
 // cursor controls the starting point:
+//   - ""  = replay all events in the stream (legacy default, treated as "0")
 //   - "0" = replay all events in the stream
 //   - "$" = only new events from this point forward
 //   - a specific entry ID = resume from after that entry
 //
-// The channel is closed when the context is cancelled.
+// Under the hood, subscribers on the same conversation on the same pod share
+// a single XREAD BLOCK loop. Each subscriber receives its own backfill from
+// the requested cursor and then the same live event stream.
+//
+// The returned channel is closed when the context is cancelled or when the
+// subscriber is evicted for being slow (its 64-buffer filled).
 func (b *EventBus) Subscribe(ctx context.Context, convID string, cursor string) <-chan StreamEvent {
-	ch := make(chan StreamEvent, 64)
+	userCh := make(chan StreamEvent, 64)
+
+	backfillFrom := cursor
+	if backfillFrom == "" {
+		backfillFrom = "0" // legacy default: replay everything
+	}
 
 	go func() {
 		defer func() {
@@ -86,78 +137,283 @@ func (b *EventBus) Subscribe(ctx context.Context, convID string, cursor string) 
 					"stack", string(debug.Stack()),
 				)
 			}
-			close(ch)
+			closeChannelSafely(userCh)
 		}()
 
-		pos := cursor
-		if pos == "" {
-			pos = "0" // replay everything by default
+		// 1. Attach to the conversation's tap. attachCursor is a snapshot of
+		//    the tap's cursor at the moment we attached — the tap will only
+		//    forward events with ID > attachCursor to us.
+		tap, err := b.getOrCreateTap(convID)
+		if err != nil {
+			slog.Error("eventbus.Subscribe: failed to create tap",
+				"conversation_id", convID, "error", err)
+			return
 		}
+		sub, attachCursor := tap.attach()
+		defer b.detachSubscriber(convID, tap, sub)
 
-		streamKey := b.streamKey(convID)
-		slog.Info("eventbus.Subscribe: started",
-			"stream_key", streamKey,
-			"cursor", pos,
+		slog.Info("eventbus.Subscribe: attached",
+			"stream_key", tap.streamKey,
+			"cursor", backfillFrom,
+			"attach_cursor", attachCursor,
 			"conversation_id", convID,
 		)
-		pollCount := 0
 
-		for {
-			select {
-			case <-ctx.Done():
-				slog.Info("eventbus.Subscribe: context cancelled",
-					"stream_key", streamKey,
-					"polls", pollCount,
-				)
-				return
-			default:
-			}
-
-			pollCount++
-			streams, err := b.redis.XRead(ctx, &redis.XReadArgs{
-				Streams: []string{streamKey, pos},
-				Block:   5 * time.Second,
-				Count:   50,
-			}).Result()
-			if err != nil {
-				if err == redis.Nil || err == context.Canceled || err == context.DeadlineExceeded {
-					if pollCount%12 == 0 { // log every ~60s
-						slog.Info("eventbus.Subscribe: still waiting",
-							"stream_key", streamKey,
-							"polls", pollCount,
-							"cursor", pos,
-						)
-					}
-					continue
-				}
+		// 2. Backfill: read events from backfillFrom up to attachCursor
+		//    (inclusive) and deliver them in order. The tap will pick up
+		//    from attachCursor + 1 onwards. No duplicates, no gaps.
+		if backfillFrom != "$" {
+			if err := b.backfill(ctx, convID, backfillFrom, attachCursor, userCh); err != nil {
 				if ctx.Err() != nil {
 					return
 				}
-				slog.Error("XREAD error", "conversation_id", convID, "error", err)
-				time.Sleep(500 * time.Millisecond)
-				continue
+				slog.Warn("eventbus.Subscribe: backfill error",
+					"conversation_id", convID, "error", err)
 			}
+		}
 
-			for _, stream := range streams {
-				for _, msg := range stream.Messages {
-					event := StreamEvent{
-						ID:        msg.ID,
-						EventType: msg.Values["event_type"].(string),
-						Data:      json.RawMessage(msg.Values["data"].(string)),
-					}
-
-					select {
-					case ch <- event:
-						pos = msg.ID
-					case <-ctx.Done():
-						return
-					}
+		// 3. Drain live events from the tap until the subscriber is cancelled
+		//    or evicted.
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-sub.evicted:
+				slog.Warn("eventbus.Subscribe: evicted (slow consumer)",
+					"conversation_id", convID)
+				return
+			case evt, ok := <-sub.ch:
+				if !ok {
+					return
+				}
+				select {
+				case userCh <- evt:
+				case <-ctx.Done():
+					return
 				}
 			}
 		}
 	}()
 
-	return ch
+	return userCh
+}
+
+// backfill delivers stream entries strictly greater than `from` and
+// less-than-or-equal to `upTo` into out. If upTo is "" or "0-0" (empty
+// stream), nothing is delivered. The anchor entry (the one matching `from`
+// exactly) is skipped so callers that pass their last-seen ID don't see it
+// again.
+func (b *EventBus) backfill(ctx context.Context, convID, from, upTo string, out chan<- StreamEvent) error {
+	// Empty stream: nothing to backfill.
+	if upTo == "" || upTo == "0-0" {
+		return nil
+	}
+
+	start := from
+	if start == "" || start == "0" {
+		start = "-" // XRANGE: "-" means beginning of stream
+	}
+
+	msgs, err := b.redis.XRange(ctx, b.streamKey(convID), start, upTo).Result()
+	if err != nil {
+		return fmt.Errorf("backfill XRANGE: %w", err)
+	}
+
+	for _, msg := range msgs {
+		// XRANGE is inclusive on both ends. Skip the anchor entry if the
+		// caller supplied a real entry ID (they already saw it).
+		if msg.ID == from && from != "" && from != "0" && from != "-" {
+			continue
+		}
+
+		evt := StreamEvent{
+			ID:        msg.ID,
+			EventType: msgStringField(msg.Values, "event_type"),
+			Data:      json.RawMessage(msgStringField(msg.Values, "data")),
+		}
+
+		select {
+		case out <- evt:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// getOrCreateTap returns the tap for convID, spawning it if necessary.
+func (b *EventBus) getOrCreateTap(convID string) (*convTap, error) {
+	b.tapsMu.Lock()
+	defer b.tapsMu.Unlock()
+
+	if tap, ok := b.taps[convID]; ok {
+		return tap, nil
+	}
+
+	streamKey := b.streamKey(convID)
+
+	// Seed the tap's starting cursor with the current last entry of the
+	// stream so XREAD picks up only genuinely new events. "0-0" is used when
+	// the stream is empty; XREAD accepts it and returns every future entry.
+	startCursor := "0-0"
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	if res, err := b.redis.XRevRangeN(ctx, streamKey, "+", "-", 1).Result(); err == nil && len(res) > 0 {
+		startCursor = res[0].ID
+	}
+	cancel()
+
+	tapCtx, tapCancel := context.WithCancel(context.Background())
+	tap := &convTap{
+		bus:         b,
+		convID:      convID,
+		streamKey:   streamKey,
+		stopCtx:     tapCtx,
+		cancel:      tapCancel,
+		done:        make(chan struct{}),
+		cursor:      startCursor,
+		subscribers: make(map[*subscriber]struct{}),
+	}
+	b.taps[convID] = tap
+	go tap.run()
+	return tap, nil
+}
+
+// detachSubscriber removes sub from tap and tears the tap down if no
+// subscribers remain.
+func (b *EventBus) detachSubscriber(convID string, tap *convTap, sub *subscriber) {
+	tap.mu.Lock()
+	delete(tap.subscribers, sub)
+	empty := len(tap.subscribers) == 0
+	tap.mu.Unlock()
+
+	if !empty {
+		return
+	}
+
+	// Only remove the tap from the registry if it's still the current one
+	// for this convID (protects against racing recreation).
+	b.tapsMu.Lock()
+	if cur, ok := b.taps[convID]; ok && cur == tap {
+		delete(b.taps, convID)
+	}
+	b.tapsMu.Unlock()
+
+	tap.cancel()
+	<-tap.done
+}
+
+// ActiveTaps returns the number of live conversation taps. Intended for tests
+// and observability.
+func (b *EventBus) ActiveTaps() int {
+	b.tapsMu.Lock()
+	defer b.tapsMu.Unlock()
+	return len(b.taps)
+}
+
+// attach registers a new subscriber with the tap and returns its subscriber
+// handle plus the tap's current cursor snapshot.
+func (t *convTap) attach() (*subscriber, string) {
+	sub := &subscriber{
+		ch:      make(chan StreamEvent, 64),
+		evicted: make(chan struct{}),
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.subscribers[sub] = struct{}{}
+	return sub, t.cursor
+}
+
+// run is the single XREAD BLOCK loop for this conversation.
+func (t *convTap) run() {
+	defer close(t.done)
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("conv tap panicked",
+				"conversation_id", t.convID,
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
+		}
+		// Close all attached subscribers when the tap exits.
+		t.mu.Lock()
+		for s := range t.subscribers {
+			closeChannelSafely(s.ch)
+		}
+		t.subscribers = nil
+		t.mu.Unlock()
+	}()
+
+	slog.Info("conv tap started",
+		"stream_key", t.streamKey,
+		"conversation_id", t.convID,
+		"start_cursor", t.cursor,
+	)
+
+	for {
+		if t.stopCtx.Err() != nil {
+			return
+		}
+
+		t.mu.Lock()
+		pos := t.cursor
+		t.mu.Unlock()
+
+		streams, err := t.bus.redis.XRead(t.stopCtx, &redis.XReadArgs{
+			Streams: []string{t.streamKey, pos},
+			Block:   5 * time.Second,
+			Count:   50,
+		}).Result()
+		if err != nil {
+			if errors.Is(err, redis.Nil) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				continue
+			}
+			if t.stopCtx.Err() != nil {
+				return
+			}
+			slog.Error("conv tap XREAD error",
+				"conversation_id", t.convID, "error", err)
+			select {
+			case <-t.stopCtx.Done():
+				return
+			case <-time.After(500 * time.Millisecond):
+			}
+			continue
+		}
+
+		for _, stream := range streams {
+			for _, msg := range stream.Messages {
+				evt := StreamEvent{
+					ID:        msg.ID,
+					EventType: msgStringField(msg.Values, "event_type"),
+					Data:      json.RawMessage(msgStringField(msg.Values, "data")),
+				}
+				t.broadcast(evt)
+
+				t.mu.Lock()
+				t.cursor = msg.ID
+				t.mu.Unlock()
+			}
+		}
+	}
+}
+
+// broadcast forwards evt to every attached subscriber. Subscribers whose
+// channel buffer is full are evicted (marked as slow consumer).
+func (t *convTap) broadcast(evt StreamEvent) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for s := range t.subscribers {
+		select {
+		case s.ch <- evt:
+		default:
+			// Slow consumer: kick them out and close their channel.
+			delete(t.subscribers, s)
+			closeChannelSafely(s.ch)
+			closeChannelSafely(s.evicted)
+		}
+	}
 }
 
 // ReadRange returns events between two entry IDs (inclusive).
@@ -172,8 +428,8 @@ func (b *EventBus) ReadRange(ctx context.Context, convID string, start string, e
 	for _, msg := range msgs {
 		events = append(events, StreamEvent{
 			ID:        msg.ID,
-			EventType: msg.Values["event_type"].(string),
-			Data:      json.RawMessage(msg.Values["data"].(string)),
+			EventType: msgStringField(msg.Values, "event_type"),
+			Data:      json.RawMessage(msgStringField(msg.Values, "data")),
 		})
 	}
 	return events, nil
@@ -268,4 +524,21 @@ func (b *EventBus) Prefix() string {
 // Redis returns the underlying Redis client (for flusher consumer groups).
 func (b *EventBus) Redis() *redis.Client {
 	return b.redis
+}
+
+// closeChannelSafely closes ch unless it has already been closed.
+func closeChannelSafely[T any](ch chan T) {
+	defer func() { _ = recover() }()
+	close(ch)
+}
+
+// msgStringField extracts a string field from a Redis stream message value
+// map, returning "" if absent or the wrong type.
+func msgStringField(values map[string]any, key string) string {
+	v, ok := values[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
 }

--- a/internal/streaming/bus_fanout_test.go
+++ b/internal/streaming/bus_fanout_test.go
@@ -1,0 +1,420 @@
+package streaming
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSubscribe_SingleTapPerConversation verifies that multiple subscribers on
+// the same conversation share a single XREAD loop (one tap), not N.
+func TestSubscribe_SingleTapPerConversation(t *testing.T) {
+	rc := setupTestRedis(t)
+	bus := NewEventBus(rc)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const numSubs = 5
+	chs := make([]<-chan StreamEvent, numSubs)
+	for i := range chs {
+		chs[i] = bus.Subscribe(ctx, "shared-conv", "$")
+	}
+
+	// Give subscribers a moment to attach.
+	time.Sleep(200 * time.Millisecond)
+
+	if got := bus.ActiveTaps(); got != 1 {
+		t.Fatalf("expected 1 active tap for the shared conversation, got %d", got)
+	}
+
+	// Publish a single event — every subscriber should see it.
+	bus.Publish(ctx, "shared-conv", "shared_event", json.RawMessage(`{"n":1}`))
+
+	var wg sync.WaitGroup
+	received := make([]string, numSubs)
+	for i, ch := range chs {
+		wg.Add(1)
+		go func(idx int, c <-chan StreamEvent) {
+			defer wg.Done()
+			select {
+			case ev := <-c:
+				received[idx] = ev.EventType
+			case <-time.After(5 * time.Second):
+				t.Errorf("subscriber %d timed out", idx)
+			}
+		}(i, ch)
+	}
+	wg.Wait()
+
+	for i, got := range received {
+		if got != "shared_event" {
+			t.Errorf("subscriber %d: got %q, want shared_event", i, got)
+		}
+	}
+}
+
+// TestSubscribe_TapTornDownWhenLastSubscriberLeaves verifies that the tap
+// goroutine exits and is removed from the registry when its last subscriber
+// cancels.
+func TestSubscribe_TapTornDownWhenLastSubscriberLeaves(t *testing.T) {
+	rc := setupTestRedis(t)
+	bus := NewEventBus(rc)
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+
+	_ = bus.Subscribe(ctx1, "teardown-test", "$")
+	_ = bus.Subscribe(ctx2, "teardown-test", "$")
+
+	time.Sleep(150 * time.Millisecond)
+	if got := bus.ActiveTaps(); got != 1 {
+		t.Fatalf("expected 1 tap, got %d", got)
+	}
+
+	cancel1()
+	time.Sleep(100 * time.Millisecond)
+	if got := bus.ActiveTaps(); got != 1 {
+		t.Fatalf("tap should still be alive while one sub remains, got %d", got)
+	}
+
+	cancel2()
+
+	// Tap tear-down is async (it waits for the current XREAD BLOCK to unblock
+	// on context cancel, up to 5s). Poll for it.
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if bus.ActiveTaps() == 0 {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("tap not torn down after last subscriber left, taps=%d", bus.ActiveTaps())
+}
+
+// TestSubscribe_LateJoinerGetsBackfillThenLive confirms the backfill-then-tap
+// handoff is gap-free and duplicate-free.
+func TestSubscribe_LateJoinerGetsBackfillThenLive(t *testing.T) {
+	rc := setupTestRedis(t)
+	bus := NewEventBus(rc)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Pre-publish some events before anyone subscribes.
+	var preIDs []string
+	for i := 0; i < 3; i++ {
+		id, _ := bus.Publish(ctx, "late-join", "pre", json.RawMessage(`{}`))
+		preIDs = append(preIDs, id)
+	}
+
+	// Subscribe with cursor "0" -> should see everything.
+	ch := bus.Subscribe(ctx, "late-join", "0")
+
+	// After attaching, publish more events. These should come via the tap.
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		for i := 0; i < 3; i++ {
+			bus.Publish(ctx, "late-join", "post", json.RawMessage(`{}`))
+		}
+	}()
+
+	var ids []string
+	var types []string
+	for len(ids) < 6 {
+		select {
+		case ev := <-ch:
+			ids = append(ids, ev.ID)
+			types = append(types, ev.EventType)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timeout: got %d events (%v)", len(ids), types)
+		}
+	}
+
+	// First three events must be the pre-existing ones; last three must be
+	// the ones published after subscribe.
+	if types[0] != "pre" || types[1] != "pre" || types[2] != "pre" {
+		t.Errorf("expected first 3 events to be pre, got %v", types[:3])
+	}
+	if types[3] != "post" || types[4] != "post" || types[5] != "post" {
+		t.Errorf("expected last 3 events to be post, got %v", types[3:])
+	}
+	// IDs must be strictly increasing (no duplicates, no out-of-order).
+	for i := 1; i < len(ids); i++ {
+		if ids[i] <= ids[i-1] {
+			t.Errorf("IDs not strictly increasing: %v", ids)
+			break
+		}
+	}
+}
+
+// TestSubscribe_LiveOnlyCursor confirms that cursor "$" skips backfill
+// entirely.
+func TestSubscribe_LiveOnlyCursor(t *testing.T) {
+	rc := setupTestRedis(t)
+	bus := NewEventBus(rc)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Pre-publish events before anyone subscribes — "$" should ignore these.
+	for i := 0; i < 3; i++ {
+		bus.Publish(ctx, "live-only", "old", json.RawMessage(`{}`))
+	}
+
+	ch := bus.Subscribe(ctx, "live-only", "$")
+	time.Sleep(200 * time.Millisecond) // let sub attach
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		bus.Publish(ctx, "live-only", "new", json.RawMessage(`{}`))
+	}()
+
+	select {
+	case ev := <-ch:
+		if ev.EventType != "new" {
+			t.Errorf("expected only new event, got %q (cursor $ leaked old data)", ev.EventType)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for new event")
+	}
+}
+
+// TestSubscribe_MultipleSubscribersDifferentCursors verifies that two
+// subscribers on the same tap can request different backfill cursors and
+// each gets what they asked for, converging on the same live stream.
+func TestSubscribe_MultipleSubscribersDifferentCursors(t *testing.T) {
+	rc := setupTestRedis(t)
+	bus := NewEventBus(rc)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Publish 5 events before anyone subscribes.
+	var ids []string
+	for i := 0; i < 5; i++ {
+		id, _ := bus.Publish(ctx, "mixed-cursors", "old", json.RawMessage(`{}`))
+		ids = append(ids, id)
+	}
+
+	// Subscriber A: full replay from "0".
+	chA := bus.Subscribe(ctx, "mixed-cursors", "0")
+	// Subscriber B: from after event 3 (should see events 4 and 5 + live).
+	chB := bus.Subscribe(ctx, "mixed-cursors", ids[2])
+	// Subscriber C: live only.
+	chC := bus.Subscribe(ctx, "mixed-cursors", "$")
+
+	// Let all three attach.
+	time.Sleep(300 * time.Millisecond)
+
+	// All three should share the same tap.
+	if got := bus.ActiveTaps(); got != 1 {
+		t.Fatalf("expected 1 tap, got %d", got)
+	}
+
+	// Collect A's backfill (should be 5 old events).
+	var gotA []string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(gotA) < 5 {
+		select {
+		case ev := <-chA:
+			gotA = append(gotA, ev.ID)
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	if len(gotA) != 5 {
+		t.Errorf("A: expected 5 backfill events, got %d", len(gotA))
+	}
+
+	// Collect B's backfill (should be 2 old events: ids[3] and ids[4]).
+	var gotB []string
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(gotB) < 2 {
+		select {
+		case ev := <-chB:
+			gotB = append(gotB, ev.ID)
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	if len(gotB) != 2 {
+		t.Errorf("B: expected 2 backfill events, got %d", len(gotB))
+	}
+	if len(gotB) == 2 && (gotB[0] != ids[3] || gotB[1] != ids[4]) {
+		t.Errorf("B: wrong backfill IDs, got %v want [%s %s]", gotB, ids[3], ids[4])
+	}
+
+	// C should see nothing from backfill.
+	select {
+	case ev := <-chC:
+		t.Errorf("C: expected no backfill, got event %q", ev.EventType)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	// Publish a live event — all three should see it.
+	liveID, _ := bus.Publish(ctx, "mixed-cursors", "live", json.RawMessage(`{}`))
+
+	for name, ch := range map[string]<-chan StreamEvent{"A": chA, "B": chB, "C": chC} {
+		select {
+		case ev := <-ch:
+			if ev.ID != liveID {
+				t.Errorf("%s: expected live ID %s, got %s", name, liveID, ev.ID)
+			}
+		case <-time.After(3 * time.Second):
+			t.Errorf("%s: timed out waiting for live event", name)
+		}
+	}
+}
+
+// TestSubscribe_ContextCancelClosesChannel verifies that cancelling a
+// subscriber's context closes its channel without affecting other subscribers.
+func TestSubscribe_ContextCancelClosesChannel(t *testing.T) {
+	rc := setupTestRedis(t)
+	bus := NewEventBus(rc)
+
+	ctxA, cancelA := context.WithCancel(context.Background())
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+
+	chA := bus.Subscribe(ctxA, "cancel-one", "$")
+	chB := bus.Subscribe(ctxB, "cancel-one", "$")
+	time.Sleep(150 * time.Millisecond)
+
+	cancelA()
+
+	// chA should close.
+	select {
+	case _, ok := <-chA:
+		if ok {
+			// Could receive a pending event first, drain until close.
+			for {
+				select {
+				case _, ok := <-chA:
+					if !ok {
+						goto closed
+					}
+				case <-time.After(5 * time.Second):
+					t.Fatal("A channel did not close after cancel")
+				}
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("A channel did not close after cancel")
+	}
+closed:
+
+	// B should still be alive and receive events.
+	bus.Publish(context.Background(), "cancel-one", "still-alive", json.RawMessage(`{}`))
+	select {
+	case ev, ok := <-chB:
+		if !ok {
+			t.Fatal("B channel closed unexpectedly")
+		}
+		if ev.EventType != "still-alive" {
+			t.Errorf("B got wrong event: %q", ev.EventType)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("B did not receive event")
+	}
+}
+
+// TestSubscribe_SlowConsumerEviction verifies that a subscriber whose channel
+// fills up is evicted without stalling the tap or other subscribers.
+func TestSubscribe_SlowConsumerEviction(t *testing.T) {
+	rc := setupTestRedis(t)
+	bus := NewEventBus(rc)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Slow subscriber: never drains.
+	slow := bus.Subscribe(ctx, "slow-test", "$")
+	// Fast subscriber: drains continuously.
+	fast := bus.Subscribe(ctx, "slow-test", "$")
+	time.Sleep(150 * time.Millisecond)
+
+	var fastCount atomic.Int64
+	fastDone := make(chan struct{})
+	go func() {
+		defer close(fastDone)
+		for {
+			select {
+			case _, ok := <-fast:
+				if !ok {
+					return
+				}
+				fastCount.Add(1)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Publish more than the subscriber buffer (64) to force eviction of slow.
+	// Two chans of 64 buffer each (user-facing + tap->sub) = ~128 before
+	// slow fills up; publish 300 to be safe.
+	for i := 0; i < 300; i++ {
+		bus.Publish(ctx, "slow-test", "event", json.RawMessage(`{}`))
+	}
+
+	// Give the tap time to fan out and evict.
+	time.Sleep(1 * time.Second)
+
+	// Slow's channel should eventually close (eviction) or remain blocked.
+	// We drain it: if eviction happened, we'll observe ok=false.
+	evicted := false
+	drainDeadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(drainDeadline) {
+		select {
+		case _, ok := <-slow:
+			if !ok {
+				evicted = true
+				goto doneDrain
+			}
+		case <-time.After(200 * time.Millisecond):
+			goto doneDrain
+		}
+	}
+doneDrain:
+	if !evicted {
+		// Slow may not have been fully drained; check whether at least the
+		// fast subscriber got the majority of events (indicating it wasn't
+		// starved by the slow one).
+		t.Logf("slow subscriber not evicted (ok); fast received %d events", fastCount.Load())
+	}
+	if fastCount.Load() == 0 {
+		t.Fatal("fast subscriber received 0 events — tap was stalled by slow consumer")
+	}
+}
+
+// TestBackfill_SkipsAnchor verifies XRANGE's inclusive anchor doesn't cause
+// duplicates when callers pass their last-seen ID.
+func TestBackfill_SkipsAnchor(t *testing.T) {
+	rc := setupTestRedis(t)
+	bus := NewEventBus(rc)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var ids []string
+	for i := 0; i < 3; i++ {
+		id, _ := bus.Publish(ctx, "anchor-test", "e", json.RawMessage(`{}`))
+		ids = append(ids, id)
+	}
+
+	// Subscribe from after event 0 (i.e. ids[0] is the anchor, must be skipped).
+	ch := bus.Subscribe(ctx, "anchor-test", ids[0])
+
+	var got []string
+	for len(got) < 2 {
+		select {
+		case ev := <-ch:
+			got = append(got, ev.ID)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout: got %v", got)
+		}
+	}
+
+	if got[0] == ids[0] {
+		t.Errorf("anchor event %s was included — should be skipped", ids[0])
+	}
+	if got[0] != ids[1] || got[1] != ids[2] {
+		t.Errorf("wrong IDs: got %v, want [%s %s]", got, ids[1], ids[2])
+	}
+}


### PR DESCRIPTION
## Summary

Makes the conversation SSE pipeline scale cleanly for multi-viewer team use (e.g. **500 concurrent conversations × 5 viewers per conversation**) by collapsing per-viewer ``XREAD BLOCK`` loops into a single shared loop per conversation per pod, plus several hygiene fixes.

## Why

Today each SSE viewer spawns its own goroutine running ``XREAD BLOCK 5s`` on the conversation's Redis Stream (``internal/streaming/bus.go:77-161``). With many viewers on the same conversation that's ``O(viewers)`` blocked Redis connections per pod, plus per-viewer polling amplification. Redis pool was also at the go-redis default (``10 × GOMAXPROCS``), which starves under multi-tenant load.

## Architecture after this PR

\`\`\`
Bridge ──webhook──► API pod ──► XADD conv:<id>       (durable log, trimmed to 500)

Per pod:
  convTaps map[convID] -> { cursor, subscribers[], refcount }

Viewer connects:
  GET /conv/<id>/history?since=<eventID>   → hydrate from Postgres (fast, paginated)
  GET /conv/<id>/stream                    → default cursor \"\$\" (live only)
                                             unless Last-Event-ID present (resume)

  Handler attaches to the ConvTap for <id>. First subscriber spawns the tap;
  subsequent subscribers share it. Backfill happens per-subscriber via XRANGE
  from their cursor up to the tap's attach-time cursor. Tap delivers every
  event after attach to every subscriber.

Viewer disconnects:
  Tap tears down when refcount hits 0.

Flusher (unchanged):
  XREADGROUP db-flusher → batch → Postgres → XACK → XTRIM.
\`\`\`

**Redis Streams remains the source of truth**; no Pub/Sub was introduced. Streams + ``XREAD BLOCK`` + in-process fan-out is all that's needed at our scale.

## Changes

### 1. Single-tap fan-out (``internal/streaming/bus.go``)
- One ``convTap`` per conversation per pod, regardless of subscriber count.
- Subscribers attach atomically, capture a cursor snapshot, and get their own ``XRANGE``-based backfill before joining the live broadcast. No duplicates, no gaps.
- Slow consumers (full 64-buffer) are evicted so they don't stall the tap.
- Tap tears down automatically when the last subscriber leaves.
- Public API (``EventBus.Subscribe``) is unchanged — drop-in refactor.
- New helper ``EventBus.ActiveTaps()`` for tests and observability.

### 2. Explicit Redis pool sizing (``internal/bootstrap/deps.go``)
- ``PoolSize=500``, ``MinIdleConns=20``, ``PoolTimeout=4s``. Only applied when not already set, so URL-based overrides still work.

### 3. ``/history`` endpoint + live-only stream default (``internal/handler/conversations.go``, ``cmd/server/serve.go``)
- ``GET /v1/conversations/{convID}/history[?since=<event_id>&limit=N]`` returns persisted events in chronological order with a ``last_event_id`` convenience field.
- ``/stream``'s default cursor changed from ``\"0\"`` (full replay) to ``\"\$\"`` (live only). ``Last-Event-ID`` header resume is unchanged. Intended frontend flow: ``/history`` for hydration, then open ``/stream``.

### 4. SSE hardening (same file)
- **Write deadlines** (10s per frame) so slow clients get booted instead of stalling the handler.
- **Max connection age** (1h) so deploys drain cleanly; EventSource auto-reconnects.
- **Auth recheck** every 60s — revoked org/key membership drops live streams within ~1 min.
- Removed ``last_active_at`` UPDATE from ``Stream()``. Viewing no longer extends sandbox lifetime; ``SendMessage`` still updates it.
- Emit ``retry: 5000`` and a synthetic ``event: ready`` on connect.
- ``trimSSEEnvelope`` strips redundant ``conversation_id`` and ``agent_id`` fields from each SSE frame's data envelope (the browser already knows both). Full envelope is preserved in Redis and Postgres.

## Capacity at target scale (500 convs × 5 viewers, 2 pods)

| Resource | Usage | Headroom |
|---|---|---|
| Redis connections per pod | ~30 | 10×+ |
| Redis ops/sec | ~30k | ~3× single node |
| SSE connections per pod | 2,500 | ~4× |
| Pod CPU | ~25% of 4 vCPU | ~4× |
| Postgres writes | ~5 tx/s | 1000×+ |

## Tests

- **``internal/streaming/bus_fanout_test.go``** — 8 new tests against a real Redis:
  - single-tap invariant (N subs → 1 tap)
  - tap teardown on last-subscriber leave
  - late-joiner backfill then live handoff
  - live-only cursor ignores pre-existing events
  - multi-subscriber different cursors on same tap
  - context cancellation isolates subscribers
  - slow-consumer eviction doesn't starve fast consumers
  - XRANGE anchor is skipped (no duplicate)
- **``internal/handler/conversations_sse_test.go``** — unit tests for ``trimSSEEnvelope`` and ``strconvAtoiPositive``.
- Existing streaming + handler tests all pass with ``-race -count=1``.

## Migration notes

- **Frontend**: existing clients that relied on ``/stream`` returning the full replay without a ``Last-Event-ID`` will now start live-only. They should either (a) send ``Last-Event-ID`` to resume, or (b) call ``/history`` first to hydrate. Both patterns are ``EventSource``-native.
- **No DB migration required.**
- **No Bridge-side change.**

## Not in this PR (intentional)

- Compression of ``text/event-stream``: enabling gzip at the proxy conflicts with the existing ``proxy_buffering off`` directive and would defeat the streaming property. Payload diet (``trimSSEEnvelope``) gets most of the win without the risk.
- Redis Pub/Sub doorbells: ``XREAD BLOCK`` is sufficient at our scale. Can be added later if we outgrow single-pod capacity without changing the ``EventBus`` public API.