### PR TITLE
refactor(frontend): replace arbitrary Tailwind values with design tokens

### DIFF
--- a/apps/web/app/(marketing)/blog/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/blog/[slug]/page.tsx
@@ -17,13 +17,13 @@ const proseComponents = {
   h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
     <h1
       {...props}
-      className="font-heading text-3xl sm:text-4xl font-bold text-foreground mt-12 -tracking-[0.5px]"
+      className="font-heading text-3xl sm:text-4xl font-bold text-foreground mt-12 -tracking-micro"
     />
   ),
   h2: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
     <h2
       {...props}
-      className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-10 -tracking-[0.5px]"
+      className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-10 -tracking-micro"
     />
   ),
   h3: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
@@ -75,7 +75,7 @@ const proseComponents = {
     // Block-level code (inside <pre>) gets `language-...` className from MDX —
     // skip our pill styling so the pre/code combo renders as a code block.
     if (className && className.startsWith("language-")) {
-      return <code {...props} className={`${className} font-mono text-[13px] leading-relaxed text-white/80`} />
+      return <code {...props} className={`${className} font-mono text-sm-alt leading-relaxed text-white/80`} />
     }
     return (
       <code
@@ -98,7 +98,7 @@ const proseComponents = {
           <span className="w-2.5 h-2.5 rounded-full bg-yellow-500/70" />
           <span className="w-2.5 h-2.5 rounded-full bg-green-500/70" />
           {title && (
-            <span className="flex-1 text-center font-mono text-[10px] text-white/25">{title}</span>
+            <span className="flex-1 text-center font-mono text-2xs text-white/25">{title}</span>
           )}
         </div>
         <pre {...rest} className="p-4 sm:p-5 overflow-x-auto">
@@ -142,10 +142,10 @@ export default async function BlogPostPage(props: PageProps) {
           }}
         />
         <div className="relative max-w-3xl mx-auto px-4 pt-16 sm:pt-24 pb-16 sm:pb-20 flex flex-col items-center text-center gap-6">
-          <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+          <span className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
             {category}
           </span>
-          <h1 className="font-heading text-[32px] sm:text-[44px] lg:text-[56px] font-bold text-foreground leading-[1.1] -tracking-[1px]">
+          <h1 className="font-heading text-[32px] sm:text-[44px] lg:text-[56px] font-bold text-foreground leading-[1.1] -tracking-small">
             {title}
           </h1>
           <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed max-w-2xl">

--- a/apps/web/app/(marketing)/blog/page.tsx
+++ b/apps/web/app/(marketing)/blog/page.tsx
@@ -57,10 +57,10 @@ export default function BlogIndex() {
       <div className="max-w-6xl mx-auto w-full px-4 pb-24">
         {/* Header */}
         <div className="flex flex-col gap-2 pt-12 sm:pt-20 pb-10 sm:pb-14">
-          <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+          <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
             Blog
           </p>
-          <h1 className="font-heading text-[28px] sm:text-[36px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-[0.5px]">
+          <h1 className="font-heading text-[28px] sm:text-[36px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-micro">
             Stories from the team
           </h1>
         </div>
@@ -90,7 +90,7 @@ export default function BlogIndex() {
               <div className="relative p-8 sm:p-12 lg:p-16 flex flex-col gap-5 max-w-3xl">
                 <div className="flex items-center gap-3">
                   <span
-                    className={`font-mono text-[11px] font-medium uppercase tracking-wider ${
+                    className={`font-mono text-mini font-medium uppercase tracking-wider ${
                       categoryColors[featured.category] ?? "text-primary"
                     }`}
                   >
@@ -100,7 +100,7 @@ export default function BlogIndex() {
                     {formatDate(featured.date)}
                   </span>
                 </div>
-                <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[40px] font-bold text-foreground leading-[1.15] -tracking-[0.5px] group-hover:text-primary transition-colors">
+                <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[40px] font-bold text-foreground leading-[1.15] -tracking-micro group-hover:text-primary transition-colors">
                   {featured.title}
                 </h2>
                 <p className="text-base sm:text-lg text-muted-foreground leading-relaxed max-w-2xl">
@@ -139,7 +139,7 @@ export default function BlogIndex() {
                 >
                   <div className="flex items-center gap-3">
                     <span
-                      className={`font-mono text-[11px] font-medium uppercase tracking-wider ${
+                      className={`font-mono text-mini font-medium uppercase tracking-wider ${
                         categoryColors[post.category] ?? "text-primary"
                       }`}
                     >
@@ -208,10 +208,10 @@ export default function BlogIndex() {
           />
           <div className="relative p-8 sm:p-12 lg:p-16 flex flex-col lg:flex-row lg:items-center gap-8 lg:gap-16">
             <div className="flex flex-col gap-3 lg:flex-1">
-              <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+              <span className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
                 Newsletter
               </span>
-              <h2 className="font-heading text-[22px] sm:text-[28px] font-bold text-foreground leading-[1.2] -tracking-[0.5px]">
+              <h2 className="font-heading text-[22px] sm:text-[28px] font-bold text-foreground leading-[1.2] -tracking-micro">
                 Stay in the loop
               </h2>
               <p className="text-sm sm:text-base text-muted-foreground leading-relaxed max-w-md">

--- a/apps/web/app/(marketing)/legal/privacy/page.tsx
+++ b/apps/web/app/(marketing)/legal/privacy/page.tsx
@@ -18,10 +18,10 @@ export default function PrivacyPage() {
           }}
         />
         <div className="relative max-w-3xl mx-auto px-4 pt-16 sm:pt-24 pb-16 sm:pb-20 flex flex-col items-center text-center gap-6">
-          <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+          <span className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
             Legal
           </span>
-          <h1 className="font-heading text-[32px] sm:text-[44px] lg:text-[56px] font-bold text-foreground leading-[1.1] -tracking-[1px]">
+          <h1 className="font-heading text-[32px] sm:text-[44px] lg:text-[56px] font-bold text-foreground leading-[1.1] -tracking-small">
             Privacy Policy
           </h1>
           <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed max-w-2xl">
@@ -36,7 +36,7 @@ export default function PrivacyPage() {
             At HiveLoop, we take your privacy seriously. This policy explains how we collect, use, and protect your information.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             1. Information We Collect
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
@@ -46,56 +46,56 @@ export default function PrivacyPage() {
             We also collect usage data including API calls, agent execution logs, and device information to improve our service.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             2. How We Use Your Information
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             We use your information to provide and improve the service, process payments, communicate about your account, and ensure platform security.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             3. Data Retention
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             We retain your data as long as your account is active. Upon deletion, we delete or anonymize your data within 30 days, except where retention is required by law.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             4. Data Security
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             We use encryption (AES-256-GCM) for credential storage, TLS for data in transit, and access controls to protect your data. No third party ever has access to your API keys.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             5. Cookies
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             We use essential cookies for authentication and session management. Analytics cookies are optional and help us understand how users interact with the platform.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             6. Third-Party Services
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             We use third-party services for payment processing (Stripe), infrastructure (Daytona), and analytics. Each has their own privacy policies governing their use of your data.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             7. Your Rights
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             You have the right to access, correct, or delete your data. You can export your data at any time through your account settings. Contact privacy@hiveloop.com for requests.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             8. Changes to Policy
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             We may update this policy periodically. We will notify you of significant changes via email or platform notification.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             Contact Us
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">

--- a/apps/web/app/(marketing)/legal/terms/page.tsx
+++ b/apps/web/app/(marketing)/legal/terms/page.tsx
@@ -18,10 +18,10 @@ export default function TermsPage() {
           }}
         />
         <div className="relative max-w-3xl mx-auto px-4 pt-16 sm:pt-24 pb-16 sm:pb-20 flex flex-col items-center text-center gap-6">
-          <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+          <span className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
             Legal
           </span>
-          <h1 className="font-heading text-[32px] sm:text-[44px] lg:text-[56px] font-bold text-foreground leading-[1.1] -tracking-[1px]">
+          <h1 className="font-heading text-[32px] sm:text-[44px] lg:text-[56px] font-bold text-foreground leading-[1.1] -tracking-small">
             Terms of Service
           </h1>
           <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed max-w-2xl">
@@ -36,63 +36,63 @@ export default function TermsPage() {
             Welcome to HiveLoop. By accessing or using our platform, you agree to be bound by these Terms of Service.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             1. Acceptance of Terms
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             By creating an account or using HiveLoop, you agree to these terms and our Privacy Policy. If you do not agree, do not use our services.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             2. Use of Service
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             You may use HiveLoop to create and deploy AI agents. You are responsible for the content and actions of agents you create. You agree not to use the platform for illegal purposes or to violate any third-party rights.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             3. Account Responsibilities
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             You are responsible for maintaining the confidentiality of your account credentials and for all activities under your account. Notify us immediately of any unauthorized use.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             4. Fees and Payment
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             Subscription fees are billed in advance. All fees are non-refundable except as required by law. We reserve the right to change pricing with 30 days notice.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             5. Intellectual Property
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             You retain ownership of content you create. We claim no ownership over your agents or data. However, you grant us a license to operate your agents as part of the service.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             6. Limitation of Liability
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             HiveLoop is provided &ldquo;as is&rdquo; without warranties. We are not liable for any indirect, incidental, or consequential damages arising from your use of the platform.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             7. Termination
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             We may terminate or suspend your account at any time for violation of these terms. You may cancel your subscription at any time through your account settings.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             8. Changes to Terms
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">
             We may update these terms from time to time. Continued use after changes constitutes acceptance of the new terms.
           </p>
 
-          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-[0.5px]">
+          <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground mt-8 -tracking-micro">
             Contact Us
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground leading-[1.8]">

--- a/apps/web/app/(marketing)/marketplace/agents/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/marketplace/agents/[slug]/page.tsx
@@ -98,7 +98,7 @@ export default function DetailVariant1() {
             </div>
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2.5">
-                <h1 className="font-heading text-[28px] sm:text-[36px] font-bold text-foreground leading-tight -tracking-[0.5px]">
+                <h1 className="font-heading text-[28px] sm:text-[36px] font-bold text-foreground leading-tight -tracking-micro">
                   {agent.name}
                 </h1>
                 {agent.verified && <HugeiconsIcon icon={CheckmarkBadge01Icon} size={22} className="text-green-500 shrink-0" />}
@@ -183,7 +183,7 @@ export default function DetailVariant1() {
 
               {/* Details */}
               <div className="rounded-2xl border border-border p-6 flex flex-col gap-3">
-                <span className="font-mono text-[10px] font-medium uppercase tracking-[1.5px] text-muted-foreground">Details</span>
+                <span className="font-mono text-2xs font-medium uppercase tracking-medium text-muted-foreground">Details</span>
                 <div className="flex flex-col gap-2.5">
                   {[
                     { label: "Category", value: agent.category },
@@ -200,11 +200,11 @@ export default function DetailVariant1() {
 
               {/* Integrations */}
               <div className="rounded-2xl border border-border p-6 flex flex-col gap-3">
-                <span className="font-mono text-[10px] font-medium uppercase tracking-[1.5px] text-muted-foreground">Integrations</span>
+                <span className="font-mono text-2xs font-medium uppercase tracking-medium text-muted-foreground">Integrations</span>
                 <div className="flex flex-col gap-2">
                   {agent.integrations.map((integration) => (
                     <div key={integration} className="flex items-center gap-2.5">
-                      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground">
+                      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-muted text-2xs font-bold text-muted-foreground">
                         {integration[0]}
                       </div>
                       <span className="text-sm text-foreground">{integration}</span>
@@ -215,7 +215,7 @@ export default function DetailVariant1() {
 
               {/* Publisher */}
               <div className="rounded-2xl border border-border p-6 flex flex-col gap-3">
-                <span className="font-mono text-[10px] font-medium uppercase tracking-[1.5px] text-muted-foreground">Publisher</span>
+                <span className="font-mono text-2xs font-medium uppercase tracking-medium text-muted-foreground">Publisher</span>
                 <div className="flex items-center gap-3">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img src={agent.publisher.avatar} alt={agent.publisher.name} className="w-10 h-10 rounded-full" />

--- a/apps/web/app/(marketing)/marketplace/page.tsx
+++ b/apps/web/app/(marketing)/marketplace/page.tsx
@@ -50,8 +50,8 @@ export default function MarketplaceAppStore() {
       {/* Hero */}
       <div className="max-w-6xl mx-auto w-full px-4 pt-12 sm:pt-20 pb-8">
         <div className="flex flex-col gap-2 mb-10">
-          <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">Marketplace</p>
-          <h1 className="font-heading text-[28px] sm:text-[40px] lg:text-[48px] font-bold text-foreground leading-[1.15] -tracking-[0.5px]">
+          <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">Marketplace</p>
+          <h1 className="font-heading text-[28px] sm:text-[40px] lg:text-5xl font-bold text-foreground leading-[1.15] -tracking-micro">
             Discover production-ready agents
           </h1>
           <p className="text-base sm:text-lg text-muted-foreground max-w-lg">
@@ -88,10 +88,10 @@ export default function MarketplaceAppStore() {
               <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-background border border-border shadow-sm text-2xl mb-1">
                 {featuredAgent.icon}
               </div>
-              <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-primary bg-primary/10 px-2.5 py-1 rounded-full w-fit">
+              <span className="font-mono text-2xs font-medium uppercase tracking-wider text-primary bg-primary/10 px-2.5 py-1 rounded-full w-fit">
                 {featuredAgent.highlight}
               </span>
-              <h2 className="font-heading text-2xl sm:text-3xl lg:text-4xl font-bold text-foreground group-hover:text-primary transition-colors -tracking-[0.5px]">
+              <h2 className="font-heading text-2xl sm:text-3xl lg:text-4xl font-bold text-foreground group-hover:text-primary transition-colors -tracking-micro">
                 {featuredAgent.name}
               </h2>
               <p className="text-base sm:text-lg text-muted-foreground leading-relaxed">
@@ -249,7 +249,7 @@ function AgentCard({ agent }: AgentCardProps) {
                   {agent.integrations.slice(0, 4).map((integration, index) => (
                     <div
                       key={integration}
-                      className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-background bg-background text-[10px] font-bold text-muted-foreground shadow-sm"
+                      className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-background bg-background text-2xs font-bold text-muted-foreground shadow-sm"
                       style={{ marginLeft: index > 0 ? "-6px" : 0, zIndex: agent.integrations.length - index }}
                     >
                       {integration[0]}
@@ -277,7 +277,7 @@ function AgentCard({ agent }: AgentCardProps) {
             <HugeiconsIcon icon={CheckmarkBadge01Icon} size={15} className="text-green-500 shrink-0" />
           )}
         </div>
-        <p className="text-[13px] text-muted-foreground leading-relaxed line-clamp-2 flex-1">
+        <p className="text-sm-alt text-muted-foreground leading-relaxed line-clamp-2 flex-1">
           {agent.description}
         </p>
         <div className="flex items-center justify-between pt-3 border-t border-border/50 mt-auto">
@@ -286,7 +286,7 @@ function AgentCard({ agent }: AgentCardProps) {
             <img src={agent.publisher.avatar} alt={agent.publisher.name} className="h-5 w-5 rounded-full object-cover" />
             <span className="text-xs text-muted-foreground">{agent.publisher.name}</span>
           </div>
-          <span className="text-[10px] font-mono font-medium uppercase tracking-wider text-muted-foreground">
+          <span className="text-2xs font-mono font-medium uppercase tracking-wider text-muted-foreground">
             {agent.category}
           </span>
         </div>

--- a/apps/web/app/(marketing)/page.tsx
+++ b/apps/web/app/(marketing)/page.tsx
@@ -94,11 +94,11 @@ export default function Home() {
           <div className="relative flex flex-col items-center gap-6 sm:gap-8 pt-12 sm:pt-16 lg:pt-25 px-4 sm:px-8 lg:px-0">
             <div className="flex items-center gap-2 px-4 py-2 bg-muted border border-border rounded-full">
               <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
-              <span className="font-mono text-[11px] font-medium uppercase tracking-[0.5px] text-muted-foreground">
+              <span className="font-mono text-mini font-medium uppercase tracking-micro text-muted-foreground">
                 introducing the marketplace with revenue sharing
               </span>
             </div>
-            <h1 className="font-heading text-[28px] sm:text-[40px] lg:text-[56px] font-bold text-foreground text-center leading-[1.15] -tracking-[0.5px] sm:-tracking-[1px]">
+            <h1 className="font-heading text-[28px] sm:text-[40px] lg:text-[56px] font-bold text-foreground text-center leading-[1.15] -tracking-micro sm:-tracking-small">
               Run production-grade <br className="hidden sm:block" /> agents for your team
             </h1>
             <p className="text-base sm:text-lg lg:text-xl text-muted-foreground text-center leading-relaxed max-w-160">
@@ -147,7 +147,7 @@ export default function Home() {
 
           {/* Trusted by */}
           <div className="relative z-10 flex flex-col items-center gap-8 py-20 sm:py-28 px-4">
-            <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+            <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
               Trusted by companies of all sizes
             </p>
             <div className="flex flex-wrap items-center justify-center gap-x-12 gap-y-6 sm:gap-x-16 opacity-40">
@@ -199,10 +199,10 @@ export default function Home() {
           <div className="relative flex flex-col items-center gap-10 sm:gap-14 pb-20 sm:pb-28 lg:pb-36">
             {/* Section header */}
             <div className="flex flex-col items-center gap-5 sm:gap-6 max-w-3xl text-center px-4">
-              <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+              <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
                 Why Hiveloop
               </p>
-              <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-[0.5px] sm:-tracking-[1px]">
+              <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-micro sm:-tracking-small">
                 Stop paying for 10 subscriptions.{" "}
                 <br className="hidden sm:block" />
                 Build your own agents instead.
@@ -220,7 +220,7 @@ export default function Home() {
                 <div className="p-6 sm:p-8 lg:p-10 bg-muted/50 dark:bg-card/50 border-b lg:border-b-0 lg:border-r border-border">
                   <div className="flex items-center gap-2 mb-6">
                     <span className="w-2 h-2 rounded-full bg-destructive" />
-                    <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-destructive">
+                    <span className="font-mono text-mini font-medium uppercase tracking-medium text-destructive">
                       What you&apos;re paying today
                     </span>
                   </div>
@@ -262,7 +262,7 @@ export default function Home() {
                       <span className="text-sm font-medium text-muted-foreground">
                         Monthly total
                       </span>
-                      <span className="text-2xl font-heading font-bold text-destructive -tracking-[0.5px]">
+                      <span className="text-2xl font-heading font-bold text-destructive -tracking-micro">
                         $723/mo
                       </span>
                     </div>
@@ -297,7 +297,7 @@ export default function Home() {
                 <div className="p-6 sm:p-8 lg:p-10 bg-background dark:bg-[oklch(0.14_0.01_55)]">
                   <div className="flex items-center gap-2 mb-6">
                     <span className="w-2 h-2 rounded-full bg-green-500" />
-                    <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-foreground">
+                    <span className="font-mono text-mini font-medium uppercase tracking-medium text-foreground">
                       What you build on Hiveloop
                     </span>
                   </div>
@@ -356,7 +356,7 @@ export default function Home() {
                       <span className="text-sm font-medium text-muted-foreground">
                         6 agents x $4.99/mo
                       </span>
-                      <span className="text-2xl font-heading font-bold text-foreground -tracking-[0.5px]">
+                      <span className="text-2xl font-heading font-bold text-foreground -tracking-micro">
                         $29.94/mo
                       </span>
                     </div>
@@ -409,7 +409,7 @@ export default function Home() {
                   key={stat.value}
                   className="flex flex-col items-center text-center gap-1.5"
                 >
-                  <span className="font-heading text-2xl sm:text-3xl lg:text-4xl font-bold text-foreground -tracking-[0.5px]">
+                  <span className="font-heading text-2xl sm:text-3xl lg:text-4xl font-bold text-foreground -tracking-micro">
                     {stat.value}
                   </span>
                   <span className="text-xs sm:text-sm text-muted-foreground leading-snug max-w-32">
@@ -446,10 +446,10 @@ export default function Home() {
           <div className="relative flex flex-col items-center gap-10 sm:gap-14 pb-20 sm:pb-28 lg:pb-36">
             {/* Section header */}
             <div className="flex flex-col items-center gap-5 sm:gap-6 max-w-3xl text-center px-4">
-              <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+              <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
                 Marketplace
               </p>
-              <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-[0.5px] sm:-tracking-[1px]">
+              <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-micro sm:-tracking-small">
                 Install an agent in seconds.{" "}
                 <br className="hidden sm:block" />
                 Or build one and get paid.
@@ -508,7 +508,7 @@ export default function Home() {
                   </div>
 
                   {/* Description */}
-                  <p className="text-[13px] leading-relaxed text-muted-foreground line-clamp-2">
+                  <p className="text-sm-alt leading-relaxed text-muted-foreground line-clamp-2">
                     {agent.description}
                   </p>
 
@@ -565,10 +565,10 @@ export default function Home() {
           <div className="relative flex flex-col items-center gap-10 sm:gap-14 pb-20 sm:pb-28 lg:pb-36">
             {/* Section header */}
             <div className="flex flex-col items-center gap-5 sm:gap-6 max-w-3xl text-center px-4">
-              <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+              <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
                 The Agent Forger
               </p>
-              <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-[0.5px] sm:-tracking-[1px]">
+              <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-micro sm:-tracking-small">
                 From zero to a running agent{" "}
                 <br className="hidden sm:block" />
                 in under five minutes.
@@ -636,7 +636,7 @@ export default function Home() {
               <div className="p-6 sm:p-8 lg:p-10">
                 <div className="flex items-center gap-2 mb-8">
                   <span className="w-2 h-2 rounded-full bg-primary" />
-                  <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-foreground">
+                  <span className="font-mono text-mini font-medium uppercase tracking-medium text-foreground">
                     How it works
                   </span>
                 </div>
@@ -711,10 +711,10 @@ export default function Home() {
           <div className="relative flex flex-col items-center gap-10 sm:gap-14 pb-20 sm:pb-28 lg:pb-36">
             {/* Section header */}
             <div className="flex flex-col items-center gap-5 sm:gap-6 max-w-3xl text-center px-4">
-              <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+              <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
                 Platform
               </p>
-              <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-[0.5px] sm:-tracking-[1px]">
+              <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-micro sm:-tracking-small">
                 Everything your agents need{" "}
                 <br className="hidden sm:block" />
                 to run in production.
@@ -833,10 +833,10 @@ export default function Home() {
           <div className="relative flex flex-col items-center gap-10 sm:gap-14 pb-20 sm:pb-28 lg:pb-36">
             {/* Section header */}
             <div className="flex flex-col items-center gap-5 sm:gap-6 max-w-3xl text-center px-4">
-              <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
+              <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">
                 Pricing
               </p>
-              <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-[0.5px] sm:-tracking-[1px]">
+              <h2 className="font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-micro sm:-tracking-small">
                 Simple, transparent pricing.
               </h2>
               <p className="text-base sm:text-lg text-muted-foreground leading-relaxed max-w-2xl">
@@ -850,11 +850,11 @@ export default function Home() {
               {/* Free */}
               <div className="flex flex-col rounded-2xl border border-border bg-background p-8 gap-6">
                 <div className="flex flex-col gap-4">
-                  <span className="font-mono text-[11px] font-medium uppercase tracking-[1px] text-muted-foreground">
+                  <span className="font-mono text-mini font-medium uppercase tracking-small text-muted-foreground">
                     Free forever
                   </span>
                   <div className="flex items-baseline gap-1">
-                    <span className="font-heading text-[48px] font-bold text-foreground leading-none">
+                    <span className="font-heading text-5xl font-bold text-foreground leading-none">
                       $0
                     </span>
                   </div>
@@ -912,11 +912,11 @@ export default function Home() {
                   }}
                 />
                 <div className="flex flex-col gap-4 relative">
-                  <span className="font-mono text-[11px] font-medium uppercase tracking-[1px] text-primary">
+                  <span className="font-mono text-mini font-medium uppercase tracking-small text-primary">
                     Pro
                   </span>
                   <div className="flex items-baseline gap-1">
-                    <span className="font-heading text-[48px] font-bold text-foreground leading-none">
+                    <span className="font-heading text-5xl font-bold text-foreground leading-none">
                       $4.99
                     </span>
                     <span className="text-sm text-muted-foreground">
@@ -928,7 +928,7 @@ export default function Home() {
                   </p>
                 </div>
                 <div className="flex flex-col gap-2.5 relative">
-                  <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-muted-foreground mb-1">
+                  <span className="font-mono text-2xs font-medium uppercase tracking-small text-muted-foreground mb-1">
                     Everything in Free, plus
                   </span>
                   {[
@@ -1001,7 +1001,7 @@ export default function Home() {
                   "radial-gradient(ellipse at center bottom, black 20%, transparent 70%)",
               }}
             />
-            <h2 className="relative font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-[0.5px] sm:-tracking-[1px]">
+            <h2 className="relative font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-micro sm:-tracking-small">
               Stop subscribing.{" "}
               <br className="hidden sm:block" />
               Start building.

--- a/apps/web/app/(marketing)/pricing/page.tsx
+++ b/apps/web/app/(marketing)/pricing/page.tsx
@@ -16,8 +16,8 @@ export default function PricingPage() {
     <div className="w-full bg-background flex flex-col relative">
       {/* Hero */}
       <div className="flex flex-col items-center gap-4 pt-16 sm:pt-24 pb-12 px-4">
-        <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">Pricing</p>
-        <h1 className="font-heading text-[28px] sm:text-[40px] lg:text-[48px] font-bold text-foreground text-center leading-[1.15] -tracking-[0.5px]">
+        <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">Pricing</p>
+        <h1 className="font-heading text-[28px] sm:text-[40px] lg:text-5xl font-bold text-foreground text-center leading-[1.15] -tracking-micro">
           Simple, transparent pricing
         </h1>
         <p className="text-base sm:text-lg text-muted-foreground text-center max-w-lg">
@@ -31,9 +31,9 @@ export default function PricingPage() {
           {/* Free Plan */}
           <div className="flex flex-col rounded-2xl border border-border p-8 gap-8">
             <div className="flex flex-col gap-4">
-              <span className="font-mono text-[11px] font-medium uppercase tracking-[1px] text-muted-foreground">Free forever</span>
+              <span className="font-mono text-mini font-medium uppercase tracking-small text-muted-foreground">Free forever</span>
               <div className="flex items-baseline gap-1">
-                <span className="font-heading text-[48px] font-bold text-foreground leading-none">$0</span>
+                <span className="font-heading text-5xl font-bold text-foreground leading-none">$0</span>
               </div>
               <p className="text-sm text-muted-foreground">For exploring and prototyping</p>
               <Link href="/auth">
@@ -42,7 +42,7 @@ export default function PricingPage() {
             </div>
 
             <div className="flex flex-col gap-3">
-              <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-muted-foreground">What&apos;s included</span>
+              <span className="font-mono text-2xs font-medium uppercase tracking-small text-muted-foreground">What&apos;s included</span>
               <div className="flex flex-col gap-2.5">
                 <div className="flex items-center gap-2.5 text-sm"><Check /> 1 agent</div>
                 <div className="flex items-center gap-2.5 text-sm"><Check /> 100 runs/month</div>
@@ -67,9 +67,9 @@ export default function PricingPage() {
               }}
             />
             <div className="flex flex-col gap-4 relative">
-              <span className="font-mono text-[11px] font-medium uppercase tracking-[1px] text-primary">Pro</span>
+              <span className="font-mono text-mini font-medium uppercase tracking-small text-primary">Pro</span>
               <div className="flex items-baseline gap-1">
-                <span className="font-heading text-[48px] font-bold text-foreground leading-none">$4.99</span>
+                <span className="font-heading text-5xl font-bold text-foreground leading-none">$4.99</span>
                 <span className="text-sm text-muted-foreground">/mo per agent</span>
               </div>
               <p className="text-sm text-muted-foreground">For teams shipping agents to production</p>
@@ -79,7 +79,7 @@ export default function PricingPage() {
             </div>
 
             <div className="flex flex-col gap-3 relative">
-              <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-muted-foreground">Everything in Free, plus</span>
+              <span className="font-mono text-2xs font-medium uppercase tracking-small text-muted-foreground">Everything in Free, plus</span>
               <div className="flex flex-col gap-2.5">
                 <div className="flex items-center gap-2.5 text-sm"><Check /> Unlimited agents</div>
                 <div className="flex items-center gap-2.5 text-sm"><Check /> 300 runs/agent/month</div>
@@ -101,9 +101,9 @@ export default function PricingPage() {
         <div className="rounded-2xl border border-border p-8 sm:p-10 relative overflow-hidden">
           <div className="flex flex-col md:flex-row md:items-start gap-8 md:gap-12">
             <div className="flex flex-col gap-4 md:flex-1">
-              <span className="font-mono text-[11px] font-medium uppercase tracking-[1px] text-muted-foreground">Add-on for Pro agents</span>
+              <span className="font-mono text-mini font-medium uppercase tracking-small text-muted-foreground">Add-on for Pro agents</span>
               <div className="flex items-baseline gap-2">
-                <span className="font-heading text-[36px] sm:text-[48px] font-bold text-foreground leading-none">+$2</span>
+                <span className="font-heading text-[36px] sm:text-5xl font-bold text-foreground leading-none">+$2</span>
                 <span className="text-sm text-muted-foreground">/mo per agent</span>
               </div>
               <h3 className="font-heading text-lg font-semibold text-foreground">Dedicated sandbox</h3>
@@ -115,7 +115,7 @@ export default function PricingPage() {
               </Link>
             </div>
             <div className="flex flex-col gap-2.5 md:flex-1">
-              <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-muted-foreground mb-1">Everything in Pro, plus</span>
+              <span className="font-mono text-2xs font-medium uppercase tracking-small text-muted-foreground mb-1">Everything in Pro, plus</span>
               <div className="flex items-center gap-2.5 text-sm"><Check /> Isolated sandbox per run</div>
               <div className="flex items-center gap-2.5 text-sm"><Check /> Full shell & filesystem access</div>
               <div className="flex items-center gap-2.5 text-sm"><Check /> Git clone, build tools, linters</div>
@@ -133,7 +133,7 @@ export default function PricingPage() {
       <div className="max-w-5xl mx-auto w-full px-4 pb-20">
         <div className="flex flex-col gap-8">
           <div className="flex flex-col gap-2">
-            <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">Usage-based pricing</p>
+            <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">Usage-based pricing</p>
             <h2 className="font-heading text-xl sm:text-2xl font-bold text-foreground">Runs, overages, and what they cost</h2>
             <p className="text-sm text-muted-foreground max-w-2xl">
               A run is a single agent execution — a PR review, a support ticket response, a deploy check. Each plan includes runs. If you go over, you pay per extra run.
@@ -142,7 +142,7 @@ export default function PricingPage() {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="rounded-2xl border border-border p-6 flex flex-col gap-4">
-              <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-muted-foreground">Free</span>
+              <span className="font-mono text-2xs font-medium uppercase tracking-small text-muted-foreground">Free</span>
               <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-muted-foreground">Included runs</span>
@@ -167,7 +167,7 @@ export default function PricingPage() {
                   background: "radial-gradient(circle at 50% 0%, color-mix(in oklch, var(--primary) 6%, transparent) 0%, transparent 60%)",
                 }}
               />
-              <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-primary relative">Pro (shared sandbox)</span>
+              <span className="font-mono text-2xs font-medium uppercase tracking-small text-primary relative">Pro (shared sandbox)</span>
               <div className="flex flex-col gap-2 relative">
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-muted-foreground">Included runs</span>
@@ -186,7 +186,7 @@ export default function PricingPage() {
             </div>
 
             <div className="rounded-2xl border border-border p-6 flex flex-col gap-4">
-              <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-muted-foreground">Pro + Dedicated sandbox</span>
+              <span className="font-mono text-2xs font-medium uppercase tracking-small text-muted-foreground">Pro + Dedicated sandbox</span>
               <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-muted-foreground">Included runs</span>
@@ -211,7 +211,7 @@ export default function PricingPage() {
       <div className="max-w-5xl mx-auto w-full px-4 pb-20">
         <div className="flex flex-col gap-8">
           <div className="flex flex-col gap-2">
-            <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">Real-world examples</p>
+            <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">Real-world examples</p>
             <h2 className="font-heading text-xl sm:text-2xl font-bold text-foreground">What will you actually pay?</h2>
           </div>
 
@@ -248,7 +248,7 @@ export default function PricingPage() {
       {/* Feature comparison table */}
       <div className="max-w-5xl mx-auto w-full px-4 pb-24">
         <div className="flex flex-col gap-8">
-          <p className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">Compare plans</p>
+          <p className="font-mono text-mini font-medium uppercase tracking-medium text-primary">Compare plans</p>
 
           {/* Agents & Limits */}
           <div className="flex flex-col">

--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -104,7 +104,7 @@ export default function AuthPage() {
           </div>
 
           <div className="flex flex-col gap-3">
-            <h1 className="font-heading text-[28px] text-center font-bold text-foreground leading-tight -tracking-[0.5px]">
+            <h1 className="font-heading text-[28px] text-center font-bold text-foreground leading-tight -tracking-micro">
               Build, run and monitor <br />your agents
             </h1>
             <p className="text-base text-muted-foreground leading-relaxed text-center">

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -14,6 +14,22 @@
 
 @theme {
     --font-heading: var(--font-bricolage), "Bricolage Grotesque", system-ui, sans-serif;
+
+    /* Custom font-size utilities for sub-xs text used heavily in marketing and dashboard chrome */
+    /* `text-2xs` → 10px, `text-mini` → 11px, `text-sm-alt` → 13px */
+    --text-2xs: 0.625rem;
+    --text-2xs--line-height: 0.875rem;
+    --text-mini: 0.6875rem;
+    --text-mini--line-height: 1rem;
+    --text-sm-alt: 0.8125rem;
+    --text-sm-alt--line-height: 1.125rem;
+
+    /* Custom letter-spacing utilities for marketing typography */
+    /* `tracking-micro` → 0.5px, `tracking-small` → 1px, `tracking-medium` → 1.5px */
+    /* (works with negative too: `-tracking-micro`, etc.) */
+    --tracking-micro: 0.5px;
+    --tracking-small: 1px;
+    --tracking-medium: 1.5px;
 }
 
 @theme inline {

--- a/apps/web/app/invites/accept/page.tsx
+++ b/apps/web/app/invites/accept/page.tsx
@@ -181,7 +181,7 @@ function AcceptInviteContents() {
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">
           Sent to <span className="font-medium text-foreground">{inviteEmail}</span> — role{" "}
-          <Badge variant="secondary" className="text-[10px]">{invite.role}</Badge>
+          <Badge variant="secondary" className="text-2xs">{invite.role}</Badge>
         </p>
         <div className="mt-6 flex flex-col gap-2">
           <Link href={nextHref} className={buttonVariants({ className: "w-full" })}>
@@ -191,7 +191,7 @@ function AcceptInviteContents() {
             Create account
           </Link>
         </div>
-        <p className="mt-4 text-[11px] text-muted-foreground text-center">
+        <p className="mt-4 text-mini text-muted-foreground text-center">
           After signing in, come back to this link to accept the invitation.
         </p>
       </CenterCard>
@@ -231,7 +231,7 @@ function AcceptInviteContents() {
       </h1>
       <p className="mt-2 text-sm text-muted-foreground">
         {invite.inviter_name ?? "An admin"} invited you to {orgName} as{" "}
-        <Badge variant="secondary" className="text-[10px]">{invite.role}</Badge>
+        <Badge variant="secondary" className="text-2xs">{invite.role}</Badge>
       </p>
       <div className="mt-6 flex flex-col gap-2">
         <Button

--- a/apps/web/app/w/agents/[id]/_components/active-runs.tsx
+++ b/apps/web/app/w/agents/[id]/_components/active-runs.tsx
@@ -10,7 +10,7 @@ export function ActiveRuns({ runs, onSelectRun }: ActiveRunsProps) {
   if (runs.length === 0) {
     return (
       <div className="rounded-xl border border-border p-6">
-        <h2 className="font-mono text-[10px] font-medium uppercase tracking-[1.5px] text-muted-foreground mb-4">Active runs</h2>
+        <h2 className="font-mono text-2xs font-medium uppercase tracking-medium text-muted-foreground mb-4">Active runs</h2>
         <p className="text-sm text-muted-foreground">No active runs right now.</p>
       </div>
     )
@@ -18,7 +18,7 @@ export function ActiveRuns({ runs, onSelectRun }: ActiveRunsProps) {
 
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="font-mono text-[10px] font-medium uppercase tracking-[1.5px] text-muted-foreground">
+      <h2 className="font-mono text-2xs font-medium uppercase tracking-medium text-muted-foreground">
         Active runs ({runs.length})
       </h2>
       <div className="flex flex-col gap-2">

--- a/apps/web/app/w/agents/[id]/_components/conversation/timeline.tsx
+++ b/apps/web/app/w/agents/[id]/_components/conversation/timeline.tsx
@@ -33,12 +33,12 @@ function CollapsibleMarkdown({ content }: CollapsibleMarkdownProps) {
   const displayed = expanded || !isLong ? content : content.slice(0, LONG_CONTENT_THRESHOLD) + "\n\n…"
 
   return (
-    <div className="text-[13px] leading-[1.6] text-foreground [&_pre]:my-2 [&_pre]:rounded-lg [&_pre]:bg-muted/60 [&_pre]:p-3 [&_pre]:text-[11px] [&_pre]:overflow-x-auto [&_code]:font-mono [&_code]:text-[11px] [&_p]:my-2 [&_ul]:my-2 [&_ul]:ml-5 [&_ul]:list-disc [&_ol]:my-2 [&_ol]:ml-5 [&_ol]:list-decimal [&_table]:my-2 [&_table]:w-full [&_table]:border-collapse [&_th]:border [&_th]:border-border/40 [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_td]:border [&_td]:border-border/40 [&_td]:px-2 [&_td]:py-1 [&_h1]:my-2 [&_h1]:text-[15px] [&_h1]:font-semibold [&_h2]:my-2 [&_h2]:text-[14px] [&_h2]:font-semibold [&_h3]:my-2 [&_h3]:text-[13px] [&_h3]:font-semibold">
+    <div className="text-sm-alt leading-[1.6] text-foreground [&_pre]:my-2 [&_pre]:rounded-lg [&_pre]:bg-muted/60 [&_pre]:p-3 [&_pre]:text-mini [&_pre]:overflow-x-auto [&_code]:font-mono [&_code]:text-mini [&_p]:my-2 [&_ul]:my-2 [&_ul]:ml-5 [&_ul]:list-disc [&_ol]:my-2 [&_ol]:ml-5 [&_ol]:list-decimal [&_table]:my-2 [&_table]:w-full [&_table]:border-collapse [&_th]:border [&_th]:border-border/40 [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_td]:border [&_td]:border-border/40 [&_td]:px-2 [&_td]:py-1 [&_h1]:my-2 [&_h1]:text-[15px] [&_h1]:font-semibold [&_h2]:my-2 [&_h2]:text-sm [&_h2]:font-semibold [&_h3]:my-2 [&_h3]:text-sm-alt [&_h3]:font-semibold">
       <ReactMarkdown remarkPlugins={[remarkGfm]}>{displayed}</ReactMarkdown>
       {isLong && (
         <button
           onClick={() => setExpanded(!expanded)}
-          className="mt-2 text-[11px] font-medium text-primary hover:underline cursor-pointer"
+          className="mt-2 text-mini font-medium text-primary hover:underline cursor-pointer"
         >
           {expanded ? "Show less" : `Show all (${content.length.toLocaleString()} chars)`}
         </button>
@@ -57,10 +57,10 @@ function ConversationCreatedItem({ timestamp }: SystemMarkerProps) {
       <div className="h-px flex-1 bg-border/30" />
       <div className="flex items-center gap-2 rounded-full bg-muted/30 px-3 py-1">
         <HugeiconsIcon icon={SparklesIcon} size={10} className="text-muted-foreground/50" />
-        <span className="text-[10px] text-muted-foreground/60 font-mono uppercase tracking-wider">
+        <span className="text-2xs text-muted-foreground/60 font-mono uppercase tracking-wider">
           Conversation started
         </span>
-        <span className="text-[10px] text-muted-foreground/30 font-mono">{formatTimestamp(timestamp)}</span>
+        <span className="text-2xs text-muted-foreground/30 font-mono">{formatTimestamp(timestamp)}</span>
       </div>
       <div className="h-px flex-1 bg-border/30" />
     </div>
@@ -71,7 +71,7 @@ function DoneItem({ timestamp }: SystemMarkerProps) {
   return (
     <div className="flex items-center justify-center gap-2 py-3">
       <div className="h-px flex-1 bg-border/30" />
-      <span className="text-[10px] text-muted-foreground/40 font-mono uppercase tracking-wider">
+      <span className="text-2xs text-muted-foreground/40 font-mono uppercase tracking-wider">
         Ended · {formatTimestamp(timestamp)}
       </span>
       <div className="h-px flex-1 bg-border/30" />
@@ -114,10 +114,10 @@ function TriggerMessageCard({ content, timestamp, index }: TriggerMessageCardPro
             <HugeiconsIcon icon={SparklesIcon} size={11} className="text-primary" />
           </div>
           <div className="flex-1 min-w-0 flex items-center gap-2">
-            <span className="font-mono text-[11px] font-medium text-foreground/70 shrink-0">Trigger</span>
+            <span className="font-mono text-mini font-medium text-foreground/70 shrink-0">Trigger</span>
             {preview && (
               <span
-                className="font-mono text-[11px] text-muted-foreground/50 truncate min-w-0"
+                className="font-mono text-mini text-muted-foreground/50 truncate min-w-0"
                 title={preview}
               >
                 <span className="text-muted-foreground/30 mr-1">·</span>
@@ -125,10 +125,10 @@ function TriggerMessageCard({ content, timestamp, index }: TriggerMessageCardPro
               </span>
             )}
           </div>
-          <span className="font-mono text-[10px] px-1.5 py-0.5 rounded bg-muted/60 text-muted-foreground/70 shrink-0">
+          <span className="font-mono text-2xs px-1.5 py-0.5 rounded bg-muted/60 text-muted-foreground/70 shrink-0">
             {lineCount} lines
           </span>
-          <span className="font-mono text-[10px] text-muted-foreground/30 shrink-0">
+          <span className="font-mono text-2xs text-muted-foreground/30 shrink-0">
             {formatTimestamp(timestamp)}
           </span>
           <motion.div animate={{ rotate: expanded ? 180 : 0 }} transition={{ duration: 0.15 }}>
@@ -145,7 +145,7 @@ function TriggerMessageCard({ content, timestamp, index }: TriggerMessageCardPro
               className="overflow-hidden"
             >
               <div className="border-t border-border/30 px-4 py-3 max-h-[60vh] overflow-auto">
-                <div className="text-[13px] leading-[1.6] text-foreground [&_pre]:my-2 [&_pre]:rounded-lg [&_pre]:bg-muted/60 [&_pre]:p-3 [&_pre]:text-[11px] [&_pre]:overflow-x-auto [&_code]:font-mono [&_code]:text-[11px] [&_p]:my-2 [&_ul]:my-2 [&_ul]:ml-5 [&_ul]:list-disc [&_ol]:my-2 [&_ol]:ml-5 [&_ol]:list-decimal [&_table]:my-2 [&_table]:w-full [&_table]:border-collapse [&_th]:border [&_th]:border-border/40 [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_td]:border [&_td]:border-border/40 [&_td]:px-2 [&_td]:py-1 [&_h1]:my-2 [&_h1]:text-[15px] [&_h1]:font-semibold [&_h2]:my-2 [&_h2]:text-[14px] [&_h2]:font-semibold [&_h3]:my-2 [&_h3]:text-[13px] [&_h3]:font-semibold">
+                <div className="text-sm-alt leading-[1.6] text-foreground [&_pre]:my-2 [&_pre]:rounded-lg [&_pre]:bg-muted/60 [&_pre]:p-3 [&_pre]:text-mini [&_pre]:overflow-x-auto [&_code]:font-mono [&_code]:text-mini [&_p]:my-2 [&_ul]:my-2 [&_ul]:ml-5 [&_ul]:list-disc [&_ol]:my-2 [&_ol]:ml-5 [&_ol]:list-decimal [&_table]:my-2 [&_table]:w-full [&_table]:border-collapse [&_th]:border [&_th]:border-border/40 [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_td]:border [&_td]:border-border/40 [&_td]:px-2 [&_td]:py-1 [&_h1]:my-2 [&_h1]:text-[15px] [&_h1]:font-semibold [&_h2]:my-2 [&_h2]:text-sm [&_h2]:font-semibold [&_h3]:my-2 [&_h3]:text-sm-alt [&_h3]:font-semibold">
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
                 </div>
               </div>
@@ -188,9 +188,9 @@ function AgentResponseItem({
       </div>
       <div className="flex-1 min-w-0">
         <div className="flex items-baseline gap-2 mb-1.5">
-          <span className="text-[13px] font-semibold text-primary">Agent</span>
-          <span className="text-[10px] text-muted-foreground/30 font-mono">{formatTimestamp(timestamp)}</span>
-          {model && <span className="text-[10px] text-muted-foreground/25 font-mono">· {model}</span>}
+          <span className="text-sm-alt font-semibold text-primary">Agent</span>
+          <span className="text-2xs text-muted-foreground/30 font-mono">{formatTimestamp(timestamp)}</span>
+          {model && <span className="text-2xs text-muted-foreground/25 font-mono">· {model}</span>}
         </div>
         {status === "streaming" && !content ? (
           <div className="flex items-center gap-1.5 py-2">
@@ -204,7 +204,7 @@ function AgentResponseItem({
           </div>
         )}
         {status === "completed" && inputTokens != null && outputTokens != null && (
-          <div className="mt-2 flex items-center gap-3 text-[10px] text-muted-foreground/30 font-mono">
+          <div className="mt-2 flex items-center gap-3 text-2xs text-muted-foreground/30 font-mono">
             <span>↓ {formatTokens(inputTokens)}</span>
             <span>↑ {formatTokens(outputTokens)}</span>
           </div>
@@ -276,12 +276,12 @@ function ToolCallItem({
             />
           </div>
           <div className="flex-1 min-w-0 flex items-center gap-2">
-            <span className="font-mono text-[11px] font-medium text-foreground/70 shrink-0 truncate max-w-[55%]">
+            <span className="font-mono text-mini font-medium text-foreground/70 shrink-0 truncate max-w-[55%]">
               {toolName}
             </span>
             {subtitle && (
               <span
-                className="font-mono text-[11px] text-muted-foreground/50 truncate min-w-0"
+                className="font-mono text-mini text-muted-foreground/50 truncate min-w-0"
                 title={subtitleFull ?? subtitle}
               >
                 <span className="text-muted-foreground/30 mr-1">·</span>
@@ -294,7 +294,7 @@ function ToolCallItem({
               {meta.map((badge) => (
                 <span
                   key={badge}
-                  className="font-mono text-[10px] px-1.5 py-0.5 rounded bg-muted/60 text-muted-foreground/70"
+                  className="font-mono text-2xs px-1.5 py-0.5 rounded bg-muted/60 text-muted-foreground/70"
                 >
                   {badge}
                 </span>
@@ -309,7 +309,7 @@ function ToolCallItem({
             </div>
           ) : (
             durationMs != null && (
-              <span className="font-mono text-[10px] text-muted-foreground/30 shrink-0">
+              <span className="font-mono text-2xs text-muted-foreground/30 shrink-0">
                 {formatDuration(durationMs)}
               </span>
             )
@@ -333,7 +333,7 @@ function ToolCallItem({
                 {Object.keys(args).length > 0 && (
                   <div className="rounded-lg bg-muted/40 p-2.5">
                     {Object.entries(args).map(([key, value]) => (
-                      <div key={key} className="font-mono text-[10px] leading-relaxed">
+                      <div key={key} className="font-mono text-2xs leading-relaxed">
                         <span className="text-muted-foreground/50">{key}: </span>
                         <span className="text-foreground/70 whitespace-pre-wrap break-all">
                           {formatArg(value)}
@@ -344,7 +344,7 @@ function ToolCallItem({
                 )}
                 {result && (
                   <div className="rounded-lg bg-muted/40 p-2.5 max-h-80 overflow-auto">
-                    <pre className="font-mono text-[10px] text-foreground/70 whitespace-pre-wrap break-all leading-relaxed">
+                    <pre className="font-mono text-2xs text-foreground/70 whitespace-pre-wrap break-all leading-relaxed">
                       {result}
                     </pre>
                   </div>
@@ -368,7 +368,7 @@ interface TurnSummaryItemProps {
 function TurnSummaryItem({ turnNumber, model, inputTokens, outputTokens }: TurnSummaryItemProps) {
   return (
     <div className="flex items-center justify-center gap-2 py-1.5">
-      <div className="flex items-center gap-2 rounded-full bg-muted/20 px-3 py-1 text-[10px] font-mono text-muted-foreground/40">
+      <div className="flex items-center gap-2 rounded-full bg-muted/20 px-3 py-1 text-2xs font-mono text-muted-foreground/40">
         <HugeiconsIcon icon={FlashIcon} size={10} className="text-muted-foreground/40" />
         <span>turn {turnNumber}</span>
         <span>·</span>

--- a/apps/web/app/w/agents/[id]/_components/edit-agent-panel/index.tsx
+++ b/apps/web/app/w/agents/[id]/_components/edit-agent-panel/index.tsx
@@ -172,7 +172,7 @@ function EditAgentForm() {
           <div className="flex flex-col gap-2">
             {credentialsLoading ? (
               Array.from({ length: 2 }).map((_, i) => (
-                <Skeleton key={i} className="h-[60px] w-full rounded-xl" />
+                <Skeleton key={i} className="h-15 w-full rounded-xl" />
               ))
             ) : credentials.length === 0 ? (
               <p className="text-sm text-muted-foreground">No credentials yet.</p>
@@ -343,11 +343,11 @@ function EditAgentForm() {
                     <p className="text-sm font-medium text-foreground">{trigger.connectionName}</p>
                     <div className="flex flex-wrap gap-1 mt-1">
                       {trigger.triggerKeys.map((key) => (
-                        <Badge key={key} variant="secondary" className="text-[10px] font-mono">{key}</Badge>
+                        <Badge key={key} variant="secondary" className="text-2xs font-mono">{key}</Badge>
                       ))}
                     </div>
                     {trigger.conditions && trigger.conditions.conditions.length > 0 && (
-                      <p className="text-[11px] text-muted-foreground mt-1">
+                      <p className="text-mini text-muted-foreground mt-1">
                         {trigger.conditions.conditions.length} filter{trigger.conditions.conditions.length !== 1 ? "s" : ""}
                       </p>
                     )}

--- a/apps/web/app/w/agents/[id]/_components/edit-agent-panel/skills-section.tsx
+++ b/apps/web/app/w/agents/[id]/_components/edit-agent-panel/skills-section.tsx
@@ -26,7 +26,7 @@ export function SkillsSection({ skillIds, onToggle }: SkillsSectionProps) {
       <div className="flex flex-col gap-2">
         {isLoading ? (
           Array.from({ length: 3 }).map((_, index) => (
-            <Skeleton key={index} className="h-[52px] w-full rounded-xl" />
+            <Skeleton key={index} className="h-13 w-full rounded-xl" />
           ))
         ) : skills.length === 0 ? (
           <p className="text-sm text-muted-foreground">No skills available.</p>

--- a/apps/web/app/w/agents/[id]/_components/edit-agent-panel/tool-permissions.tsx
+++ b/apps/web/app/w/agents/[id]/_components/edit-agent-panel/tool-permissions.tsx
@@ -155,7 +155,7 @@ export function ToolPermissionsSection({ permissions, onChange }: ToolPermission
           const categoryTools = grouped.get(category)!
           return (
             <div key={category} className="flex flex-col gap-1.5">
-              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              <p className="text-mini font-medium uppercase tracking-wider text-muted-foreground">
                 {categoryLabels[category] ?? category}
               </p>
               <div className="flex flex-wrap gap-1.5">

--- a/apps/web/app/w/agents/[id]/_components/recent-runs.tsx
+++ b/apps/web/app/w/agents/[id]/_components/recent-runs.tsx
@@ -9,7 +9,7 @@ type RecentRunsProps = {
 export function RecentRuns({ runs, onSelectRun }: RecentRunsProps) {
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="font-mono text-[10px] font-medium uppercase tracking-[1.5px] text-muted-foreground">
+      <h2 className="font-mono text-2xs font-medium uppercase tracking-medium text-muted-foreground">
         Recent runs
       </h2>
       <div className="flex flex-col gap-2">

--- a/apps/web/app/w/agents/[id]/_components/run-card.tsx
+++ b/apps/web/app/w/agents/[id]/_components/run-card.tsx
@@ -23,11 +23,11 @@ export function RunCard({ run, onClick }: RunCardProps) {
     >
       <span className={`h-2 w-2 rounded-full shrink-0 ${displayStatus.color} ${displayStatus.pulse ? "animate-pulse" : ""}`} />
       <span className="text-sm font-medium text-foreground truncate flex-1 min-w-0">{run.subject}</span>
-      <span className={`font-mono text-[11px] uppercase tracking-[0.5px] shrink-0 ${isWaiting ? "text-yellow-500" : "text-muted-foreground"}`}>
+      <span className={`font-mono text-mini uppercase tracking-micro shrink-0 ${isWaiting ? "text-yellow-500" : "text-muted-foreground"}`}>
         {displayStatus.label}
       </span>
-      <span className="font-mono text-[11px] text-muted-foreground shrink-0">{run.duration}</span>
-      <span className="font-mono text-[11px] text-muted-foreground shrink-0 tabular-nums">${run.cost.toFixed(2)}</span>
+      <span className="font-mono text-mini text-muted-foreground shrink-0">{run.duration}</span>
+      <span className="font-mono text-mini text-muted-foreground shrink-0 tabular-nums">${run.cost.toFixed(2)}</span>
     </button>
   )
 }

--- a/apps/web/app/w/agents/[id]/_components/run-panel.tsx
+++ b/apps/web/app/w/agents/[id]/_components/run-panel.tsx
@@ -35,7 +35,7 @@ function formatTokens(count: number) {
 function UserMessage({ message }: { message: StreamMessage }) {
   return (
     <div className="rounded-xl bg-primary/10 p-4 ml-8">
-      <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-foreground/60">You</span>
+      <span className="font-mono text-2xs font-medium uppercase tracking-small text-foreground/60">You</span>
       <p className="text-sm text-foreground mt-1.5 leading-relaxed">{message.content}</p>
     </div>
   )
@@ -44,7 +44,7 @@ function UserMessage({ message }: { message: StreamMessage }) {
 function AgentMessage({ message, isStreaming }: { message: StreamMessage; isStreaming: boolean }) {
   return (
     <div className="rounded-xl border border-border p-4">
-      <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-primary">Agent</span>
+      <span className="font-mono text-2xs font-medium uppercase tracking-small text-primary">Agent</span>
       <div className="mt-1.5 text-sm text-foreground leading-relaxed prose prose-sm prose-neutral dark:prose-invert max-w-none prose-p:my-1.5 prose-headings:mt-4 prose-headings:mb-2 prose-li:my-0.5 prose-pre:my-2 prose-ul:my-1.5 prose-ol:my-1.5">
         {message.content ? (
           <Streamdown isAnimating={isStreaming}>{message.content}</Streamdown>
@@ -63,7 +63,7 @@ function AgentMessage({ message, isStreaming }: { message: StreamMessage; isStre
 function ErrorMessage({ message }: { message: StreamMessage }) {
   return (
     <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4">
-      <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-destructive">Error</span>
+      <span className="font-mono text-2xs font-medium uppercase tracking-small text-destructive">Error</span>
       <p className="text-sm text-destructive mt-1.5">{message.content}</p>
     </div>
   )
@@ -141,9 +141,9 @@ function ToolCallEvent({ event }: { event: RunEvent }) {
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {isRunning ? (
-            <span className="font-mono text-[11px] text-primary">Running...</span>
+            <span className="font-mono text-mini text-primary">Running...</span>
           ) : event.toolResult ? (
-            <span className="font-mono text-[11px] text-muted-foreground">{event.toolResult.duration}</span>
+            <span className="font-mono text-mini text-muted-foreground">{event.toolResult.duration}</span>
           ) : null}
           <HugeiconsIcon
             icon={ArrowDown01Icon}
@@ -161,11 +161,11 @@ function ToolCallEvent({ event }: { event: RunEvent }) {
           <div className="border-t border-border px-4 py-3 flex flex-col gap-3">
             {event.toolParams && Object.keys(event.toolParams).length > 0 && (
               <div>
-                <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-muted-foreground">Arguments</span>
+                <span className="font-mono text-2xs font-medium uppercase tracking-small text-muted-foreground">Arguments</span>
                 <div className="mt-1.5 rounded-lg bg-muted p-3">
                   <div className="flex flex-col gap-1">
                     {Object.entries(event.toolParams).map(([key, value]) => (
-                      <div key={key} className="flex gap-2 font-mono text-[11px]">
+                      <div key={key} className="flex gap-2 font-mono text-mini">
                         <span className="text-muted-foreground shrink-0">{key}:</span>
                         <span className="text-foreground break-all">{value}</span>
                       </div>
@@ -177,9 +177,9 @@ function ToolCallEvent({ event }: { event: RunEvent }) {
 
             {parsedResponse && (
               <div>
-                <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-muted-foreground">Response</span>
+                <span className="font-mono text-2xs font-medium uppercase tracking-small text-muted-foreground">Response</span>
                 <div className="mt-1.5 rounded-lg bg-muted p-3 overflow-x-auto">
-                  <pre className="font-mono text-[11px] text-foreground whitespace-pre-wrap break-all leading-relaxed">
+                  <pre className="font-mono text-mini text-foreground whitespace-pre-wrap break-all leading-relaxed">
                     {parsedResponse}
                   </pre>
                 </div>
@@ -193,12 +193,12 @@ function ToolCallEvent({ event }: { event: RunEvent }) {
                   <span className="h-1 w-1 rounded-full bg-primary animate-[bounce_1s_ease-in-out_0.15s_infinite]" />
                   <span className="h-1 w-1 rounded-full bg-primary animate-[bounce_1s_ease-in-out_0.3s_infinite]" />
                 </div>
-                <span className="font-mono text-[11px] text-muted-foreground">Waiting for response...</span>
+                <span className="font-mono text-mini text-muted-foreground">Waiting for response...</span>
               </div>
             )}
 
             {!isRunning && (
-              <div className="flex items-center gap-4 text-[11px] text-muted-foreground font-mono">
+              <div className="flex items-center gap-4 text-mini text-muted-foreground font-mono">
                 <span>Status: <span className={isSuccess ? "text-green-500" : "text-destructive"}>{status}</span></span>
                 <span>Duration: {event.toolResult?.duration}</span>
                 <span>Time: {event.timestamp}</span>
@@ -223,7 +223,7 @@ function ApprovalEvent({ event }: { event: RunEvent }) {
       >
         <span className={`h-2 w-2 rounded-full shrink-0 ${isPending ? "bg-yellow-500 animate-pulse" : "bg-muted-foreground"}`} />
         <span className="font-mono text-xs font-medium text-foreground flex-1 min-w-0 truncate">{event.toolName}</span>
-        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.5px] text-yellow-500 shrink-0">
+        <span className="font-mono text-2xs font-medium uppercase tracking-micro text-yellow-500 shrink-0">
           {isPending ? "Approval needed" : event.approvalStatus}
         </span>
         <HugeiconsIcon
@@ -241,11 +241,11 @@ function ApprovalEvent({ event }: { event: RunEvent }) {
           <div className={`border-t px-4 py-3 flex flex-col gap-3 ${isPending ? "border-yellow-500/20" : "border-border"}`}>
             {event.toolParams && Object.keys(event.toolParams).length > 0 && (
               <div>
-                <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-muted-foreground">Arguments</span>
+                <span className="font-mono text-2xs font-medium uppercase tracking-small text-muted-foreground">Arguments</span>
                 <div className="mt-1.5 rounded-lg bg-muted p-3">
                   <div className="flex flex-col gap-1.5">
                     {Object.entries(event.toolParams).map(([key, value]) => (
-                      <div key={key} className="flex flex-col gap-0.5 font-mono text-[11px]">
+                      <div key={key} className="flex flex-col gap-0.5 font-mono text-mini">
                         <span className="text-muted-foreground">{key}</span>
                         <span className="text-foreground break-all whitespace-pre-wrap">{value}</span>
                       </div>
@@ -375,7 +375,7 @@ export function RunPanel({ conversationId, onClose }: RunPanelProps) {
 
           {error && !messages.length && (
             <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4">
-              <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-destructive">Connection error</span>
+              <span className="font-mono text-2xs font-medium uppercase tracking-small text-destructive">Connection error</span>
               <p className="text-sm text-destructive mt-1.5">{error}</p>
             </div>
           )}
@@ -420,7 +420,7 @@ export function RunPanel({ conversationId, onClose }: RunPanelProps) {
               </span>
             </span>
             {tokenStats.model && (
-              <span className="font-mono text-[10px] text-muted-foreground/50 truncate max-w-48">
+              <span className="font-mono text-2xs text-muted-foreground/50 truncate max-w-48">
                 {tokenStats.model}
               </span>
             )}

--- a/apps/web/app/w/agents/[id]/_components/runs-empty.tsx
+++ b/apps/web/app/w/agents/[id]/_components/runs-empty.tsx
@@ -31,7 +31,7 @@ export function RunsEmpty({ onStartRun, startingRun, onEditAgent }: RunsEmptyPro
             <p className="text-sm font-semibold text-foreground">
               {startingRun ? "Starting run..." : "Start a run"}
             </p>
-            <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">
+            <p className="text-sm-alt text-muted-foreground mt-0.5 leading-relaxed">
               Create a new conversation and watch your agent work in real time.
             </p>
           </div>
@@ -50,7 +50,7 @@ export function RunsEmpty({ onStartRun, startingRun, onEditAgent }: RunsEmptyPro
           <HugeiconsIcon icon={PencilEdit02Icon} size={20} className="shrink-0 mt-0.5 text-muted-foreground" />
           <div className="flex-1 min-w-0">
             <p className="text-sm font-semibold text-foreground">Edit agent</p>
-            <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">
+            <p className="text-sm-alt text-muted-foreground mt-0.5 leading-relaxed">
               Tweak the system prompt, model, or integrations before running.
             </p>
           </div>

--- a/apps/web/app/w/agents/[id]/conversations/[conversationId]/page.tsx
+++ b/apps/web/app/w/agents/[id]/conversations/[conversationId]/page.tsx
@@ -34,10 +34,10 @@ function BrowserPanel() {
         </div>
         <div className="flex-1 flex items-center rounded-xl bg-background border border-border px-3 py-1.5">
           <HugeiconsIcon icon={LinkSquare02Icon} size={11} className="text-muted-foreground/40 mr-2" />
-          <span className="text-[11px] text-muted-foreground/40 font-mono truncate">No active browser session</span>
+          <span className="text-mini text-muted-foreground/40 font-mono truncate">No active browser session</span>
         </div>
       </div>
-      <div className="flex-1 overflow-y-auto p-4 flex items-center justify-center text-[12px] text-muted-foreground/40">
+      <div className="flex-1 overflow-y-auto p-4 flex items-center justify-center text-xs text-muted-foreground/40">
         Browser panel is not wired up yet
       </div>
     </div>
@@ -49,10 +49,10 @@ function TerminalPanel() {
     <div className="flex flex-col h-full">
       <div className="flex items-center gap-2 px-3 py-2 bg-muted/20 border-b border-border shrink-0">
         <HugeiconsIcon icon={CommandLineIcon} size={12} className="text-muted-foreground" />
-        <span className="text-[11px] font-mono text-muted-foreground">Terminal</span>
+        <span className="text-mini font-mono text-muted-foreground">Terminal</span>
       </div>
       <div className="flex-1 overflow-y-auto bg-foreground p-4 flex items-center justify-center">
-        <span className="font-mono text-[11px] text-background/40">No active terminal session</span>
+        <span className="font-mono text-mini text-background/40">No active terminal session</span>
       </div>
     </div>
   )
@@ -60,7 +60,7 @@ function TerminalPanel() {
 
 function EmptyTimeline() {
   return (
-    <div className="flex items-center justify-center py-20 text-[13px] text-muted-foreground/40">
+    <div className="flex items-center justify-center py-20 text-sm-alt text-muted-foreground/40">
       No events yet. The agent will stream events here as it works.
     </div>
   )
@@ -189,7 +189,7 @@ export default function ConversationPage() {
           {isLoading ? (
             <TimelineSkeleton />
           ) : error ? (
-            <div className="py-10 text-center text-[13px] text-destructive/70">
+            <div className="py-10 text-center text-sm-alt text-destructive/70">
               Failed to load conversation events.
             </div>
           ) : timeline.length === 0 ? (
@@ -198,7 +198,7 @@ export default function ConversationPage() {
             <>
               <ConversationTimeline items={timeline} />
               {hasMore && (
-                <div className="mt-6 text-center text-[11px] text-muted-foreground/40 font-mono">
+                <div className="mt-6 text-center text-mini text-muted-foreground/40 font-mono">
                   More events available — pagination not yet wired.
                 </div>
               )}
@@ -216,7 +216,7 @@ export default function ConversationPage() {
             <Textarea
               placeholder="Composer is not wired up yet"
               disabled
-              className="border-0 bg-transparent min-h-[60px] max-h-32 focus-visible:ring-0 focus-visible:border-transparent text-[14px]"
+              className="border-0 bg-transparent min-h-15 max-h-32 focus-visible:ring-0 focus-visible:border-transparent text-sm"
             />
             <div className="flex items-center justify-between px-2 pt-1">
               <span className="font-mono text-[9px] text-muted-foreground/20">

--- a/apps/web/app/w/agents/[id]/conversations/layout.tsx
+++ b/apps/web/app/w/agents/[id]/conversations/layout.tsx
@@ -40,8 +40,8 @@ function ConversationItem({ conversation, isActive, onClick, index }: {
           conversation.status === "active" ? "bg-green-500" : conversation.status === "error" ? "bg-destructive" : "bg-muted-foreground/15"
         }`} />
         <span className="flex-1 min-w-0">
-          <span className="text-[13px] font-medium truncate block leading-tight">{conversation.title}</span>
-          <span className="text-[11px] text-muted-foreground/40 font-mono mt-0.5 block">{conversation.date}</span>
+          <span className="text-sm-alt font-medium truncate block leading-tight">{conversation.title}</span>
+          <span className="text-mini text-muted-foreground/40 font-mono mt-0.5 block">{conversation.date}</span>
         </span>
       </span>
     </motion.button>
@@ -80,15 +80,15 @@ export default function ConversationsLayout({ children }: { children: React.Reac
 
   return (
     <div className="flex h-[calc(100vh-54px)] overflow-hidden bg-background">
-      <aside className="flex flex-col w-[300px] shrink-0 border-r border-border bg-sidebar h-full">
+      <aside className="flex flex-col w-75 shrink-0 border-r border-border bg-sidebar h-full">
         <div className="flex items-center justify-between px-4 py-3.5 border-b border-border">
           <div className="flex items-center gap-2.5">
             <div className="h-7 w-7 rounded-xl bg-primary/15 flex items-center justify-center">
               <HugeiconsIcon icon={Robot01Icon} size={14} className="text-primary" />
             </div>
             <div>
-              <h2 className="text-[13px] font-semibold text-foreground leading-tight">{agent?.name ?? "Agent"}</h2>
-              <span className="text-[10px] text-muted-foreground/40 font-mono">{agent?.model ?? ""}</span>
+              <h2 className="text-sm-alt font-semibold text-foreground leading-tight">{agent?.name ?? "Agent"}</h2>
+              <span className="text-2xs text-muted-foreground/40 font-mono">{agent?.model ?? ""}</span>
             </div>
           </div>
           <button className="h-7 w-7 rounded-lg hover:bg-primary/8 flex items-center justify-center transition-colors">
@@ -99,7 +99,7 @@ export default function ConversationsLayout({ children }: { children: React.Reac
         <div className="px-3 py-2">
           <div className="flex items-center gap-2 rounded-xl bg-muted/30 px-3 py-2 cursor-text hover:bg-muted/50 transition-colors">
             <HugeiconsIcon icon={Search01Icon} size={13} className="text-muted-foreground/30" />
-            <span className="text-[12px] text-muted-foreground/30">Search conversations...</span>
+            <span className="text-xs text-muted-foreground/30">Search conversations...</span>
           </div>
         </div>
 
@@ -107,7 +107,7 @@ export default function ConversationsLayout({ children }: { children: React.Reac
           {Object.entries(grouped).map(([group, items]) => (
             <div key={group} className="mb-3">
               <div className="flex items-center gap-2 px-3 py-1.5">
-                <span className="text-[10px] font-semibold uppercase tracking-[1.5px] text-muted-foreground/25">{group}</span>
+                <span className="text-2xs font-semibold uppercase tracking-medium text-muted-foreground/25">{group}</span>
                 <div className="flex-1 h-px bg-border/40" />
               </div>
               {items.map((conv) => {
@@ -135,7 +135,7 @@ export default function ConversationsLayout({ children }: { children: React.Reac
             </div>
           ))}
           {conversations.length === 0 && (
-            <div className="flex items-center justify-center py-10 text-[12px] text-muted-foreground/40">
+            <div className="flex items-center justify-center py-10 text-xs text-muted-foreground/40">
               No conversations yet
             </div>
           )}

--- a/apps/web/app/w/agents/[id]/conversations/page.tsx
+++ b/apps/web/app/w/agents/[id]/conversations/page.tsx
@@ -8,7 +8,7 @@ export default function ConversationsIndexPage() {
         <div className="h-12 w-12 rounded-2xl bg-muted/30 flex items-center justify-center">
           <HugeiconsIcon icon={Robot01Icon} size={24} className="text-muted-foreground/30" />
         </div>
-        <p className="text-[13px]">Select a conversation to view</p>
+        <p className="text-sm-alt">Select a conversation to view</p>
       </div>
     </div>
   )

--- a/apps/web/app/w/agents/_components/agents-empty.tsx
+++ b/apps/web/app/w/agents/_components/agents-empty.tsx
@@ -29,7 +29,7 @@ export function AgentsEmpty({ onCreateFromScratch, onCreateFromMarketplace }: Ag
           <HugeiconsIcon icon={PencilEdit02Icon} size={20} className="shrink-0 mt-0.5 text-muted-foreground" />
           <div className="flex-1 min-w-0">
             <p className="text-sm font-semibold text-foreground">Create from scratch</p>
-            <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">
+            <p className="text-sm-alt text-muted-foreground mt-0.5 leading-relaxed">
               Write your own system prompt and configure every detail manually.
             </p>
           </div>
@@ -44,7 +44,7 @@ export function AgentsEmpty({ onCreateFromScratch, onCreateFromMarketplace }: Ag
           <HugeiconsIcon icon={Store01Icon} size={20} className="shrink-0 mt-0.5 text-muted-foreground" />
           <div className="flex-1 min-w-0">
             <p className="text-sm font-semibold text-foreground">Install from marketplace</p>
-            <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">
+            <p className="text-sm-alt text-muted-foreground mt-0.5 leading-relaxed">
               Browse community-built agents and install one in seconds.
             </p>
           </div>

--- a/apps/web/app/w/agents/_components/agents-table.tsx
+++ b/apps/web/app/w/agents/_components/agents-table.tsx
@@ -96,7 +96,7 @@ export function AgentsTable({ agents, onEditAgent }: AgentsTableProps) {
   return (
     <>
       <div className="flex flex-col gap-2">
-        <div className="hidden md:flex items-center gap-3 px-4 py-1 text-[10px] font-mono uppercase tracking-[1px] text-muted-foreground/50">
+        <div className="hidden md:flex items-center gap-3 px-4 py-1 text-2xs font-mono uppercase tracking-small text-muted-foreground/50">
           <span className="flex-1 min-w-0">Name</span>
           <span className="w-20 shrink-0">Integrations</span>
           <span className="w-28 shrink-0 text-right">Model</span>
@@ -119,13 +119,13 @@ export function AgentsTable({ agents, onEditAgent }: AgentsTableProps) {
               <div className="w-20 shrink-0">
                 <IntegrationLogos integrations={getIntegrationSummaries(agent.integrations, connectionsById)} size={20} />
               </div>
-              <span className="w-28 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums truncate">
+              <span className="w-28 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums truncate">
                 {agent.model}
               </span>
-              <span className="w-20 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+              <span className="w-20 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                 {agent.sandbox_type}
               </span>
-              <span className="w-24 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+              <span className="w-24 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                 {agent.created_at ? formatDate(agent.created_at) : "\u2014"}
               </span>
               <div className="w-6 shrink-0 flex justify-center">

--- a/apps/web/app/w/agents/_components/configure-resources-dialog.tsx
+++ b/apps/web/app/w/agents/_components/configure-resources-dialog.tsx
@@ -260,12 +260,12 @@ function ResourceInstanceListView({ connectionId, resourceType, selectedItems, i
             <p className="text-xs font-medium text-amber-800 dark:text-amber-200">
               {orphans.length} {label}{orphans.length !== 1 ? "s" : ""} no longer accessible
             </p>
-            <p className="text-[11px] text-amber-800/80 dark:text-amber-200/80 mt-0.5">
+            <p className="text-mini text-amber-800/80 dark:text-amber-200/80 mt-0.5">
               These will be removed from this agent when you save.
             </p>
             <ul className="mt-2 space-y-0.5">
               {orphans.map((item) => (
-                <li key={item.id} className="font-mono text-[11px] text-amber-900 dark:text-amber-100">
+                <li key={item.id} className="font-mono text-mini text-amber-900 dark:text-amber-100">
                   {item.id}
                 </li>
               ))}

--- a/apps/web/app/w/agents/_components/create-agent/add-llm-key-dialog.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/add-llm-key-dialog.tsx
@@ -254,7 +254,7 @@ export function AddLlmKeyDialog({ open, onOpenChange, onCreated }: AddLlmKeyDial
                 {isLoading ? (
                   <div className="flex flex-col gap-2">
                     {Array.from({ length: 6 }).map((_, index) => (
-                      <Skeleton key={index} className="h-[52px] w-full rounded-xl" />
+                      <Skeleton key={index} className="h-13 w-full rounded-xl" />
                     ))}
                   </div>
                 ) : filtered.length === 0 ? (

--- a/apps/web/app/w/agents/_components/create-agent/choice-card.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/choice-card.tsx
@@ -25,7 +25,7 @@ export function ChoiceCard({ icon, iconClassName, logoUrl, title, description, o
       ) : null}
       <div className="flex-1 min-w-0">
         <p className="text-sm font-semibold text-foreground">{title}</p>
-        <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">{description}</p>
+        <p className="text-sm-alt text-muted-foreground mt-0.5 leading-relaxed">{description}</p>
       </div>
       {trailing ?? (
         <HugeiconsIcon

--- a/apps/web/app/w/agents/_components/create-agent/provider-prompt-editor.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/provider-prompt-editor.tsx
@@ -182,7 +182,7 @@ export function ProviderPromptEditor({ value, onChange, className }: ProviderPro
         </div>
 
         {filledCount > 0 && (
-          <p className="text-[11px] text-muted-foreground shrink-0">
+          <p className="text-mini text-muted-foreground shrink-0">
             {filledCount}/{PROMPT_PROVIDERS.length}
           </p>
         )}

--- a/apps/web/app/w/agents/_components/create-agent/skill-card.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/skill-card.tsx
@@ -38,14 +38,14 @@ export function SkillCard({ skill, selected, onToggle }: SkillCardProps) {
             <HugeiconsIcon icon={StarIcon} size={12} className="text-amber-500 shrink-0" />
           )}
         </div>
-        <p className="text-[13px] text-muted-foreground mt-0.5 line-clamp-2">{skill.description}</p>
+        <p className="text-sm-alt text-muted-foreground mt-0.5 line-clamp-2">{skill.description}</p>
 
         <div className="flex items-center gap-1.5 mt-2 flex-wrap">
           <ScopeBadge scope={skill.scope} />
           {skill.tags.slice(0, 3).map((tag) => (
             <span
               key={tag}
-              className="text-[10px] font-medium text-muted-foreground bg-background/60 border border-border/60 rounded-full px-1.5 py-0.5"
+              className="text-2xs font-medium text-muted-foreground bg-background/60 border border-border/60 rounded-full px-1.5 py-0.5"
             >
               {tag}
             </span>
@@ -57,7 +57,7 @@ export function SkillCard({ skill, selected, onToggle }: SkillCardProps) {
         {selected ? (
           <HugeiconsIcon icon={CheckmarkCircle02Icon} size={18} className="text-primary" />
         ) : (
-          <div className="size-[18px] rounded-full border border-muted-foreground/30 group-hover:border-muted-foreground/50 transition-colors" />
+          <div className="size-4.5 rounded-full border border-muted-foreground/30 group-hover:border-muted-foreground/50 transition-colors" />
         )}
       </div>
     </button>
@@ -71,13 +71,13 @@ interface ScopeBadgeProps {
 function ScopeBadge({ scope }: ScopeBadgeProps) {
   if (scope === "public") {
     return (
-      <span className="text-[10px] font-medium uppercase tracking-wide text-emerald-600 bg-emerald-500/10 rounded-full px-1.5 py-0.5">
+      <span className="text-2xs font-medium uppercase tracking-wide text-emerald-600 bg-emerald-500/10 rounded-full px-1.5 py-0.5">
         Public
       </span>
     )
   }
   return (
-    <span className="text-[10px] font-medium uppercase tracking-wide text-blue-600 bg-blue-500/10 rounded-full px-1.5 py-0.5">
+    <span className="text-2xs font-medium uppercase tracking-wide text-blue-600 bg-blue-500/10 rounded-full px-1.5 py-0.5">
       Your org
     </span>
   )

--- a/apps/web/app/w/agents/_components/create-agent/step-integrations.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/step-integrations.tsx
@@ -131,7 +131,7 @@ export function StepIntegrations() {
             <div className="flex flex-col gap-2 mt-4 flex-1 overflow-y-auto">
               {isLoading ? (
                 Array.from({ length: 4 }).map((_, index) => (
-                  <Skeleton key={index} className="h-[64px] w-full rounded-xl" />
+                  <Skeleton key={index} className="h-16 w-full rounded-xl" />
                 ))
               ) : filtered.length === 0 ? (
                 <div className="flex flex-col items-center justify-center py-12 gap-3">
@@ -167,7 +167,7 @@ export function StepIntegrations() {
                       <IntegrationLogo provider={connection.provider ?? ""} size={32} className="shrink-0 mt-0.5" />
                       <div className="flex-1 min-w-0">
                         <p className="text-sm font-semibold text-foreground">{connection.display_name}</p>
-                        <p className="text-[13px] text-muted-foreground mt-0.5">
+                        <p className="text-sm-alt text-muted-foreground mt-0.5">
                           {actionCount > 0
                             ? `${actionCount} of ${connection.actions_count ?? 0} actions selected`
                             : `${connection.actions_count ?? 0} actions available`}
@@ -299,7 +299,7 @@ function ActionDetailView({
         {isLoading ? (
           <div className="flex flex-col pt-[52px]">
             {Array.from({ length: 6 }).map((_, index) => (
-              <Skeleton key={index} className="h-[60px] w-full rounded-xl mb-2" />
+              <Skeleton key={index} className="h-15 w-full rounded-xl mb-2" />
             ))}
           </div>
         ) : filteredActions.length === 0 ? (
@@ -332,13 +332,13 @@ function ActionDetailView({
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 min-w-0">
                         <span className="text-sm font-medium text-foreground truncate">{action.display_name}</span>
-                        <span className={`font-mono text-[9px] uppercase tracking-[0.5px] px-1.5 py-0.5 rounded-full shrink-0 ${
+                        <span className={`font-mono text-[9px] uppercase tracking-micro px-1.5 py-0.5 rounded-full shrink-0 ${
                           action.access === "read" ? "bg-blue-500/10 text-blue-500" : "bg-green-500/10 text-green-500"
                         }`}>
                           {action.access}
                         </span>
                       </div>
-                      <p className="text-[12px] text-muted-foreground mt-0.5 line-clamp-1">{action.description}</p>
+                      <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{action.description}</p>
                     </div>
                     {isSelected && (
                       <HugeiconsIcon icon={Tick02Icon} size={16} className="text-primary shrink-0 mt-0.5" />

--- a/apps/web/app/w/agents/_components/create-agent/step-marketplace.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/step-marketplace.tsx
@@ -75,13 +75,13 @@ export function StepMarketplaceBrowse() {
               </div>
               <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2 leading-relaxed">{agent.description}</p>
               <div className="flex items-center gap-3 mt-2">
-                <span className="flex items-center gap-1.5 text-[10px] text-muted-foreground/40">
+                <span className="flex items-center gap-1.5 text-2xs text-muted-foreground/40">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img src={agent.publisher.avatar} alt="" className="h-3.5 w-3.5 rounded-full" />
                   {agent.publisher.name}
                 </span>
-                <span className="text-[10px] text-muted-foreground/30">·</span>
-                <span className="font-mono text-[10px] text-muted-foreground/40">
+                <span className="text-2xs text-muted-foreground/30">·</span>
+                <span className="font-mono text-2xs text-muted-foreground/40">
                   {formatInstalls(agent.installs)} installs
                 </span>
                 <span className="flex items-center -space-x-1.5 ml-auto">
@@ -162,7 +162,7 @@ export function StepMarketplaceDetail() {
         </div>
 
         <div className="flex flex-col gap-2">
-          <span className="font-mono text-[10px] text-muted-foreground/60 uppercase tracking-[1px]">Required integrations</span>
+          <span className="font-mono text-2xs text-muted-foreground/60 uppercase tracking-small">Required integrations</span>
           <div className="flex flex-wrap gap-2">
             {agent.integrations.map((name) => {
               const connected = connectedIntegrations.has(name)

--- a/apps/web/app/w/agents/_components/create-agent/step-skills.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/step-skills.tsx
@@ -184,7 +184,7 @@ export function StepSkills() {
       <div className="flex flex-col gap-2 mt-3 flex-1 overflow-y-auto pr-1">
         {isLoading ? (
           Array.from({ length: 5 }).map((_, index) => (
-            <Skeleton key={index} className="h-[88px] w-full rounded-xl" />
+            <Skeleton key={index} className="h-22 w-full rounded-xl" />
           ))
         ) : skills.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12 gap-3">
@@ -211,7 +211,7 @@ export function StepSkills() {
             {hasNextPage && (
               <div ref={loadMoreRef} className="py-4 flex items-center justify-center">
                 {isFetchingNextPage ? (
-                  <Skeleton className="h-[88px] w-full rounded-xl" />
+                  <Skeleton className="h-22 w-full rounded-xl" />
                 ) : (
                   <span className="text-xs text-muted-foreground">Load more</span>
                 )}

--- a/apps/web/app/w/agents/_components/create-agent/step-subagents.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/step-subagents.tsx
@@ -149,7 +149,7 @@ export function StepSubagents() {
       <div className="flex flex-col gap-2 mt-3 flex-1 overflow-y-auto pr-1">
         {isLoading ? (
           Array.from({ length: 5 }).map((_, index) => (
-            <Skeleton key={index} className="h-[88px] w-full rounded-xl" />
+            <Skeleton key={index} className="h-22 w-full rounded-xl" />
           ))
         ) : subagents.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12 gap-3">
@@ -176,7 +176,7 @@ export function StepSubagents() {
             {hasNextPage && (
               <div ref={loadMoreRef} className="py-4 flex items-center justify-center">
                 {isFetchingNextPage ? (
-                  <Skeleton className="h-[88px] w-full rounded-xl" />
+                  <Skeleton className="h-22 w-full rounded-xl" />
                 ) : (
                   <span className="text-xs text-muted-foreground">Load more</span>
                 )}

--- a/apps/web/app/w/agents/_components/create-agent/step-summary.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/step-summary.tsx
@@ -126,7 +126,7 @@ export function StepSummary() {
                     />
                   </div>
                   <span className="text-sm font-medium text-foreground truncate">{skill.name}</span>
-                  <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground ml-auto">
+                  <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground ml-auto">
                     {skill.scope === "public" ? "Public" : "Your org"}
                   </span>
                 </div>

--- a/apps/web/app/w/agents/_components/create-agent/step-trigger/choice-view.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/step-trigger/choice-view.tsx
@@ -48,11 +48,11 @@ export function ChoiceView({ onAddTrigger, onContinue, onBack }: ChoiceViewProps
                     <p className="text-sm font-semibold text-foreground">{trigger.connectionName}</p>
                     <div className="flex flex-wrap gap-1 mt-1.5">
                       {trigger.triggerDisplayNames.map((displayName) => (
-                        <Badge key={displayName} variant="secondary" className="text-[10px]">{displayName}</Badge>
+                        <Badge key={displayName} variant="secondary" className="text-2xs">{displayName}</Badge>
                       ))}
                     </div>
                     {trigger.conditions && trigger.conditions.conditions.length > 0 && (
-                      <p className="text-[11px] text-muted-foreground mt-1.5">
+                      <p className="text-mini text-muted-foreground mt-1.5">
                         {trigger.conditions.conditions.length} filter{trigger.conditions.conditions.length !== 1 ? "s" : ""} ({trigger.conditions.mode})
                       </p>
                     )}
@@ -77,7 +77,7 @@ export function ChoiceView({ onAddTrigger, onContinue, onBack }: ChoiceViewProps
               </div>
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-semibold text-foreground">Add a trigger</p>
-                <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">
+                <p className="text-sm-alt text-muted-foreground mt-0.5 leading-relaxed">
                   Start this agent automatically when a webhook event fires — like a new issue, PR, or deployment.
                 </p>
               </div>

--- a/apps/web/app/w/agents/_components/create-agent/step-trigger/condition-builder.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/step-trigger/condition-builder.tsx
@@ -113,7 +113,7 @@ export function ConditionBuilderView({ triggerDisplayNames, refs, initialConditi
       <div className="flex flex-col gap-3 mt-4 flex-1 overflow-y-auto">
         {/* Event context */}
         <div className="rounded-xl bg-muted/50 p-3">
-          <p className="text-[12px] text-muted-foreground">
+          <p className="text-xs text-muted-foreground">
             {triggerDisplayNames.join(", ")}
           </p>
         </div>
@@ -129,7 +129,7 @@ export function ConditionBuilderView({ triggerDisplayNames, refs, initialConditi
           >
             <div>
               <Label className="text-sm">Match all conditions</Label>
-              <p className="text-[11px] text-muted-foreground mt-0.5">
+              <p className="text-mini text-muted-foreground mt-0.5">
                 {matchAll ? "All conditions must pass (AND)" : "Any condition can pass (OR)"}
               </p>
             </div>
@@ -149,7 +149,7 @@ export function ConditionBuilderView({ triggerDisplayNames, refs, initialConditi
             >
               <div className="rounded-xl bg-muted/50 border border-transparent p-4">
                 <div className="flex items-start justify-between mb-3">
-                  <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                  <span className="text-mini font-medium uppercase tracking-wider text-muted-foreground">
                     Condition {index + 1}
                   </span>
                   <button
@@ -164,13 +164,13 @@ export function ConditionBuilderView({ triggerDisplayNames, refs, initialConditi
                 <div className="flex flex-col gap-2.5">
                   {/* Field */}
                   <div className="flex flex-col gap-1.5">
-                    <Label className="text-[11px] text-muted-foreground">Field</Label>
+                    <Label className="text-mini text-muted-foreground">Field</Label>
                     {customPathIndex === index ? (
                       <Input
                         placeholder="payload.path"
                         value={condition.path}
                         onChange={(event) => updateCondition(index, "path", event.target.value)}
-                        className="font-mono text-[12px]"
+                        className="font-mono text-xs"
                         autoFocus
                       />
                     ) : (
@@ -181,7 +181,7 @@ export function ConditionBuilderView({ triggerDisplayNames, refs, initialConditi
                         <SelectContent>
                           {pathOptions.map((option) => (
                             <SelectItem key={option.path} value={option.path}>
-                              <span className="font-mono text-[11px]">{option.label}</span>
+                              <span className="font-mono text-mini">{option.label}</span>
                             </SelectItem>
                           ))}
                           <SelectItem value="__custom__">
@@ -194,7 +194,7 @@ export function ConditionBuilderView({ triggerDisplayNames, refs, initialConditi
 
                   {/* Operator */}
                   <div className="flex flex-col gap-1.5">
-                    <Label className="text-[11px] text-muted-foreground">Operator</Label>
+                    <Label className="text-mini text-muted-foreground">Operator</Label>
                     <Select value={condition.operator} onValueChange={(value) => updateCondition(index, "operator", value ?? "equals")}>
                       <SelectTrigger className="w-full">
                         <SelectValue />
@@ -216,12 +216,12 @@ export function ConditionBuilderView({ triggerDisplayNames, refs, initialConditi
                       transition={{ duration: 0.12 }}
                       className="flex flex-col gap-1.5"
                     >
-                      <Label className="text-[11px] text-muted-foreground">Value</Label>
+                      <Label className="text-mini text-muted-foreground">Value</Label>
                       <Input
                         placeholder="value"
                         value={typeof condition.value === "string" ? condition.value : String(condition.value ?? "")}
                         onChange={(event) => updateCondition(index, "value", event.target.value)}
-                        className="font-mono text-[12px]"
+                        className="font-mono text-xs"
                       />
                     </motion.div>
                   )}

--- a/apps/web/app/w/agents/_components/create-agent/step-trigger/connection-picker.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/step-trigger/connection-picker.tsx
@@ -60,7 +60,7 @@ export function ConnectionPickerView({ search, onSearchChange, onPickConnection,
 
       <div className="flex flex-col gap-2 mt-4 flex-1 overflow-y-auto">
         {isLoading ? (
-          Array.from({ length: 4 }).map((_, index) => <Skeleton key={index} className="h-[64px] w-full rounded-xl" />)
+          Array.from({ length: 4 }).map((_, index) => <Skeleton key={index} className="h-16 w-full rounded-xl" />)
         ) : filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12 gap-3">
             <p className="text-sm text-muted-foreground">No connections found.</p>
@@ -76,7 +76,7 @@ export function ConnectionPickerView({ search, onSearchChange, onPickConnection,
               <IntegrationLogo provider={connection.provider ?? ""} size={32} className="shrink-0 mt-0.5" />
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-semibold text-foreground">{connection.display_name}</p>
-                <p className="text-[13px] text-muted-foreground mt-0.5">{connection.provider}</p>
+                <p className="text-sm-alt text-muted-foreground mt-0.5">{connection.provider}</p>
               </div>
               <HugeiconsIcon icon={ArrowRight01Icon} size={16} className="text-muted-foreground/30 shrink-0 mt-0.5" />
             </button>

--- a/apps/web/app/w/agents/_components/create-agent/step-trigger/trigger-picker.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/step-trigger/trigger-picker.tsx
@@ -118,7 +118,7 @@ export function TriggerPickerView({ provider, connectionName, search, onSearchCh
         ) : (
           Object.entries(grouped).map(([resourceType, resourceTriggers]) => (
             <div key={resourceType} className="mb-3">
-              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground px-1 mb-1.5">{resourceType}</p>
+              <p className="text-mini font-medium uppercase tracking-wider text-muted-foreground px-1 mb-1.5">{resourceType}</p>
               <div className="flex flex-col gap-1">
                 {resourceTriggers.map((trigger) => {
                   const triggerKey = trigger.key ?? ""
@@ -139,9 +139,9 @@ export function TriggerPickerView({ provider, connectionName, search, onSearchCh
                       </div>
                       <div className="flex-1 min-w-0">
                         <p className="text-sm font-medium text-foreground">{trigger.display_name}</p>
-                        <p className="text-[12px] text-muted-foreground mt-0.5 line-clamp-1">{trigger.description}</p>
+                        <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{trigger.description}</p>
                         {hasFilters && (
-                          <Badge variant="secondary" className="text-[10px] mt-1.5">
+                          <Badge variant="secondary" className="text-2xs mt-1.5">
                             {selectedEvent.conditions!.conditions.length} filter{selectedEvent.conditions!.conditions.length !== 1 ? "s" : ""}
                           </Badge>
                         )}

--- a/apps/web/app/w/agents/_components/create-agent/subagent-card.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/subagent-card.tsx
@@ -31,12 +31,12 @@ export function SubagentCard({ subagent, selected, onToggle }: SubagentCardProps
 
       <div className="flex-1 min-w-0">
         <p className="text-sm font-semibold text-foreground truncate">{subagent.name}</p>
-        <p className="text-[13px] text-muted-foreground mt-0.5 line-clamp-2">{subagent.description}</p>
+        <p className="text-sm-alt text-muted-foreground mt-0.5 line-clamp-2">{subagent.description}</p>
 
         <div className="flex items-center gap-1.5 mt-2 flex-wrap">
           <ScopeBadge scope={subagent.scope} />
           {subagent.model && (
-            <span className="text-[10px] font-medium text-muted-foreground bg-background/60 border border-border/60 rounded-full px-1.5 py-0.5">
+            <span className="text-2xs font-medium text-muted-foreground bg-background/60 border border-border/60 rounded-full px-1.5 py-0.5">
               {subagent.model}
             </span>
           )}
@@ -47,7 +47,7 @@ export function SubagentCard({ subagent, selected, onToggle }: SubagentCardProps
         {selected ? (
           <HugeiconsIcon icon={CheckmarkCircle02Icon} size={18} className="text-primary" />
         ) : (
-          <div className="size-[18px] rounded-full border border-muted-foreground/30 group-hover:border-muted-foreground/50 transition-colors" />
+          <div className="size-4.5 rounded-full border border-muted-foreground/30 group-hover:border-muted-foreground/50 transition-colors" />
         )}
       </div>
     </button>
@@ -57,13 +57,13 @@ export function SubagentCard({ subagent, selected, onToggle }: SubagentCardProps
 function ScopeBadge({ scope }: { scope: SubagentPreview["scope"] }) {
   if (scope === "public") {
     return (
-      <span className="text-[10px] font-medium uppercase tracking-wide text-emerald-600 bg-emerald-500/10 rounded-full px-1.5 py-0.5">
+      <span className="text-2xs font-medium uppercase tracking-wide text-emerald-600 bg-emerald-500/10 rounded-full px-1.5 py-0.5">
         Public
       </span>
     )
   }
   return (
-    <span className="text-[10px] font-medium uppercase tracking-wide text-blue-600 bg-blue-500/10 rounded-full px-1.5 py-0.5">
+    <span className="text-2xs font-medium uppercase tracking-wide text-blue-600 bg-blue-500/10 rounded-full px-1.5 py-0.5">
       Your org
     </span>
   )

--- a/apps/web/app/w/agents/_components/edit-triggers-dialog.tsx
+++ b/apps/web/app/w/agents/_components/edit-triggers-dialog.tsx
@@ -385,14 +385,14 @@ function TriggerListView({ triggers, onAdd, onEdit, onRemove, onDone }: TriggerL
                     <Badge
                       key={`${displayName}-${keyIndex}`}
                       variant="secondary"
-                      className="text-[10px] font-mono"
+                      className="text-2xs font-mono"
                     >
                       {displayName}
                     </Badge>
                   ))}
                 </div>
                 {trigger.conditions && trigger.conditions.conditions.length > 0 && (
-                  <p className="text-[11px] text-muted-foreground mt-1">
+                  <p className="text-mini text-muted-foreground mt-1">
                     {trigger.conditions.conditions.length} filter
                     {trigger.conditions.conditions.length !== 1 ? "s" : ""} ({trigger.conditions.mode})
                   </p>

--- a/apps/web/app/w/agents/_components/env-vars-dialog.tsx
+++ b/apps/web/app/w/agents/_components/env-vars-dialog.tsx
@@ -90,7 +90,7 @@ export function EnvVarsDialog({ open, onOpenChange, agentName }: EnvVarsDialogPr
               className="min-h-32 font-mono text-xs"
               autoFocus
             />
-            <p className="text-[11px] text-muted-foreground">
+            <p className="text-mini text-muted-foreground">
               Paste KEY=VALUE pairs, one per line. Lines starting with # are ignored.
             </p>
             <div className="flex gap-2 justify-end">
@@ -104,7 +104,7 @@ export function EnvVarsDialog({ open, onOpenChange, agentName }: EnvVarsDialogPr
           </div>
         ) : (
           <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-2 px-1 text-[10px] font-mono uppercase tracking-[1px] text-muted-foreground/50">
+            <div className="flex items-center gap-2 px-1 text-2xs font-mono uppercase tracking-small text-muted-foreground/50">
               <span className="flex-1">Key</span>
               <span className="flex-1">Value</span>
               <span className="w-8 shrink-0" />

--- a/apps/web/app/w/agents/_components/manage-integrations-dialog.tsx
+++ b/apps/web/app/w/agents/_components/manage-integrations-dialog.tsx
@@ -211,7 +211,7 @@ export function ManageIntegrationsDialog({
               <div className="flex flex-col gap-2 mt-4 flex-1 overflow-y-auto">
                 {isLoading ? (
                   Array.from({ length: 4 }).map((_, i) => (
-                    <Skeleton key={i} className="h-[64px] w-full rounded-xl" />
+                    <Skeleton key={i} className="h-16 w-full rounded-xl" />
                   ))
                 ) : filtered.length === 0 ? (
                   <div className="flex flex-col items-center justify-center py-12 gap-3">
@@ -266,7 +266,7 @@ export function ManageIntegrationsDialog({
                           <p className="text-sm font-semibold text-foreground">
                             {connection.display_name}
                           </p>
-                          <p className="text-[13px] text-muted-foreground mt-0.5">
+                          <p className="text-sm-alt text-muted-foreground mt-0.5">
                             {actionCount > 0
                               ? `${actionCount} of ${connection.actions_count ?? 0} actions selected`
                               : `${connection.actions_count ?? 0} actions available`}
@@ -433,7 +433,7 @@ function ActionDetailView({
         {isLoading ? (
           <div className="flex flex-col pt-[52px]">
             {Array.from({ length: 6 }).map((_, i) => (
-              <Skeleton key={i} className="h-[60px] w-full rounded-xl mb-2" />
+              <Skeleton key={i} className="h-15 w-full rounded-xl mb-2" />
             ))}
           </div>
         ) : filteredActions.length === 0 ? (
@@ -477,7 +477,7 @@ function ActionDetailView({
                           {action.display_name}
                         </span>
                         <span
-                          className={`font-mono text-[9px] uppercase tracking-[0.5px] px-1.5 py-0.5 rounded-full shrink-0 ${
+                          className={`font-mono text-[9px] uppercase tracking-micro px-1.5 py-0.5 rounded-full shrink-0 ${
                             action.access === "read"
                               ? "bg-blue-500/10 text-blue-500"
                               : "bg-green-500/10 text-green-500"
@@ -486,7 +486,7 @@ function ActionDetailView({
                           {action.access}
                         </span>
                       </div>
-                      <p className="text-[12px] text-muted-foreground mt-0.5 line-clamp-1">
+                      <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
                         {action.description}
                       </p>
                     </div>

--- a/apps/web/app/w/agents/_components/setup-commands-dialog.tsx
+++ b/apps/web/app/w/agents/_components/setup-commands-dialog.tsx
@@ -49,7 +49,7 @@ export function SetupCommandsDialog({ open, onOpenChange, agentName }: SetupComm
           {commands.map((command, index) => (
             <div key={index} className="flex items-center gap-2">
               <div className="flex items-center gap-2 flex-1">
-                <span className="text-[10px] font-mono text-muted-foreground/50 w-5 text-right shrink-0">
+                <span className="text-2xs font-mono text-muted-foreground/50 w-5 text-right shrink-0">
                   {index + 1}.
                 </span>
                 <Input

--- a/apps/web/app/w/connections/_components/connections-table.tsx
+++ b/apps/web/app/w/connections/_components/connections-table.tsx
@@ -105,7 +105,7 @@ export function ConnectionsTable({ connections }: ConnectionsTableProps) {
   return (
     <>
       <div className="flex flex-col gap-2">
-        <div className="hidden md:flex items-center gap-3 px-4 py-1 text-[10px] font-mono uppercase tracking-[1px] text-muted-foreground/50">
+        <div className="hidden md:flex items-center gap-3 px-4 py-1 text-2xs font-mono uppercase tracking-small text-muted-foreground/50">
           <span className="flex-1 min-w-0">Provider</span>
           <span className="w-20 shrink-0 text-right">Agents</span>
           <span className="w-24 shrink-0 text-right">Connected</span>
@@ -122,10 +122,10 @@ export function ConnectionsTable({ connections }: ConnectionsTableProps) {
                   {connection.display_name}
                 </span>
               </div>
-              <span className="w-20 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+              <span className="w-20 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                 0
               </span>
-              <span className="w-24 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+              <span className="w-24 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                 {connection.created_at ? formatDate(connection.created_at) : "—"}
               </span>
               <div className="w-6 shrink-0 flex justify-center">
@@ -304,9 +304,9 @@ function WebhookConfigDialog({ connection, open, onOpenChange, loading, onConfir
 
         <div className="flex flex-col gap-4 mt-4">
           <div className="rounded-xl bg-muted/50 border border-border p-4">
-            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-2">Webhook URL</p>
+            <p className="text-mini font-medium uppercase tracking-wider text-muted-foreground mb-2">Webhook URL</p>
             <div className="flex items-center gap-2">
-              <code className="flex-1 text-[12px] font-mono bg-background rounded-lg px-3 py-2 border border-border break-all select-all">
+              <code className="flex-1 text-xs font-mono bg-background rounded-lg px-3 py-2 border border-border break-all select-all">
                 {webhookUrl}
               </code>
               <Button variant="outline" size="sm" onClick={handleCopy} className="shrink-0 h-8">
@@ -323,8 +323,8 @@ function WebhookConfigDialog({ connection, open, onOpenChange, loading, onConfir
           </div>
 
           <div className="rounded-xl bg-muted/50 border border-border p-4">
-            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-2">Setup instructions</p>
-            <ol className="list-decimal list-inside text-[13px] text-muted-foreground leading-relaxed space-y-1">
+            <p className="text-mini font-medium uppercase tracking-wider text-muted-foreground mb-2">Setup instructions</p>
+            <ol className="list-decimal list-inside text-sm-alt text-muted-foreground leading-relaxed space-y-1">
               <li>Open your {connection.display_name} project dashboard</li>
               <li>Go to <strong>Settings</strong> &rarr; <strong>Webhooks</strong></li>
               <li>Paste the webhook URL shown above</li>

--- a/apps/web/app/w/layout.tsx
+++ b/apps/web/app/w/layout.tsx
@@ -94,7 +94,7 @@ function WorkspaceHeader() {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={8} className="min-w-60">
           <DropdownMenuGroup>
-            <DropdownMenuLabel className="font-mono text-[10px] uppercase tracking-[1.5px]">Workspaces</DropdownMenuLabel>
+            <DropdownMenuLabel className="font-mono text-2xs uppercase tracking-medium">Workspaces</DropdownMenuLabel>
             <DropdownMenuSeparator />
             {orgs.map((org) => (
               <DropdownMenuItem key={org.id} onClick={() => setActiveOrg(org)}>

--- a/apps/web/app/w/settings/_components/api-keys-settings.tsx
+++ b/apps/web/app/w/settings/_components/api-keys-settings.tsx
@@ -60,16 +60,16 @@ const API_KEY_SCOPES = [
 ] as const
 
 function ScopeBadge({ scopes }: { scopes?: string[] }) {
-  if (!scopes || scopes.length === 0) return <span className="text-[11px] text-muted-foreground">{"\u2014"}</span>
+  if (!scopes || scopes.length === 0) return <span className="text-mini text-muted-foreground">{"\u2014"}</span>
 
   if (scopes.length === 1 && scopes[0] === "all") {
-    return <Badge variant="secondary" className="text-[10px]">all</Badge>
+    return <Badge variant="secondary" className="text-2xs">all</Badge>
   }
 
   return (
     <Tooltip>
       <TooltipTrigger className="cursor-default">
-        <Badge variant="secondary" className="text-[10px]">{scopes.length} scopes</Badge>
+        <Badge variant="secondary" className="text-2xs">{scopes.length} scopes</Badge>
       </TooltipTrigger>
       <TooltipContent>
         {scopes.join(", ")}
@@ -297,7 +297,7 @@ export function ApiKeysSettings() {
                 <HugeiconsIcon icon={Key01Icon} size={20} className="shrink-0 mt-0.5 text-muted-foreground" />
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-semibold text-foreground">Create API key</p>
-                  <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">
+                  <p className="text-sm-alt text-muted-foreground mt-0.5 leading-relaxed">
                     Generate a key to authenticate requests to the Hiveloop API.
                   </p>
                 </div>
@@ -307,7 +307,7 @@ export function ApiKeysSettings() {
           </div>
         ) : (
           <>
-            <div className="hidden md:flex items-center gap-3 px-4 py-1 text-[10px] font-mono uppercase tracking-[1px] text-muted-foreground/50">
+            <div className="hidden md:flex items-center gap-3 px-4 py-1 text-2xs font-mono uppercase tracking-small text-muted-foreground/50">
               <span className="flex-1 min-w-0">Name</span>
               <span className="w-32 shrink-0">Key</span>
               <span className="w-20 shrink-0">Scopes</span>
@@ -322,13 +322,13 @@ export function ApiKeysSettings() {
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-foreground truncate">{apiKey.name}</p>
                   </div>
-                  <span className="w-32 shrink-0 text-[11px] text-muted-foreground font-mono tabular-nums truncate">
+                  <span className="w-32 shrink-0 text-mini text-muted-foreground font-mono tabular-nums truncate">
                     {apiKey.key_prefix ? `${apiKey.key_prefix}...` : "\u2014"}
                   </span>
                   <div className="w-20 shrink-0">
                     <ScopeBadge scopes={apiKey.scopes} />
                   </div>
-                  <span className="w-28 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+                  <span className="w-28 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                     {apiKey.created_at ? formatDate(apiKey.created_at) : "\u2014"}
                   </span>
                   <div className="w-8 shrink-0 flex justify-center">

--- a/apps/web/app/w/settings/_components/llm-keys-settings.tsx
+++ b/apps/web/app/w/settings/_components/llm-keys-settings.tsx
@@ -112,7 +112,7 @@ export function LlmKeysSettings() {
       <div className="flex flex-col gap-2">
         {isLoading ? (
           Array.from({ length: 3 }).map((_, index) => (
-            <Skeleton key={index} className="h-[52px] w-full rounded-xl" />
+            <Skeleton key={index} className="h-13 w-full rounded-xl" />
           ))
         ) : credentials.length === 0 ? (
           <div className="flex flex-col items-center py-14">
@@ -131,7 +131,7 @@ export function LlmKeysSettings() {
                 <HugeiconsIcon icon={ArtificialIntelligence01Icon} size={20} className="shrink-0 mt-0.5 text-muted-foreground" />
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-semibold text-foreground">Add LLM key</p>
-                  <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">
+                  <p className="text-sm-alt text-muted-foreground mt-0.5 leading-relaxed">
                     Connect a provider like OpenAI or Anthropic to power your agents.
                   </p>
                 </div>
@@ -141,7 +141,7 @@ export function LlmKeysSettings() {
           </div>
         ) : (
           <>
-            <div className="hidden md:flex items-center gap-3 px-4 py-1 text-[10px] font-mono uppercase tracking-[1px] text-muted-foreground/50">
+            <div className="hidden md:flex items-center gap-3 px-4 py-1 text-2xs font-mono uppercase tracking-small text-muted-foreground/50">
               <span className="flex-1 min-w-0">Label</span>
               <span className="w-24 shrink-0 text-right">Requests</span>
               <span className="w-28 shrink-0 text-right">Last used</span>
@@ -160,13 +160,13 @@ export function LlmKeysSettings() {
                       <p className="text-xs text-muted-foreground">{credential.provider_id}</p>
                     </div>
                   </div>
-                  <span className="w-24 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+                  <span className="w-24 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                     {credential.request_count ?? 0}
                   </span>
-                  <span className="w-28 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+                  <span className="w-28 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                     {credential.last_used_at ? formatDate(credential.last_used_at) : "\u2014"}
                   </span>
-                  <span className="w-28 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+                  <span className="w-28 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                     {credential.created_at ? formatDate(credential.created_at) : "\u2014"}
                   </span>
                   <div className="w-8 shrink-0 flex justify-center">

--- a/apps/web/app/w/settings/_components/members-settings.tsx
+++ b/apps/web/app/w/settings/_components/members-settings.tsx
@@ -190,7 +190,7 @@ export function MembersSettings() {
           <p className="text-sm text-muted-foreground">No pending invitations.</p>
         ) : (
           <div className="flex flex-col gap-2">
-            <div className="hidden md:flex items-center gap-3 px-4 py-1 text-[10px] font-mono uppercase tracking-[1px] text-muted-foreground/50">
+            <div className="hidden md:flex items-center gap-3 px-4 py-1 text-2xs font-mono uppercase tracking-small text-muted-foreground/50">
               <span className="flex-1 min-w-0">Email</span>
               <span className="w-20 shrink-0">Role</span>
               <span className="w-40 shrink-0">Invited by</span>
@@ -204,12 +204,12 @@ export function MembersSettings() {
                     <p className="text-sm font-medium text-foreground truncate">{invite.email}</p>
                   </div>
                   <div className="w-20 shrink-0">
-                    <Badge variant="secondary" className="text-[10px]">{invite.role}</Badge>
+                    <Badge variant="secondary" className="text-2xs">{invite.role}</Badge>
                   </div>
-                  <span className="w-40 shrink-0 text-[11px] text-muted-foreground truncate">
+                  <span className="w-40 shrink-0 text-mini text-muted-foreground truncate">
                     {invite.invited_by_name || invite.invited_by_email || "\u2014"}
                   </span>
-                  <span className="w-28 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+                  <span className="w-28 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                     {formatDate(invite.created_at)}
                   </span>
                   <div className="w-8 shrink-0 flex justify-center">
@@ -252,7 +252,7 @@ export function MembersSettings() {
                         {invite.invited_by_name || invite.invited_by_email || "\u2014"}
                       </p>
                     </div>
-                    <Badge variant="secondary" className="text-[10px]">{invite.role}</Badge>
+                    <Badge variant="secondary" className="text-2xs">{invite.role}</Badge>
                   </div>
                   <div className="flex items-center gap-2">
                     <Button
@@ -306,7 +306,7 @@ export function MembersSettings() {
                   </p>
                   <p className="text-xs text-muted-foreground truncate">{member.email}</p>
                 </div>
-                <Badge variant="secondary" className="text-[10px]">{member.role}</Badge>
+                <Badge variant="secondary" className="text-2xs">{member.role}</Badge>
               </div>
             ))}
             <p className="text-sm text-muted-foreground">
@@ -315,7 +315,7 @@ export function MembersSettings() {
           </div>
         ) : (
           <div className="flex flex-col gap-2">
-            <div className="hidden md:flex items-center gap-3 px-4 py-1 text-[10px] font-mono uppercase tracking-[1px] text-muted-foreground/50">
+            <div className="hidden md:flex items-center gap-3 px-4 py-1 text-2xs font-mono uppercase tracking-small text-muted-foreground/50">
               <span className="flex-1 min-w-0">Name</span>
               <span className="w-56 shrink-0">Email</span>
               <span className="w-20 shrink-0">Role</span>
@@ -331,13 +331,13 @@ export function MembersSettings() {
                     {member.name || member.email}
                   </p>
                 </div>
-                <span className="w-56 shrink-0 text-[11px] text-muted-foreground truncate md:block">
+                <span className="w-56 shrink-0 text-mini text-muted-foreground truncate md:block">
                   {member.email}
                 </span>
                 <div className="w-20 shrink-0">
-                  <Badge variant="secondary" className="text-[10px]">{member.role}</Badge>
+                  <Badge variant="secondary" className="text-2xs">{member.role}</Badge>
                 </div>
-                <span className="w-28 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+                <span className="w-28 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                   {formatDate(member.joined_at)}
                 </span>
               </div>

--- a/apps/web/app/w/settings/_components/sandbox-templates/sandbox-templates-list.tsx
+++ b/apps/web/app/w/settings/_components/sandbox-templates/sandbox-templates-list.tsx
@@ -144,7 +144,7 @@ export function SandboxTemplatesList() {
               <HugeiconsIcon icon={ContainerIcon} size={20} className="shrink-0 mt-0.5 text-muted-foreground" />
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-semibold text-foreground">Create template</p>
-                <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">
+                <p className="text-sm-alt text-muted-foreground mt-0.5 leading-relaxed">
                   Define a custom environment with build commands and dependencies.
                 </p>
               </div>
@@ -169,13 +169,13 @@ export function SandboxTemplatesList() {
                       <span className="text-sm font-medium truncate">{template.name}</span>
                       {getStatusBadge(template.build_status)}
                       {isPublic && (
-                        <Badge variant="secondary" className="text-[10px] px-1.5 py-0">Public</Badge>
+                        <Badge variant="secondary" className="text-2xs px-1.5 py-0">Public</Badge>
                       )}
                     </div>
                     {tags.length > 0 && (
                       <div className="flex items-center gap-1 mt-0.5">
                         {tags.map((tag) => (
-                          <span key={tag} className="text-[11px] text-muted-foreground">
+                          <span key={tag} className="text-mini text-muted-foreground">
                             {tag}
                           </span>
                         ))}

--- a/apps/web/app/w/settings/_components/skill-detail-dialog.tsx
+++ b/apps/web/app/w/settings/_components/skill-detail-dialog.tsx
@@ -314,7 +314,7 @@ export function SkillDetailDialog({ skill, open, onOpenChange }: SkillDetailDial
                 <div className="min-w-0">
                   <p className="text-xs font-medium text-foreground truncate">{skill?.name}</p>
                   {skill?.description && (
-                    <p className="text-[11px] text-muted-foreground truncate">{skill.description}</p>
+                    <p className="text-mini text-muted-foreground truncate">{skill.description}</p>
                   )}
                 </div>
               </div>
@@ -343,7 +343,7 @@ export function SkillDetailDialog({ skill, open, onOpenChange }: SkillDetailDial
                     <Button
                       variant="ghost"
                       className={cn(
-                        "px-2.5 rounded-full text-[11px]",
+                        "px-2.5 rounded-full text-mini",
                         viewMode === "rendered" && "bg-background shadow-sm"
                       )}
                       onClick={() => setViewMode("rendered")}
@@ -354,7 +354,7 @@ export function SkillDetailDialog({ skill, open, onOpenChange }: SkillDetailDial
                     <Button
                       variant="ghost"
                       className={cn(
-                        "px-2.5 rounded-full text-[11px]",
+                        "px-2.5 rounded-full text-mini",
                         viewMode === "raw" && "bg-background shadow-sm"
                       )}
                       onClick={() => setViewMode("raw")}

--- a/apps/web/app/w/settings/_components/skills-settings.tsx
+++ b/apps/web/app/w/settings/_components/skills-settings.tsx
@@ -58,7 +58,7 @@ function SkillHydrationBadge({ skill }: { skill: SkillRow }) {
     return (
       <Tooltip>
         <TooltipTrigger className="cursor-default">
-          <Badge variant="secondary" className="text-[10px] bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20">
+          <Badge variant="secondary" className="text-2xs bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20">
             error
           </Badge>
         </TooltipTrigger>
@@ -71,14 +71,14 @@ function SkillHydrationBadge({ skill }: { skill: SkillRow }) {
 
   if (status === "pending") {
     return (
-      <Badge variant="secondary" className="text-[10px] bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 border-yellow-500/20">
+      <Badge variant="secondary" className="text-2xs bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 border-yellow-500/20">
         pending
       </Badge>
     )
   }
 
   return (
-    <Badge variant="default" className="text-[10px] bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20">
+    <Badge variant="default" className="text-2xs bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20">
       ready
     </Badge>
   )
@@ -402,7 +402,7 @@ export function SkillsSettings() {
       <div className="flex flex-col gap-2">
         {isLoading ? (
           Array.from({ length: 3 }).map((_, index) => (
-            <Skeleton key={index} className="h-[52px] w-full rounded-xl" />
+            <Skeleton key={index} className="h-13 w-full rounded-xl" />
           ))
         ) : skills.length === 0 ? (
           <div className="flex flex-col items-center py-14">
@@ -421,7 +421,7 @@ export function SkillsSettings() {
                 <HugeiconsIcon icon={BookOpen01Icon} size={20} className="shrink-0 mt-0.5 text-muted-foreground" />
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-semibold text-foreground">Create a skill</p>
-                  <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">
+                  <p className="text-sm-alt text-muted-foreground mt-0.5 leading-relaxed">
                     Write inline instructions or sync from a Git repository.
                   </p>
                 </div>
@@ -431,7 +431,7 @@ export function SkillsSettings() {
           </div>
         ) : (
           <>
-            <div className="hidden md:flex items-center gap-3 px-4 py-1 text-[10px] font-mono uppercase tracking-[1px] text-muted-foreground/50">
+            <div className="hidden md:flex items-center gap-3 px-4 py-1 text-2xs font-mono uppercase tracking-small text-muted-foreground/50">
               <span className="flex-1 min-w-0">Name</span>
               <span className="w-20 shrink-0 text-right">Source</span>
               <span className="w-20 shrink-0 text-right">Status</span>
@@ -460,14 +460,14 @@ export function SkillsSettings() {
                     </div>
                   </div>
                   <span className="w-20 shrink-0 text-right">
-                    <Badge variant="secondary" className="text-[10px]">
+                    <Badge variant="secondary" className="text-2xs">
                       {skill.source_type === "git" ? "git" : "inline"}
                     </Badge>
                   </span>
                   <span className="w-20 shrink-0 text-right">
                     <SkillHydrationBadge skill={skill} />
                   </span>
-                  <span className="w-28 shrink-0 text-right text-[11px] text-muted-foreground font-mono tabular-nums">
+                  <span className="w-28 shrink-0 text-right text-mini text-muted-foreground font-mono tabular-nums">
                     {skill.created_at ? formatDate(skill.created_at) : "\u2014"}
                   </span>
                   <div className="w-8 shrink-0 flex justify-center">
@@ -507,7 +507,7 @@ export function SkillsSettings() {
                     />
                   </div>
                   <div className="flex items-center gap-2 text-xs text-muted-foreground font-mono tabular-nums">
-                    <Badge variant="secondary" className="text-[10px]">
+                    <Badge variant="secondary" className="text-2xs">
                       {skill.source_type === "git" ? "git" : "inline"}
                     </Badge>
                     <SkillHydrationBadge skill={skill} />

--- a/apps/web/components/integration-logos.tsx
+++ b/apps/web/components/integration-logos.tsx
@@ -41,7 +41,7 @@ export function IntegrationLogos({ integrations, max = 4, size = 20, className }
             ))}
             {overflow > 0 && (
               <span
-                className="flex items-center justify-center rounded-full border-2 border-background bg-muted text-[10px] font-medium text-muted-foreground"
+                className="flex items-center justify-center rounded-full border-2 border-background bg-muted text-2xs font-medium text-muted-foreground"
                 style={{
                   marginLeft: -(size * 0.3),
                   width: size,
@@ -65,7 +65,7 @@ export function IntegrationLogos({ integrations, max = 4, size = 20, className }
             <div className="flex flex-col gap-0.5 min-w-0">
               <span className="text-xs font-medium">{integration.name}</span>
               {integration.actions.length > 0 && (
-                <span className="text-[10px] opacity-70 leading-relaxed">
+                <span className="text-2xs opacity-70 leading-relaxed">
                   {integration.actions.join(", ")}
                 </span>
               )}

--- a/apps/web/components/marketing-footer.tsx
+++ b/apps/web/components/marketing-footer.tsx
@@ -94,7 +94,7 @@ export function MarketingFooter() {
             {/* Brand — full width on mobile, 5 cols on desktop */}
             <div className="col-span-2 sm:col-span-5 flex flex-col gap-6 pr-0 sm:pr-8">
               <Logo className="h-7" />
-              <p className="text-[13px] text-muted-foreground leading-relaxed max-w-80">
+              <p className="text-sm-alt text-muted-foreground leading-relaxed max-w-80">
                 Build, run, and monitor production-grade AI agents. Bring your
                 own keys, pick your models, install from the marketplace or
                 create from scratch.
@@ -191,7 +191,7 @@ function FooterColumn({
 }) {
   return (
     <div className="flex flex-col gap-3.5">
-      <span className="font-mono text-[10px] font-medium uppercase tracking-[1.5px] text-foreground">
+      <span className="font-mono text-2xs font-medium uppercase tracking-medium text-foreground">
         {title}
       </span>
       <div className="flex flex-col gap-2">
@@ -202,7 +202,7 @@ function FooterColumn({
               href={link.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-[13px] text-muted-foreground hover:text-foreground transition-colors w-fit"
+              className="text-sm-alt text-muted-foreground hover:text-foreground transition-colors w-fit"
             >
               {link.label}
             </a>
@@ -210,7 +210,7 @@ function FooterColumn({
             <Link
               key={link.label}
               href={link.href}
-              className="text-[13px] text-muted-foreground hover:text-foreground transition-colors w-fit"
+              className="text-sm-alt text-muted-foreground hover:text-foreground transition-colors w-fit"
             >
               {link.label}
             </Link>

--- a/apps/web/components/message-input.tsx
+++ b/apps/web/components/message-input.tsx
@@ -43,7 +43,7 @@ export function MessageInput({
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
         disabled={disabled}
-        className="pr-12 min-h-[80px] max-h-40"
+        className="pr-12 min-h-20 max-h-40"
       />
       <Button
         size="icon-sm"

--- a/apps/web/components/settings-dialog.tsx
+++ b/apps/web/components/settings-dialog.tsx
@@ -167,7 +167,7 @@ export function SettingsDialog({ open, onOpenChange, initialSection }: SettingsD
           <nav className="hidden md:flex w-52 shrink-0 flex-col gap-4 border-r border-border bg-muted/30 p-3">
             {settingsGroups.map((group) => (
               <div key={group.label} className="flex flex-col gap-1">
-                <p className="px-2.5 pb-1 font-mono text-[10px] uppercase tracking-[1.5px] text-muted-foreground">
+                <p className="px-2.5 pb-1 font-mono text-2xs uppercase tracking-medium text-muted-foreground">
                   {group.label}
                 </p>
                 {group.items.map((item) => (


### PR DESCRIPTION
## Summary

- Replaces ~220 arbitrary Tailwind class values across `apps/web` with named design tokens, cutting the arbitrary-value count from **298 -> 76 (~75% reduction)**.
- Adds six new design tokens to the `@theme` block in `apps/web/app/globals.css` to cover sub-xs font sizes and fine-grained tracking that Tailwind doesn't ship by default.
- Keeps bundle semantics identical: every replacement is a 1:1 value-equivalent swap (no visual regressions expected).

## Tokens added (`apps/web/app/globals.css`)

| Token | Value | Replaces |
| --- | --- | --- |
| `text-2xs` | 0.625rem (10px) | `text-[10px]` x85 |
| `text-mini` | 0.6875rem (11px) | `text-[11px]` x84 |
| `text-sm-alt` | 0.8125rem (13px) | `text-[13px]` x31 |
| `tracking-micro` | 0.5px | `tracking-[0.5px]` / `-tracking-[0.5px]` x40 |
| `tracking-small` | 1px | `tracking-[1px]` / `-tracking-[1px]` x38 |
| `tracking-medium` | 1.5px | `tracking-[1.5px]` / `-tracking-[1.5px]` x29 |

## Swaps to existing Tailwind utilities

- `text-[48px]` -> `text-5xl`
- `text-[12px]` -> `text-xs`, `text-[14px]` -> `text-sm`
- `h-[52px|60px|64px|80px|88px]` -> `h-13 / h-15 / h-16 / h-20 / h-22`
- `min-h-[60px|80px]` -> `min-h-15 / min-h-20`
- `w-[300px]` -> `w-75`, `size-[18px]` -> `size-4.5`

## Remaining arbitrary values (76, intentionally deferred)

- Responsive marketing heading scale (`text-[28px|32px|36px|40px|44px|56px]`): deliberate typographic ramp across breakpoints; reworking it is a broader typography redesign.
- One-off animation offsets (`translate-x-[1.5px]`, `translate-x-[-1.5px]`).
- Viewport-relative sizes (`max-h-[85vh]`, `pt-[20vh]`, `h-[calc(...)]`) that are context-specific.
- Low-frequency one-offs (`text-[7px|8px|9px|15px|22px]`, `ring-[3px]`, `rounded-[2px]`, a handful of `max-w-[...px]`).

These are good candidates for a follow-up once the heading scale is productized.

## Scope notes

- Only `apps/web/` was touched.
- `style={{}}` inline attributes were intentionally left alone (that is #91's scope).

## Test plan

- [x] `pnpm --filter web typecheck` passes
- [x] `pnpm --filter web lint` shows the same 79 pre-existing problems (41 errors, 38 warnings) as `origin/main` - no new lint errors introduced
- [ ] Visual smoke test of `/` marketing page, `/marketplace`, `/blog`, and `/w/agents/*` dashboards (reviewer to confirm - dev server not run locally)

Closes #92