### PR TITLE
fix(frontend): eliminate `as never` type casts

### DIFF
--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -53,7 +53,7 @@ export default function AuthPage() {
 
   const requestOTP = useCallback(async () => {
     otpRequest.mutate(
-      { body: { email } as never },
+      { body: { email } },
       {
         onSuccess: () => {
           setResendTimer(RESEND_COOLDOWN)
@@ -80,7 +80,7 @@ export default function AuthPage() {
     if (value.length < 6) return
 
     otpVerify.mutate(
-      { body: { email, code: value } as never },
+      { body: { email, code: value } },
       {
         onSuccess: () => {
           router.replace("/w")

--- a/apps/web/app/w/agents/[id]/_components/edit-agent-panel/context.tsx
+++ b/apps/web/app/w/agents/[id]/_components/edit-agent-panel/context.tsx
@@ -200,7 +200,7 @@ export function EditAgentProvider({ children, agent, open, onClose }: EditAgentP
       }
     }
 
-    const body: Record<string, unknown> = {
+    const body: components["schemas"]["updateAgentRequest"] = {
       name: values.name.trim(),
       description: values.description.trim() || undefined,
       credential_id: values.credentialId || undefined,
@@ -213,7 +213,7 @@ export function EditAgentProvider({ children, agent, open, onClose }: EditAgentP
       triggers: triggers.map((trigger) => ({
         connection_id: trigger.connectionId,
         trigger_keys: trigger.triggerKeys,
-        conditions: trigger.conditions,
+        conditions: trigger.conditions ?? undefined,
       })),
       shared_memory: values.sharedMemory,
       team: values.team.trim() || undefined,
@@ -224,7 +224,7 @@ export function EditAgentProvider({ children, agent, open, onClose }: EditAgentP
     updateAgent.mutate(
       {
         params: { path: { id: agent.id } },
-        body: body as never,
+        body,
       },
       {
         onSuccess: () => {

--- a/apps/web/app/w/agents/_components/configure-resources-dialog.tsx
+++ b/apps/web/app/w/agents/_components/configure-resources-dialog.tsx
@@ -497,7 +497,7 @@ export function ConfigureResourcesDialog({ open, onOpenChange, agent: agentProp 
     }
 
     updateAgent.mutate(
-      { params: { path: { id: agent?.id as string } }, body: { resources: cleanedResources } as never },
+      { params: { path: { id: agent?.id as string } }, body: { resources: cleanedResources } },
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ["get", "/v1/agents"] })

--- a/apps/web/app/w/agents/_components/create-agent/add-llm-key-dialog.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/add-llm-key-dialog.tsx
@@ -84,7 +84,7 @@ export function AddLlmKeyDialog({ open, onOpenChange, onCreated }: AddLlmKeyDial
           api_key: apiKey.trim(),
           label: label.trim() || `${selectedProvider.name} key`,
           base_url: baseUrl.trim() || undefined,
-        } as never,
+        },
       },
       {
         onSuccess: (data) => {

--- a/apps/web/app/w/agents/_components/create-agent/context.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/context.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { $api } from "@/lib/api/hooks"
 import { extractErrorMessage } from "@/lib/api/error"
+import type { components } from "@/lib/api/schema"
 import { scratchSteps, marketplaceSteps } from "./types"
 import type { CreationMode, Step, SkillPreview, SubagentPreview, TriggerConfig } from "./types"
 
@@ -210,7 +211,7 @@ export function CreateAgentProvider({ children, onClose, initialMode }: CreateAg
       }
     }
 
-    const body: Record<string, unknown> = {
+    const body: components["schemas"]["createAgentRequest"] = {
       name: values.name.trim(),
       description: values.description.trim() || undefined,
       credential_id: values.credentialId,
@@ -234,12 +235,12 @@ export function CreateAgentProvider({ children, onClose, initialMode }: CreateAg
       body.triggers = triggers.map((trigger) => ({
         connection_id: trigger.connectionId,
         trigger_keys: trigger.triggerKeys,
-        conditions: trigger.conditions,
+        conditions: trigger.conditions ?? undefined,
       }))
     }
 
     createAgent.mutate(
-      { body: body as never },
+      { body },
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ["get", "/v1/agents"] })

--- a/apps/web/app/w/connections/_hooks/use-connect-integration.ts
+++ b/apps/web/app/w/connections/_hooks/use-connect-integration.ts
@@ -50,7 +50,7 @@ export function useConnectIntegration() {
 
       const connection = await api.POST("/v1/in/integrations/{id}/connections", {
         params: { path: { id: integrationId } },
-        body: { nango_connection_id: authResult.connectionId } as never,
+        body: { nango_connection_id: authResult.connectionId },
       })
 
       if (connection.error) throw new Error("Failed to save connection")

--- a/apps/web/app/w/settings/_components/skills-settings.tsx
+++ b/apps/web/app/w/settings/_components/skills-settings.tsx
@@ -166,7 +166,7 @@ function CreateSkillDialog({ open, onOpenChange }: { open: boolean; onOpenChange
     event.preventDefault()
     if (!name.trim()) return
 
-    const body: Record<string, unknown> = {
+    const body: components["schemas"]["createSkillRequest"] = {
       name: name.trim(),
       description: description.trim() || undefined,
       source_type: sourceType,
@@ -191,7 +191,7 @@ function CreateSkillDialog({ open, onOpenChange }: { open: boolean; onOpenChange
     }
 
     createSkill.mutate(
-      { body: body as never },
+      { body },
       {
         onSuccess: () => {
           toast.success("Skill created")

--- a/apps/web/components/create-workspace-dialog.tsx
+++ b/apps/web/components/create-workspace-dialog.tsx
@@ -33,7 +33,7 @@ export function CreateWorkspaceDialog({ open, onOpenChange }: CreateWorkspaceDia
     setLoading(true)
 
     const response = await api.POST("/v1/orgs", {
-      body: { name: name.trim() } as never,
+      body: { name: name.trim() },
     })
 
     if (response.error) {


### PR DESCRIPTION
## Summary

Eliminates all 9 `as never` type escape casts in `apps/web` by applying the proper OpenAPI-generated request body types.

Investigation showed the committed OpenAPI spec (`docs/openapi.json`) was already in sync — regenerating `apps/web/lib/api/schema.d.ts` produced an identical file. The casts were masking trivially-fixable typing issues (implicit `Record<string, unknown>` bodies, `null` vs `undefined` on optional fields) rather than real spec drift.

## Changes

- `components/create-workspace-dialog.tsx`, `app/auth/page.tsx` (x2), `app/w/agents/_components/configure-resources-dialog.tsx`, `app/w/agents/_components/create-agent/add-llm-key-dialog.tsx`, `app/w/connections/_hooks/use-connect-integration.ts`: drop the cast — the inline body literal already matches the generated request schema.
- `app/w/agents/_components/create-agent/context.tsx`, `app/w/agents/[id]/_components/edit-agent-panel/context.tsx`: type the local `body` as `components["schemas"]["createAgentRequest" | "updateAgentRequest"]`, and coerce `trigger.conditions` from `null` to `undefined` so it satisfies the optional schema field.
- `app/w/settings/_components/skills-settings.tsx`: type `body` as `components["schemas"]["createSkillRequest"]`.

## Test plan

- [x] `pnpm --filter web typecheck` passes clean
- [x] Zero remaining `as never` casts in `apps/web/` source (only in `node_modules/`)

Closes #90