### PR TITLE
refactor(frontend): replace hand-rolled types with OpenAPI-generated types

### DIFF
--- a/apps/web/app/w/agents/_components/create-agent/types.ts
+++ b/apps/web/app/w/agents/_components/create-agent/types.ts
@@ -1,3 +1,5 @@
+import type { components } from "@/lib/api/schema"
+
 export type CreationMode = "scratch" | "marketplace"
 
 export type Step =
@@ -35,6 +37,27 @@ export const marketplaceSteps: Step[] = [
   "marketplace-detail",
 ]
 
+/**
+ * UI-only mock shape used by `./data.ts` to render the marketplace browse /
+ * detail preview before the backend marketplace endpoints return real data.
+ * Once wired up, prefer `components["schemas"]["marketplaceAgentResponse"]`
+ * directly and delete this alongside `./data.ts`.
+ */
+export interface MarketplaceAgentPreview {
+  slug: string
+  name: string
+  description: string
+  publisher: { name: string; avatar: string }
+  installs: number
+  integrations: string[]
+  verified: boolean
+}
+
+/**
+ * UI-only mock shape used by `./data.ts` for the integration / action picker.
+ * Real integrations come from `components["schemas"]["integrationSummary"]`
+ * and `components["schemas"]["actionSummary"]` via `/v1/catalog/integrations`.
+ */
 export interface Integration {
   id: string
   name: string
@@ -50,16 +73,10 @@ export interface IntegrationAction {
   type: "read" | "write" | "delete"
 }
 
-export interface MarketplaceAgentPreview {
-  slug: string
-  name: string
-  description: string
-  publisher: { name: string; avatar: string }
-  installs: number
-  integrations: string[]
-  verified: boolean
-}
-
+/**
+ * UI-only mock shape for the LLM key picker seed data in `./data.ts`.
+ * Real keys come from `components["schemas"]["credentialResponse"]`.
+ */
 export interface LlmKey {
   id: string
   name: string
@@ -68,10 +85,15 @@ export interface LlmKey {
   models: string[]
 }
 
-export interface SkillPreview {
-  id: string
-  slug: string
-  name: string
+/**
+ * UI projection of `components["schemas"]["skillResponse"]` with camel-cased
+ * field names and a narrowed `scope` derived from `org_id`. Built via
+ * `toSkillPreview` in `step-skills.tsx`.
+ */
+export type SkillPreview = {
+  id: NonNullable<components["schemas"]["skillResponse"]["id"]>
+  slug: NonNullable<components["schemas"]["skillResponse"]["slug"]>
+  name: NonNullable<components["schemas"]["skillResponse"]["name"]>
   description: string
   sourceType: "inline" | "git"
   scope: "public" | "org"
@@ -80,14 +102,26 @@ export interface SkillPreview {
   featured: boolean
 }
 
-export interface SubagentPreview {
-  id: string
-  name: string
+/**
+ * UI projection of `components["schemas"]["subagentResponse"]` with a narrowed
+ * `scope` derived from `org_id`. Built via `toSubagentPreview` in
+ * `step-subagents.tsx`.
+ */
+export type SubagentPreview = {
+  id: NonNullable<components["schemas"]["subagentResponse"]["id"]>
+  name: NonNullable<components["schemas"]["subagentResponse"]["name"]>
   description: string
   model: string
   scope: "public" | "org"
 }
 
+/**
+ * UI state for the trigger picker. Collapses the backend
+ * `components["schemas"]["agentTriggerResponse"]` (snake_case, opaque
+ * `conditions`) into a shape that's ergonomic for dialog state: we keep the
+ * resolved display name alongside the raw key, and represent conditions as a
+ * typed mode + list instead of an opaque `unknown`.
+ */
 export interface TriggerConditionConfig {
   path: string
   operator: string

--- a/apps/web/app/w/connections/_components/credentials-form.tsx
+++ b/apps/web/app/w/connections/_components/credentials-form.tsx
@@ -9,15 +9,9 @@ import { Label } from "@/components/ui/label"
 import { IntegrationLogo } from "@/components/integration-logo"
 import type { components } from "@/lib/api/schema"
 
-type NangoConfig = components["schemas"]["NangoConfig"]
 type ConnectionConfigField = components["schemas"]["ConnectionConfigField"]
 
-interface Integration {
-  id?: string
-  provider?: string
-  display_name?: string
-  nango_config?: NangoConfig
-}
+type Integration = components["schemas"]["inIntegrationAvailableResponse"]
 
 interface CredentialsFormProps {
   integration: Integration

--- a/apps/web/components/impersonate-user-dialog.tsx
+++ b/apps/web/components/impersonate-user-dialog.tsx
@@ -12,8 +12,11 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog"
+import type { components } from "@/lib/api/schema"
 
-interface AdminUser {
+// Backend fields are all optional in the spec; this dialog only consumes the
+// identity triple, which must be present on any real row we render.
+type AdminUser = components["schemas"]["adminUserResponse"] & {
   id: string
   email: string
   name: string

--- a/apps/web/hooks/use-conversation-stream.ts
+++ b/apps/web/hooks/use-conversation-stream.ts
@@ -6,6 +6,12 @@ import { fetchEventSource } from "@microsoft/fetch-event-source"
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL as string
 
+/**
+ * Response shape for `GET /api/auth/stream-token` — a Next.js edge route that
+ * forwards a short-lived access token for direct backend SSE connections.
+ * Not part of the backend OpenAPI spec (it's a frontend-only helper); the
+ * contract lives alongside the handler at `app/api/auth/stream-token/route.ts`.
+ */
 interface StreamToken {
   access_token: string
   org_id: string | null


### PR DESCRIPTION
## Summary

Swaps hand-rolled type declarations for references to the OpenAPI-generated schema where a matching backend resource exists, and documents the remaining UI-local types so the reason for keeping them is explicit.

Replaced / tightened:
- `AdminUser` in `components/impersonate-user-dialog.tsx` now extends `components["schemas"]["adminUserResponse"]` (all spec fields optional) with the narrowed identity triple the dialog requires.
- `Integration` in `app/w/connections/_components/credentials-form.tsx` is now a direct alias of `components["schemas"]["inIntegrationAvailableResponse"]` (dropped the redundant local duplicate).
- `SkillPreview` and `SubagentPreview` in `app/w/agents/_components/create-agent/types.ts` now derive their `id` / `name` / `slug` fields from `components["schemas"]["skillResponse"]` and `components["schemas"]["subagentResponse"]` via `NonNullable<...>`, so renames on the backend propagate.

Documented / kept (with rationale inline):
- `StreamToken` in `hooks/use-conversation-stream.ts` is the response of a Next.js-only edge route (`/api/auth/stream-token`), not part of the backend OpenAPI spec.
- `Integration`, `IntegrationAction`, `LlmKey`, `MarketplaceAgentPreview` in `create-agent/types.ts` back demo mock data in `./data.ts`; comments now point to the backend schemas that should replace them once the marketplace flows are wired up.
- `TriggerConfig` / `TriggerConditionConfig` / `TriggerConditionsConfig` are UI state for the trigger picker dialog, intentionally richer than the opaque `agentTriggerResponse`.
- Conversation-event data types in `[id]/_lib/conversation-events.ts` narrow the opaque `data` field (backend types it as `number[]` from `json.RawMessage`), so they're kept as SSE-payload types.

## Test plan

- [x] `pnpm --filter web typecheck` passes
- [x] `pnpm --filter web lint` unchanged from baseline (79 problems, same 41 errors / 38 warnings as main)

Closes #94