### PR TITLE
chore(frontend): remove useless comments and section dividers

### DIFF
--- a/apps/web/app/api/proxy/[...path]/route.ts
+++ b/apps/web/app/api/proxy/[...path]/route.ts
@@ -23,10 +23,6 @@ const AUTH_PATHS = new Set([
 
 const LOGOUT_PATH = "auth/logout"
 
-// ---------------------------------------------------------------------------
-// Concurrent refresh lock
-// ---------------------------------------------------------------------------
-
 let refreshPromise: Promise<SessionData | null> | null = null
 
 async function refreshTokens(refreshToken: string): Promise<SessionData | null> {
@@ -55,10 +51,6 @@ async function safeRefresh(refreshToken: string): Promise<SessionData | null> {
   })
   return refreshPromise
 }
-
-// ---------------------------------------------------------------------------
-// Build headers for upstream request
-// ---------------------------------------------------------------------------
 
 function buildUpstreamHeaders(
   req: NextRequest,
@@ -93,10 +85,6 @@ function buildUpstreamHeaders(
   return headers
 }
 
-// ---------------------------------------------------------------------------
-// Forward a request to the Go backend
-// ---------------------------------------------------------------------------
-
 async function forward(
   url: URL,
   method: string,
@@ -105,10 +93,6 @@ async function forward(
 ) {
   return fetch(url, { method, headers, body })
 }
-
-// ---------------------------------------------------------------------------
-// Main handler
-// ---------------------------------------------------------------------------
 
 async function handler(
   req: NextRequest,
@@ -136,9 +120,7 @@ async function handler(
       ? await req.arrayBuffer()
       : undefined
 
-  // -----------------------------------------------------------------------
   // Logout interception: inject refresh_token into request body
-  // -----------------------------------------------------------------------
   let upstreamBody: ArrayBuffer | undefined = body
   const isLogout = apiPath === LOGOUT_PATH && req.method === "POST"
 
@@ -148,17 +130,12 @@ async function handler(
     upstreamBody = new TextEncoder().encode(JSON.stringify(payload)).buffer as ArrayBuffer
   }
 
-  // -----------------------------------------------------------------------
   // Proactive refresh if token is about to expire
-  // -----------------------------------------------------------------------
   if (session && !AUTH_PATHS.has(apiPath) && session.expires_at - Date.now() < 60_000) {
     const refreshed = await safeRefresh(session.refresh_token)
     if (refreshed) session = refreshed
   }
 
-  // -----------------------------------------------------------------------
-  // Forward to backend
-  // -----------------------------------------------------------------------
   const headers = buildUpstreamHeaders(req, session)
   let upstream: Response
   try {
@@ -169,9 +146,7 @@ async function handler(
     return NextResponse.json({ error: "upstream_unavailable" }, { status: 502 })
   }
 
-  // -----------------------------------------------------------------------
   // Auto-refresh on 401 (retry once)
-  // -----------------------------------------------------------------------
   let refreshedSession: SessionData | null = null
 
   if (upstream.status === 401 && session && !AUTH_PATHS.has(apiPath) && !isLogout) {
@@ -189,9 +164,6 @@ async function handler(
     }
   }
 
-  // -----------------------------------------------------------------------
-  // Build response
-  // -----------------------------------------------------------------------
   const responseHeaders = new Headers()
   const skipHeaders = new Set(["transfer-encoding", "content-encoding", "content-length"])
   upstream.headers.forEach((value, key) => {
@@ -199,9 +171,7 @@ async function handler(
     responseHeaders.set(key, value)
   })
 
-  // -----------------------------------------------------------------------
   // Intercept auth responses — persist session, strip tokens from body
-  // -----------------------------------------------------------------------
   if (AUTH_PATHS.has(apiPath) && upstream.ok) {
     reqLog.info("intercepting auth response")
     try {

--- a/apps/web/app/invites/accept/page.tsx
+++ b/apps/web/app/invites/accept/page.tsx
@@ -32,7 +32,6 @@ function AcceptInviteContents() {
   const router = useRouter()
   const token = searchParams.get("token") ?? ""
 
-  // Invite preview (public)
   const previewQuery = $api.useQuery(
     "get",
     "/v1/invites/{token}",
@@ -40,7 +39,7 @@ function AcceptInviteContents() {
     { enabled: token.length > 0, retry: false },
   )
 
-  // Current auth status — no retry, errors are treated as "logged out".
+  // Errors from /auth/me are treated as "logged out" — no retry.
   const meQuery = $api.useQuery("get", "/auth/me", {}, { retry: false })
   const me = meQuery.data
 
@@ -95,8 +94,6 @@ function AcceptInviteContents() {
       },
     )
   }, [logoutMutation, router])
-
-  // --- State rendering ---
 
   if (!token) {
     return (
@@ -172,7 +169,6 @@ function AcceptInviteContents() {
     )
   }
 
-  // Not logged in
   if (meQuery.isError || !me?.user) {
     return (
       <CenterCard>
@@ -198,7 +194,6 @@ function AcceptInviteContents() {
     )
   }
 
-  // Logged in, check email match
   const userEmail = (me.user.email ?? "").toLowerCase().trim()
   const expected = inviteEmail.toLowerCase().trim()
 
@@ -223,7 +218,6 @@ function AcceptInviteContents() {
     )
   }
 
-  // Logged in, matching email
   return (
     <CenterCard>
       <h1 className="text-lg font-semibold text-foreground">

--- a/apps/web/app/w/agents/[id]/_components/edit-agent-panel/context.tsx
+++ b/apps/web/app/w/agents/[id]/_components/edit-agent-panel/context.tsx
@@ -106,7 +106,6 @@ export function EditAgentProvider({ children, agent, open, onClose }: EditAgentP
   const [triggers, setTriggers] = useState<TriggerConfig[]>([])
   const [skillIds, setSkillIds] = useState<Set<string>>(new Set())
 
-  // Reset form from agent data when panel opens
   useEffect(() => {
     if (!open || !agent) return
 

--- a/apps/web/app/w/agents/[id]/_components/edit-agent-panel/index.tsx
+++ b/apps/web/app/w/agents/[id]/_components/edit-agent-panel/index.tsx
@@ -59,8 +59,6 @@ export function EditAgentPanel({ open, onOpenChange, agent }: EditAgentPanelProp
   )
 }
 
-// ---------------------------------------------------------------------------
-
 function SectionHeader({ title, description }: { title: string; description?: string }) {
   return (
     <div className="flex flex-col gap-1">
@@ -108,8 +106,6 @@ function SandboxOption({
     </button>
   )
 }
-
-// ---------------------------------------------------------------------------
 
 function EditAgentForm() {
   const { form, integrations, triggers, skillIds, isSubmitting, setIntegrations, removeIntegration, addTrigger, removeTrigger, updateTrigger, toggleSkill, handleSave } = useEditAgent()

--- a/apps/web/app/w/agents/_components/configure-resources-dialog.tsx
+++ b/apps/web/app/w/agents/_components/configure-resources-dialog.tsx
@@ -25,10 +25,6 @@ import { toast } from "sonner"
 import { extractErrorMessage } from "@/lib/api/error"
 import type { components } from "@/lib/api/schema"
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
 type Agent = components["schemas"]["agentResponse"]
 type InConnection = components["schemas"]["inConnectionResponse"]
 
@@ -44,10 +40,6 @@ interface ConfigurableResource {
   display_name: string
   description: string
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 const slideVariants = {
   enter: (direction: number) => ({ x: direction > 0 ? 60 : -60, opacity: 0 }),
@@ -79,10 +71,6 @@ function getConfigurableResources(connection: InConnection): ConfigurableResourc
   return raw as ConfigurableResource[]
 }
 
-// ---------------------------------------------------------------------------
-// Back button
-// ---------------------------------------------------------------------------
-
 function BackButton({ onClick }: { onClick: () => void }) {
   return (
     <button
@@ -95,10 +83,6 @@ function BackButton({ onClick }: { onClick: () => void }) {
     </button>
   )
 }
-
-// ---------------------------------------------------------------------------
-// Step 1: Connection list
-// ---------------------------------------------------------------------------
 
 interface ConnectionListViewProps {
   connections: InConnection[]
@@ -171,10 +155,6 @@ function ConnectionListView({ connections, getSelectedCount, getOrphanCount, onS
   )
 }
 
-// ---------------------------------------------------------------------------
-// Step 2: Resource type list
-// ---------------------------------------------------------------------------
-
 interface ResourceTypeListViewProps {
   connection: InConnection
   resourceTypes: ConfigurableResource[]
@@ -215,10 +195,6 @@ function ResourceTypeListView({ connection, resourceTypes, getTypeSelectedCount,
     </>
   )
 }
-
-// ---------------------------------------------------------------------------
-// Step 3: Resource instance multi-select
-// ---------------------------------------------------------------------------
 
 interface ResourceInstanceListViewProps {
   connectionId: string
@@ -305,10 +281,6 @@ function ResourceInstanceListView({ connectionId, resourceType, selectedItems, i
   )
 }
 
-// ---------------------------------------------------------------------------
-// Main dialog
-// ---------------------------------------------------------------------------
-
 interface ConfigureResourcesDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -329,7 +301,6 @@ export function ConfigureResourcesDialog({ open, onOpenChange, agent: agentProp 
   const [activeConnectionId, setActiveConnectionId] = useState<string | null>(null)
   const [activeResourceType, setActiveResourceType] = useState<string | null>(null)
 
-  // Reset state when dialog opens
   useEffect(() => {
     if (open && agent) {
       setResources(parseAgentResources(agent.resources))
@@ -338,7 +309,6 @@ export function ConfigureResourcesDialog({ open, onOpenChange, agent: agentProp 
     }
   }, [open, agent?.resources])
 
-  // Load connections
   const { data: connectionsData } = $api.useQuery("get", "/v1/in/connections")
   const allConnections = (connectionsData?.data ?? []) as InConnection[]
   const connectionsById = new Map(allConnections.filter((c) => c.id).map((c) => [c.id!, c]))
@@ -402,7 +372,6 @@ export function ConfigureResourcesDialog({ open, onOpenChange, agent: agentProp 
   const activeConnection = activeConnectionId ? connectionsById.get(activeConnectionId) ?? null : null
   const activeResourceTypes = activeConnection ? getConfigurableResources(activeConnection) : []
 
-  // Selection
   const toggleResource = useCallback(
     (connectionId: string, resourceType: string, item: ResourceItem) => {
       setResources((prev) => {
@@ -423,7 +392,6 @@ export function ConfigureResourcesDialog({ open, onOpenChange, agent: agentProp 
 
   if (!agent) return null
 
-  // Navigation
   function openConnection(connectionId: string) {
     direction.current = 1
     setActiveConnectionId(connectionId)
@@ -476,7 +444,6 @@ export function ConfigureResourcesDialog({ open, onOpenChange, agent: agentProp 
     return (resources[connectionId]?.[resourceType] ?? []).some((item) => item.id === resourceId)
   }
 
-  // Save
   function handleSave() {
     if (!agent?.id) return
 

--- a/apps/web/app/w/agents/_components/manage-integrations-dialog.tsx
+++ b/apps/web/app/w/agents/_components/manage-integrations-dialog.tsx
@@ -306,10 +306,6 @@ export function ManageIntegrationsDialog({
   )
 }
 
-// ---------------------------------------------------------------------------
-// Action detail sub-view (virtualized action list for a single integration)
-// ---------------------------------------------------------------------------
-
 interface ActionDetailViewProps {
   connection: { id?: string; provider?: string; display_name?: string }
   actionSearch: string

--- a/apps/web/app/w/connections/_components/add-connection-dialog.tsx
+++ b/apps/web/app/w/connections/_components/add-connection-dialog.tsx
@@ -91,7 +91,6 @@ export function AddConnectionDialog({
 
   const integrations = data ?? []
 
-  // Handle pre-selected integration from empty state
   useEffect(() => {
     if (preSelectedIntegrationId && integrations.length > 0 && !selectedIntegration) {
       const found = integrations.find((i) => i.id === preSelectedIntegrationId)

--- a/apps/web/app/w/settings/_components/skill-detail-dialog.tsx
+++ b/apps/web/app/w/settings/_components/skill-detail-dialog.tsx
@@ -267,7 +267,6 @@ export function SkillDetailDialog({ skill, open, onOpenChange }: SkillDetailDial
   const isMarkdown = selectedFile ? isMarkdownFile(selectedFile.path) : false
   const language = selectedFile ? getLanguageFromPath(selectedFile.path) : "text"
 
-  // Reset selection when opening a different skill.
   const skillId = skill?.id
   const previousSkillId = useMemo(() => skillId, [open])
   if (skillId !== previousSkillId) {

--- a/apps/web/hooks/use-conversation-stream.ts
+++ b/apps/web/hooks/use-conversation-stream.ts
@@ -199,7 +199,6 @@ export function useConversationStream(conversationId: string | null) {
               const existing = updated[idx]
               updated[idx] = {
                 ...existing,
-                // Use full_response as fallback if chunks were missed
                 content: existing.content || fullResponse || "",
                 inputTokens,
                 outputTokens,

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -12,10 +12,6 @@ export type SessionData = {
   expires_at: number // Unix ms when access_token expires
 }
 
-// ---------------------------------------------------------------------------
-// Key derivation — HKDF from SESSION_SECRET → AES-256-GCM key
-// ---------------------------------------------------------------------------
-
 let cachedKey: CryptoKey | null = null
 
 async function getKey(): Promise<CryptoKey> {
@@ -44,10 +40,6 @@ async function getKey(): Promise<CryptoKey> {
   log.info("session encryption key derived successfully")
   return cachedKey
 }
-
-// ---------------------------------------------------------------------------
-// Encrypt / Decrypt
-// ---------------------------------------------------------------------------
 
 export async function encrypt(data: SessionData): Promise<string> {
   log.debug({ expires_at: data.expires_at }, "encrypting session data")
@@ -90,10 +82,6 @@ export async function decrypt(cookie: string): Promise<SessionData | null> {
     return null
   }
 }
-
-// ---------------------------------------------------------------------------
-// Cookie helpers
-// ---------------------------------------------------------------------------
 
 export async function getSession(): Promise<SessionData | null> {
   const store = await cookies()
@@ -144,10 +132,6 @@ export function stripSessionCookie(cookieHeader: string): string {
     .filter((c) => !c.startsWith(`${COOKIE_NAME}=`))
     .join("; ")
 }
-
-// ---------------------------------------------------------------------------
-// Impersonation helpers
-// ---------------------------------------------------------------------------
 
 export type ImpersonatingInfo = {
   userId: string

--- a/apps/web/lib/source.tsx
+++ b/apps/web/lib/source.tsx
@@ -20,8 +20,6 @@ export const source = loader({
   },
 });
 
-// --- Blog ---------------------------------------------------------------
-//
 // Blog posts come from a flat fumadocs-mdx collection. Each .mdx file in
 // content/blog/ becomes one entry. We wrap the raw collection here with a
 // strongly-typed helper layer so the page files don't have to handle the

--- a/apps/web/scripts/setup-polar-pricing.ts
+++ b/apps/web/scripts/setup-polar-pricing.ts
@@ -4,10 +4,6 @@ import type { Benefit } from "@polar-sh/sdk/models/components/benefit.js"
 import type { Product } from "@polar-sh/sdk/models/components/product.js"
 import type { MeterCreate } from "@polar-sh/sdk/models/components/metercreate.js"
 
-// ---------------------------------------------------------------------------
-// Configuration
-// ---------------------------------------------------------------------------
-
 interface MeterConfig {
   name: string
   filter: MeterCreate["filter"]
@@ -110,10 +106,6 @@ const PRODUCTS: ProductConfig[] = [
     benefitDescriptions: ["Pro: 300 dedicated runs/month"],
   },
 ]
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 function log(action: string, resource: string, name: string, resourceId: string) {
   console.log(`  ${action.padEnd(10)} ${resource.padEnd(10)} ${name.padEnd(40)} ${resourceId}`)
@@ -259,10 +251,6 @@ async function findOrCreateProduct(
 
   return created
 }
-
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
 
 async function main() {
   const accessToken = process.env.POLAR_ACCESS_TOKEN


### PR DESCRIPTION
## Summary
- Removes 30+ decorative section divider comments (`// ---...`) across `apps/web/` that added visual noise without information.
- Removes narrating comments that restated the adjacent code (e.g. `// Reset state when dialog opens`, `// Load connections`, `// Navigation`, `// Save`, `// Not logged in`).
- Keeps all comments that explain *why* (hidden constraints, orphan-resource logic, HKDF/AES-GCM key derivation notes, fumadocs collection quirks, etc.) and JSDoc on exported helpers.

## Files touched
- `app/api/proxy/[...path]/route.ts`
- `app/invites/accept/page.tsx`
- `app/w/agents/[id]/_components/edit-agent-panel/{index,context}.tsx`
- `app/w/agents/_components/{configure-resources-dialog,manage-integrations-dialog}.tsx`
- `app/w/connections/_components/add-connection-dialog.tsx`
- `app/w/settings/_components/skill-detail-dialog.tsx`
- `hooks/use-conversation-stream.ts`
- `lib/auth/session.ts`
- `lib/source.tsx`
- `scripts/setup-polar-pricing.ts`

## Test plan
- [x] `pnpm --filter web typecheck` passes
- [x] `pnpm --filter web lint` baseline unchanged (41 pre-existing errors, none introduced by this PR)

Closes #97