### PR TITLE
fix(cmd/server): restore build by replacing bootstrap type shims with real types

### DIFF
--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	chimw "github.com/go-chi/chi/v5/middleware"
-	"gorm.io/gorm"
 
 	"github.com/usehiveloop/hiveloop/internal/bootstrap"
 	"github.com/usehiveloop/hiveloop/internal/email"
@@ -19,7 +18,6 @@ import (
 	"github.com/usehiveloop/hiveloop/internal/goroutine"
 	"github.com/usehiveloop/hiveloop/internal/handler"
 	"github.com/usehiveloop/hiveloop/internal/hindsight"
-	"github.com/usehiveloop/hiveloop/internal/mcpserver"
 	"github.com/usehiveloop/hiveloop/internal/middleware"
 	posthogobs "github.com/usehiveloop/hiveloop/internal/observability/posthog"
 	"github.com/usehiveloop/hiveloop/internal/proxy"

--- a/cmd/server/serve_mcp.go
+++ b/cmd/server/serve_mcp.go
@@ -12,6 +12,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/usehiveloop/hiveloop/internal/bootstrap"
+	"github.com/usehiveloop/hiveloop/internal/config"
 	"github.com/usehiveloop/hiveloop/internal/goroutine"
 	"github.com/usehiveloop/hiveloop/internal/handler"
 	"github.com/usehiveloop/hiveloop/internal/mcpserver"
@@ -21,7 +22,7 @@ import (
 
 func setupMCPServer(
 	ctx context.Context,
-	cfg *bootstrap.Config,
+	cfg *config.Config,
 	deps *bootstrap.Deps,
 	signingKey []byte,
 	database *gorm.DB,

--- a/cmd/server/serve_routes.go
+++ b/cmd/server/serve_routes.go
@@ -8,26 +8,29 @@ import (
 	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 
-	"github.com/usehiveloop/hiveloop/internal/bootstrap"
+	"github.com/usehiveloop/hiveloop/internal/config"
+	"github.com/usehiveloop/hiveloop/internal/crypto"
 	"github.com/usehiveloop/hiveloop/internal/handler"
+	"github.com/usehiveloop/hiveloop/internal/mcp/catalog"
 	"github.com/usehiveloop/hiveloop/internal/middleware"
+	"github.com/usehiveloop/hiveloop/internal/nango"
 )
 
 func setupPublicRoutes(
 	r chi.Router,
-	cfg *bootstrap.Config,
+	cfg *config.Config,
 	database *gorm.DB,
 	redisClient *redis.Client,
 	providerHandler *handler.ProviderHandler,
 	inIntegrationHandler *handler.InIntegrationHandler,
-	actionsCatalog bootstrap.ActionsCatalog,
+	actionsCatalog *catalog.Catalog,
 	marketplaceHandler *handler.MarketplaceHandler,
 	orgInviteHandler *handler.OrgInviteHandler,
 	bridgeWebhookHandler *handler.BridgeWebhookHandler,
 	nangoWebhookHandler *handler.NangoWebhookHandler,
 	incomingWebhookHandler *handler.IncomingWebhookHandler,
-	nangoClient bootstrap.NangoClient,
-	sandboxEncKey []byte,
+	nangoClient *nango.Client,
+	sandboxEncKey *crypto.SymmetricKey,
 ) {
 	r.Get("/healthz", healthz)
 	r.Get("/readyz", readyz(database, redisClient))
@@ -79,7 +82,7 @@ func setupPublicRoutes(
 func setupAuthRoutes(
 	r chi.Router,
 	ctx context.Context,
-	cfg *bootstrap.Config,
+	cfg *config.Config,
 	rsaPub *rsa.PublicKey,
 	authHandler *handler.AuthHandler,
 	oauthHandler *handler.OAuthHandler,

--- a/cmd/server/serve_routes_admin.go
+++ b/cmd/server/serve_routes_admin.go
@@ -3,11 +3,15 @@ package main
 import (
 	"crypto/rsa"
 	"log/slog"
+	"net/http"
 
 	"github.com/go-chi/chi/v5"
 	"gorm.io/gorm"
 
 	"github.com/usehiveloop/hiveloop/internal/bootstrap"
+	"github.com/usehiveloop/hiveloop/internal/config"
+	"github.com/usehiveloop/hiveloop/internal/counter"
+	"github.com/usehiveloop/hiveloop/internal/crypto"
 	"github.com/usehiveloop/hiveloop/internal/enqueue"
 	"github.com/usehiveloop/hiveloop/internal/handler"
 	"github.com/usehiveloop/hiveloop/internal/middleware"
@@ -15,7 +19,7 @@ import (
 
 func setupAdminRoutes(
 	r chi.Router,
-	cfg *bootstrap.Config,
+	cfg *config.Config,
 	deps *bootstrap.Deps,
 	rsaPub *rsa.PublicKey,
 	database *gorm.DB,
@@ -93,7 +97,6 @@ func setupAdminRoutes(
 			r.Delete("/custom-domains/{id}", adminHandler.DeleteCustomDomain)
 			r.Get("/audit", adminHandler.ListAudit)
 			r.Get("/usage", adminHandler.ListUsage)
-			r.Get("/admin-audit", adminHandler.ListAdminAudit)
 			r.Get("/workspace-storage", adminHandler.ListWorkspaceStorage)
 			r.Delete("/workspace-storage/{id}", adminHandler.DeleteWorkspaceStorage)
 			r.Get("/marketplace/agents", marketplaceHandler.AdminList)
@@ -107,16 +110,16 @@ func setupAdminRoutes(
 
 func setupProxyAndAuxRoutes(
 	r chi.Router,
-	cfg *bootstrap.Config,
+	cfg *config.Config,
 	deps *bootstrap.Deps,
 	signingKey []byte,
 	database *gorm.DB,
-	proxyHandler *handler.ProxyHandler,
+	proxyHandler http.Handler,
 	driveHandler *handler.DriveHandler,
-	sandboxEncKey []byte,
+	sandboxEncKey *crypto.SymmetricKey,
 	auditWriter *middleware.AuditWriter,
 	generationWriter *middleware.GenerationWriter,
-	ctr bootstrap.Counter,
+	ctr *counter.Counter,
 ) {
 	r.Route("/v1/proxy", func(r chi.Router) {
 		r.Use(middleware.TokenAuth(signingKey, database))

--- a/cmd/server/serve_routes_v1.go
+++ b/cmd/server/serve_routes_v1.go
@@ -6,18 +6,20 @@ import (
 	"github.com/go-chi/chi/v5"
 	"gorm.io/gorm"
 
-	"github.com/usehiveloop/hiveloop/internal/bootstrap"
+	"github.com/usehiveloop/hiveloop/internal/cache"
+	"github.com/usehiveloop/hiveloop/internal/config"
 	"github.com/usehiveloop/hiveloop/internal/enqueue"
 	"github.com/usehiveloop/hiveloop/internal/handler"
 	"github.com/usehiveloop/hiveloop/internal/middleware"
+	"github.com/usehiveloop/hiveloop/internal/sandbox"
 )
 
 func setupV1Routes(
 	r chi.Router,
-	cfg *bootstrap.Config,
+	cfg *config.Config,
 	rsaPub *rsa.PublicKey,
 	database *gorm.DB,
-	apiKeyCache bootstrap.APIKeyCache,
+	apiKeyCache *cache.APIKeyCache,
 	enqueuer enqueue.TaskEnqueuer,
 	orgHandler *handler.OrgHandler,
 	orgInviteHandler *handler.OrgInviteHandler,
@@ -38,7 +40,7 @@ func setupV1Routes(
 	systemConvHandler *handler.SystemConversationHandler,
 	routerHandler *handler.RouterHandler,
 	customDomainHandler *handler.CustomDomainHandler,
-	orchestrator bootstrap.Orchestrator,
+	orchestrator *sandbox.Orchestrator,
 	auditWriter *middleware.AuditWriter,
 ) {
 	r.Route("/v1", func(r chi.Router) {
@@ -232,7 +234,7 @@ func setupV1Routes(
 
 func setupConnectRoutes(
 	r chi.Router,
-	cfg *bootstrap.Config,
+	cfg *config.Config,
 	rsaPub *rsa.PublicKey,
 	database *gorm.DB,
 	platformAdminEmails []string,


### PR DESCRIPTION
## Summary

PR #20 (feat(router): add HTTP and cron trigger types) merged a commit that reverted the fix in 6f1f961, because the rebase captured the pre-fix versions of cmd/server/serve_routes*.go which still referenced the removed bootstrap type aliases (Config, ActionsCatalog, NangoClient, Counter, APIKeyCache, Orchestrator).

This cherry-picks 6f1f961 back on top of main so cmd/server compiles and `publish-api-image` / Railway deploys can succeed again.

## Evidence
- Main's `publish-api-image` is failing on commit c4ac889 with `cmd/server/serve_routes.go:18:17: undefined: bootstrap.Config` and similar across serve_routes*.go, serve_mcp.go.
- The types live in `internal/config` (Config), `internal/mcp/catalog` (Catalog), `internal/nango` (Client), `internal/crypto` (SymmetricKey).

## Test plan

- [ ] CI goes green (build, publish-api-image)
- [ ] Railway deployment resumes