### PR TITLE
refactor(frontend): replace inline styles with Tailwind utilities

### DIFF
--- a/apps/web/app/(marketing)/_components/backdrop.tsx
+++ b/apps/web/app/(marketing)/_components/backdrop.tsx
@@ -1,0 +1,141 @@
+import { cn } from "@/lib/utils"
+
+/**
+ * Grid + radial-glow backdrop used across every marketing section.
+ *
+ * The grid lines and glow both rely on CSS values that Tailwind can't express
+ * cleanly (multi-stop linear-gradients, `color-mix(in oklch, ...)` for the
+ * glow, and a radial-gradient `mask-image` to fade the grid). The utility
+ * classes `marketing-grid` and `marketing-glow` encapsulate that CSS so the
+ * surrounding markup stays declarative and inline-style free.
+ *
+ * Positioning variants control where the radial glow is centered — each
+ * section historically tuned this by hand (50% 30%, 30% 80%, 70% 50%, …);
+ * the named variants bucket those values into reusable presets.
+ */
+type GlowPosition =
+  | "top"
+  | "top-center"
+  | "hero"
+  | "center"
+  | "center-high"
+  | "bottom"
+  | "bottom-center"
+  | "left-bottom"
+  | "left-bottom-far"
+  | "right-center"
+  | "right-far"
+  | "right-wide"
+
+type GlowIntensity = "sm" | "md" | "md-high" | "lg"
+
+type GridMask =
+  | "center"
+  | "hero"
+  | "bottom"
+  | "left-bottom"
+  | "left-50"
+  | "right-center"
+  | "right-50"
+  | "right-60"
+  | "top-center"
+
+export interface MarketingBackdropProps {
+  /** Position of the radial glow. Defaults to `center`. */
+  glow?: GlowPosition
+  /** Intensity of the glow in `color-mix(primary, transparent)` — sm = 6%, md = 8%, md-high = 10%, lg = 12%. */
+  glowIntensity?: GlowIntensity
+  /** Position mask applied to the grid (fades edges). Defaults to `center`. */
+  grid?: GridMask
+  /** Grid cell size. `sm` = 40px, `md` = 60px. Defaults to `sm`. */
+  gridSize?: "sm" | "md"
+  /** Extra classes — commonly used to restrict `inset-0` reach inside `overflow-hidden` cards. */
+  className?: string
+}
+
+const glowPositionClass: Record<GlowPosition, string> = {
+  top: "marketing-glow-top",
+  "top-center": "marketing-glow-top-center",
+  hero: "marketing-glow-hero",
+  center: "marketing-glow-center",
+  "center-high": "marketing-glow-center-high",
+  bottom: "marketing-glow-bottom",
+  "bottom-center": "marketing-glow-bottom-center",
+  "left-bottom": "marketing-glow-left-bottom",
+  "left-bottom-far": "marketing-glow-left-bottom-far",
+  "right-center": "marketing-glow-right-center",
+  "right-far": "marketing-glow-right-far",
+  "right-wide": "marketing-glow-right-wide",
+}
+
+const glowIntensityClass: Record<GlowIntensity, string> = {
+  sm: "marketing-glow-sm",
+  md: "marketing-glow-md",
+  "md-high": "marketing-glow-md-high",
+  lg: "marketing-glow-lg",
+}
+
+const gridMaskClass: Record<GridMask, string> = {
+  center: "marketing-grid-mask-center",
+  hero: "marketing-grid-mask-hero",
+  bottom: "marketing-grid-mask-bottom",
+  "left-bottom": "marketing-grid-mask-left-bottom",
+  "left-50": "marketing-grid-mask-left-50",
+  "right-center": "marketing-grid-mask-right-center",
+  "right-50": "marketing-grid-mask-right-50",
+  "right-60": "marketing-grid-mask-right-60",
+  "top-center": "marketing-grid-mask-top-center",
+}
+
+export function MarketingBackdrop({
+  glow = "center",
+  glowIntensity = "md",
+  grid = "center",
+  gridSize = "sm",
+  className,
+}: MarketingBackdropProps) {
+  return (
+    <>
+      <div
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-0 pointer-events-none marketing-grid",
+          gridSize === "md" && "marketing-grid-lg",
+          gridMaskClass[grid],
+          className,
+        )}
+      />
+      <div
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-0 pointer-events-none",
+          glowPositionClass[glow],
+          glowIntensityClass[glowIntensity],
+          className,
+        )}
+      />
+    </>
+  )
+}
+
+/**
+ * Standalone glow without the grid — used for card interiors (Pro plan card,
+ * billing upgrade card, CTA gradients inside cards).
+ */
+export function MarketingGlow({
+  glow = "center",
+  glowIntensity = "md",
+  className,
+}: Pick<MarketingBackdropProps, "glow" | "glowIntensity" | "className">) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "absolute inset-0 pointer-events-none",
+        glowPositionClass[glow],
+        glowIntensityClass[glowIntensity],
+        className,
+      )}
+    />
+  )
+}

--- a/apps/web/app/(marketing)/blog/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { findPostBySlug, getAllPosts } from "@/lib/source"
 import { notFound } from "next/navigation"
 import type { Metadata } from "next"
 import { ReadingProgress } from "./reading-progress"
+import { MarketingBackdrop, MarketingGlow } from "../../_components/backdrop"
 
 interface PageProps {
   params: Promise<{ slug: string }>
@@ -124,23 +125,7 @@ export default async function BlogPostPage(props: PageProps) {
 
       {/* Hero */}
       <div className="relative w-full overflow-hidden">
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            background:
-              "radial-gradient(ellipse at 50% 80%, color-mix(in oklch, var(--primary) 12%, transparent) 0%, transparent 60%)",
-          }}
-        />
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            backgroundImage:
-              "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-            backgroundSize: "60px 60px",
-            maskImage:
-              "radial-gradient(ellipse at 50% 100%, black 10%, transparent 60%)",
-          }}
-        />
+        <MarketingBackdrop grid="top-center" gridSize="md" glow="bottom-center" glowIntensity="lg" />
         <div className="relative max-w-3xl mx-auto px-4 pt-16 sm:pt-24 pb-16 sm:pb-20 flex flex-col items-center text-center gap-6">
           <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
             {category}
@@ -184,13 +169,7 @@ export default async function BlogPostPage(props: PageProps) {
 
         {/* Newsletter */}
         <div className="mt-12 relative rounded-2xl border border-border overflow-hidden">
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              background:
-                "radial-gradient(ellipse at 70% 50%, color-mix(in oklch, var(--primary) 8%, transparent) 0%, transparent 60%)",
-            }}
-          />
+          <MarketingGlow glow="right-center" />
           <div className="relative p-6 sm:p-8 flex flex-col gap-4">
             <span className="font-heading text-lg font-semibold text-foreground">
               Enjoyed this post?

--- a/apps/web/app/(marketing)/blog/[slug]/reading-progress.tsx
+++ b/apps/web/app/(marketing)/blog/[slug]/reading-progress.tsx
@@ -74,7 +74,14 @@ export function ReadingProgress() {
 
   return (
     <div className="fixed top-0 left-0 right-0 z-200 h-0.5 bg-border">
-      <div ref={barRef} className="h-full bg-primary" style={{ width: "0%" }} />
+      {/*
+        Width starts at 0 via `w-0`; the effect below mutates
+        `ref.current.style.width` directly on every scroll frame — bypassing
+        React so the update lands in microseconds instead of waiting for a
+        reconciliation pass. The runtime width can't be expressed as a static
+        Tailwind class.
+      */}
+      <div ref={barRef} className="h-full w-0 bg-primary" />
     </div>
   )
 }

--- a/apps/web/app/(marketing)/blog/page.tsx
+++ b/apps/web/app/(marketing)/blog/page.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { getAllPosts } from "@/lib/source"
 import type { Metadata } from "next"
+import { MarketingBackdrop } from "../_components/backdrop"
 
 // All post metadata is read at build time from MDX frontmatter via the
 // fumadocs source. Adding a new post = dropping an .mdx file in
@@ -69,23 +70,7 @@ export default function BlogIndex() {
         {featured && (
           <Link href={featured.url} className="group block mb-12 sm:mb-16">
             <div className="relative rounded-3xl overflow-hidden border border-border hover:border-primary/40 transition-colors">
-              <div
-                className="absolute inset-0 pointer-events-none"
-                style={{
-                  background:
-                    "radial-gradient(ellipse at 30% 50%, color-mix(in oklch, var(--primary) 10%, transparent) 0%, transparent 70%)",
-                }}
-              />
-              <div
-                className="absolute inset-0 pointer-events-none"
-                style={{
-                  backgroundImage:
-                    "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-                  backgroundSize: "60px 60px",
-                  maskImage:
-                    "radial-gradient(ellipse at 30% 50%, black 10%, transparent 60%)",
-                }}
-              />
+              <MarketingBackdrop grid="left-bottom" gridSize="md" glow="left-bottom" glowIntensity="md-high" />
 
               <div className="relative p-8 sm:p-12 lg:p-16 flex flex-col gap-5 max-w-3xl">
                 <div className="flex items-center gap-3">
@@ -189,23 +174,7 @@ export default function BlogIndex() {
 
         {/* Newsletter */}
         <div className="mt-16 sm:mt-24 mb-16 sm:mb-24 relative rounded-3xl border border-border overflow-hidden">
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              background:
-                "radial-gradient(ellipse at 70% 50%, color-mix(in oklch, var(--primary) 8%, transparent) 0%, transparent 60%)",
-            }}
-          />
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              backgroundImage:
-                "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-              backgroundSize: "40px 40px",
-              maskImage:
-                "radial-gradient(ellipse at 70% 50%, black 10%, transparent 50%)",
-            }}
-          />
+          <MarketingBackdrop grid="right-center" glow="right-center" />
           <div className="relative p-8 sm:p-12 lg:p-16 flex flex-col lg:flex-row lg:items-center gap-8 lg:gap-16">
             <div className="flex flex-col gap-3 lg:flex-1">
               <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">

--- a/apps/web/app/(marketing)/legal/privacy/page.tsx
+++ b/apps/web/app/(marketing)/legal/privacy/page.tsx
@@ -1,22 +1,10 @@
+import { MarketingBackdrop } from "../../_components/backdrop"
+
 export default function PrivacyPage() {
   return (
     <div className="w-full bg-background flex flex-col relative min-h-screen">
       <div className="relative w-full overflow-hidden">
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            background: "radial-gradient(ellipse at 50% 80%, color-mix(in oklch, var(--primary) 12%, transparent) 0%, transparent 60%)",
-          }}
-        />
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            backgroundImage:
-              "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-            backgroundSize: "60px 60px",
-            maskImage: "radial-gradient(ellipse at 50% 100%, black 10%, transparent 60%)",
-          }}
-        />
+        <MarketingBackdrop grid="top-center" gridSize="md" glow="bottom-center" glowIntensity="lg" />
         <div className="relative max-w-3xl mx-auto px-4 pt-16 sm:pt-24 pb-16 sm:pb-20 flex flex-col items-center text-center gap-6">
           <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
             Legal

--- a/apps/web/app/(marketing)/legal/terms/page.tsx
+++ b/apps/web/app/(marketing)/legal/terms/page.tsx
@@ -1,22 +1,10 @@
+import { MarketingBackdrop } from "../../_components/backdrop"
+
 export default function TermsPage() {
   return (
     <div className="w-full bg-background flex flex-col relative min-h-screen">
       <div className="relative w-full overflow-hidden">
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            background: "radial-gradient(ellipse at 50% 80%, color-mix(in oklch, var(--primary) 12%, transparent) 0%, transparent 60%)",
-          }}
-        />
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            backgroundImage:
-              "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-            backgroundSize: "60px 60px",
-            maskImage: "radial-gradient(ellipse at 50% 100%, black 10%, transparent 60%)",
-          }}
-        />
+        <MarketingBackdrop grid="top-center" gridSize="md" glow="bottom-center" glowIntensity="lg" />
         <div className="relative max-w-3xl mx-auto px-4 pt-16 sm:pt-24 pb-16 sm:pb-20 flex flex-col items-center text-center gap-6">
           <span className="font-mono text-[11px] font-medium uppercase tracking-[1.5px] text-primary">
             Legal

--- a/apps/web/app/(marketing)/marketplace/agents/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/marketplace/agents/[slug]/page.tsx
@@ -69,19 +69,15 @@ function formatInstalls(count: number) {
 export default function DetailVariant1() {
   return (
     <div className="w-full bg-background flex flex-col relative min-h-screen">
-      {/* Hero */}
+      {/* Hero — DevOps category-tinted backdrop */}
       <div className="w-full relative overflow-hidden border-b border-border">
         <div
-          className="absolute inset-0 pointer-events-none"
-          style={{ background: "radial-gradient(ellipse at 30% 80%, oklch(0.55 0.15 250 / 14%) 0%, transparent 60%)" }}
+          aria-hidden="true"
+          className="absolute inset-0 pointer-events-none agent-detail-glow-devops"
         />
         <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            backgroundImage: "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-            backgroundSize: "60px 60px",
-            maskImage: "radial-gradient(ellipse at 30% 80%, black 10%, transparent 50%)",
-          }}
+          aria-hidden="true"
+          className="absolute inset-0 pointer-events-none marketing-grid marketing-grid-lg marketing-grid-mask-left-50"
         />
 
         <div className="max-w-6xl mx-auto w-full px-4 relative py-10 sm:py-14">

--- a/apps/web/app/(marketing)/marketplace/page.tsx
+++ b/apps/web/app/(marketing)/marketplace/page.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { Search01Icon, Download04Icon, CheckmarkBadge01Icon } from "@hugeicons/core-free-icons"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { MarketingBackdrop, MarketingGlow } from "../_components/backdrop"
 
 /**
  * Variant 1: "App Store"
@@ -70,20 +71,7 @@ export default function MarketplaceAppStore() {
       <div className="max-w-6xl mx-auto w-full px-4 pb-12">
         <Link href={`/marketplace/agents/${featuredAgent.slug}`} className="group block">
           <div className="relative rounded-3xl border border-border overflow-hidden hover:border-primary/40 transition-colors">
-            <div
-              className="absolute inset-0 pointer-events-none"
-              style={{
-                background: "radial-gradient(ellipse at 80% 50%, color-mix(in oklch, var(--primary) 10%, transparent) 0%, transparent 60%)",
-              }}
-            />
-            <div
-              className="absolute inset-0 pointer-events-none"
-              style={{
-                backgroundImage: "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-                backgroundSize: "60px 60px",
-                maskImage: "radial-gradient(ellipse at 80% 50%, black 10%, transparent 50%)",
-              }}
-            />
+            <MarketingBackdrop grid="right-50" gridSize="md" glow="right-far" glowIntensity="md-high" />
             <div className="relative p-8 sm:p-10 lg:p-14 flex flex-col gap-4 max-w-2xl">
               <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-background border border-border shadow-sm text-2xl mb-1">
                 {featuredAgent.icon}
@@ -178,7 +166,7 @@ export default function MarketplaceAppStore() {
       {/* CTA */}
       <div className="max-w-6xl mx-auto w-full px-4 pb-24">
         <div className="flex flex-col items-center gap-6 rounded-3xl border border-border p-12 text-center relative overflow-hidden">
-          <div className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(circle at 50% 100%, color-mix(in oklch, var(--primary) 6%, transparent) 0%, transparent 60%)" }} />
+          <MarketingGlow glow="bottom" glowIntensity="sm" />
           <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground relative">Build an agent, earn revenue</h2>
           <p className="text-muted-foreground max-w-md relative">Publish your agent to the marketplace and earn 50% of every install. Build once, earn forever.</p>
           <div className="flex gap-3 relative">
@@ -225,17 +213,18 @@ function AgentCard({ agent }: AgentCardProps) {
     >
       {/* Card header with gradient */}
       <div className="relative h-28 bg-muted/30 overflow-hidden border-b border-border/50">
+        {/*
+         * Inline style required — the gradient is chosen at runtime based on
+         * `agent.category`. Each category ships a distinct hue through the
+         * `categoryGradients` lookup, so Tailwind's static class extraction
+         * can't express it.
+         */}
         <div
           className="absolute inset-0"
           style={{ background: categoryGradients[agent.category] || defaultGradient }}
         />
         <div
-          className="absolute inset-0"
-          style={{
-            backgroundImage: "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-            backgroundSize: "24px 24px",
-            maskImage: "radial-gradient(ellipse at 70% 50%, black 10%, transparent 60%)",
-          }}
+          className="absolute inset-0 agent-card-grid"
         />
         {/* Agent icon */}
         <div className="absolute top-4 left-5 flex items-center justify-center w-11 h-11 rounded-xl bg-background border border-border shadow-sm text-xl">
@@ -247,10 +236,12 @@ function AgentCard({ agent }: AgentCardProps) {
               render={
                 <div className="flex items-center cursor-default">
                   {agent.integrations.slice(0, 4).map((integration, index) => (
+                    // zIndex is runtime-dependent so the first integration
+                    // stays on top as siblings overlap with negative margin.
                     <div
                       key={integration}
-                      className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-background bg-background text-[10px] font-bold text-muted-foreground shadow-sm"
-                      style={{ marginLeft: index > 0 ? "-6px" : 0, zIndex: agent.integrations.length - index }}
+                      className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-background bg-background text-[10px] font-bold text-muted-foreground shadow-sm first:ml-0 -ml-1.5"
+                      style={{ zIndex: agent.integrations.length - index }}
                     >
                       {integration[0]}
                     </div>

--- a/apps/web/app/(marketing)/page.tsx
+++ b/apps/web/app/(marketing)/page.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { Download04Icon, CheckmarkBadge01Icon } from "@hugeicons/core-free-icons"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { MarketingBackdrop, MarketingGlow } from "./_components/backdrop"
 
 const marketplaceAgents = [
   {
@@ -72,25 +73,8 @@ export default function Home() {
     <div className="w-full bg-background flex flex-col relative">
       <div className="flex flex-1 px-4 sm:px-6 lg:px-0">
         <div className="w-full max-w-424 lg:min-h-425 mx-auto relative overflow-hidden">
-          {/* Grid background */}
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              backgroundImage:
-                "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-              backgroundSize: "40px 40px",
-              maskImage:
-                "radial-gradient(ellipse at center, black, transparent 80%)",
-            }}
-          />
-          {/* Hero glow */}
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              background:
-                "radial-gradient(circle at 50% 40%, color-mix(in oklch, var(--primary) 12%, transparent) 0%, transparent 70%)",
-            }}
-          />
+          {/* Grid + hero glow */}
+          <MarketingBackdrop grid="hero" glow="hero" glowIntensity="lg" />
           <div className="relative flex flex-col items-center gap-6 sm:gap-8 pt-12 sm:pt-16 lg:pt-25 px-4 sm:px-8 lg:px-0">
             <div className="flex items-center gap-2 px-4 py-2 bg-muted border border-border rounded-full">
               <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
@@ -177,24 +161,7 @@ export default function Home() {
       {/* Value proposition: Replace subscriptions */}
       <section className="w-full px-4 sm:px-6 lg:px-0">
         <div className="w-full max-w-424 mx-auto relative">
-          {/* Grid background */}
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              backgroundImage:
-                "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-              backgroundSize: "40px 40px",
-              maskImage:
-                "radial-gradient(ellipse at center, black, transparent 70%)",
-            }}
-          />
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              background:
-                "radial-gradient(circle at 50% 50%, color-mix(in oklch, var(--primary) 8%, transparent) 0%, transparent 60%)",
-            }}
-          />
+          <MarketingBackdrop grid="center" glow="center" />
 
           <div className="relative flex flex-col items-center gap-10 sm:gap-14 pb-20 sm:pb-28 lg:pb-36">
             {/* Section header */}
@@ -425,23 +392,7 @@ export default function Home() {
       {/* Marketplace */}
       <section className="w-full px-4 sm:px-6 lg:px-0">
         <div className="w-full max-w-424 mx-auto relative">
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              backgroundImage:
-                "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-              backgroundSize: "40px 40px",
-              maskImage:
-                "radial-gradient(ellipse at center, black, transparent 70%)",
-            }}
-          />
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              background:
-                "radial-gradient(circle at 50% 40%, color-mix(in oklch, var(--primary) 8%, transparent) 0%, transparent 60%)",
-            }}
-          />
+          <MarketingBackdrop grid="center" glow="top-center" />
 
           <div className="relative flex flex-col items-center gap-10 sm:gap-14 pb-20 sm:pb-28 lg:pb-36">
             {/* Section header */}
@@ -476,10 +427,15 @@ export default function Home() {
                         render={
                           <div className="flex items-center cursor-default">
                             {agent.integrations.map((integration, index) => (
+                              // Inline style keeps index-driven stacking:
+                              // negative margin overlaps siblings and zIndex
+                              // reverses the stacking so earlier items sit on
+                              // top. Both values depend on the runtime index
+                              // and can't be expressed as static Tailwind.
                               <div
                                 key={integration}
-                                className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-background bg-muted text-[9px] font-bold text-muted-foreground"
-                                style={{ marginLeft: index > 0 ? "-8px" : 0, zIndex: agent.integrations.length - index }}
+                                className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-background bg-muted text-[9px] font-bold text-muted-foreground first:ml-0 -ml-2"
+                                style={{ zIndex: agent.integrations.length - index }}
                               >
                                 {integration[0]}
                               </div>
@@ -544,23 +500,7 @@ export default function Home() {
       {/* Agent Forger */}
       <section className="w-full px-4 sm:px-6 lg:px-0">
         <div className="w-full max-w-424 mx-auto relative">
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              backgroundImage:
-                "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-              backgroundSize: "40px 40px",
-              maskImage:
-                "radial-gradient(ellipse at center, black, transparent 70%)",
-            }}
-          />
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              background:
-                "radial-gradient(circle at 50% 30%, color-mix(in oklch, var(--primary) 8%, transparent) 0%, transparent 60%)",
-            }}
-          />
+          <MarketingBackdrop grid="center" glow="center-high" />
 
           <div className="relative flex flex-col items-center gap-10 sm:gap-14 pb-20 sm:pb-28 lg:pb-36">
             {/* Section header */}
@@ -690,23 +630,7 @@ export default function Home() {
       {/* Platform features */}
       <section className="w-full px-4 sm:px-6 lg:px-0">
         <div className="w-full max-w-424 mx-auto relative">
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              backgroundImage:
-                "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-              backgroundSize: "40px 40px",
-              maskImage:
-                "radial-gradient(ellipse at center, black, transparent 70%)",
-            }}
-          />
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              background:
-                "radial-gradient(circle at 50% 50%, color-mix(in oklch, var(--primary) 8%, transparent) 0%, transparent 60%)",
-            }}
-          />
+          <MarketingBackdrop grid="center" glow="center" />
 
           <div className="relative flex flex-col items-center gap-10 sm:gap-14 pb-20 sm:pb-28 lg:pb-36">
             {/* Section header */}
@@ -812,23 +736,7 @@ export default function Home() {
       {/* Pricing */}
       <section className="w-full px-4 sm:px-6 lg:px-0">
         <div className="w-full max-w-424 mx-auto relative">
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              backgroundImage:
-                "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-              backgroundSize: "40px 40px",
-              maskImage:
-                "radial-gradient(ellipse at center, black, transparent 70%)",
-            }}
-          />
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              background:
-                "radial-gradient(circle at 50% 40%, color-mix(in oklch, var(--primary) 8%, transparent) 0%, transparent 60%)",
-            }}
-          />
+          <MarketingBackdrop grid="center" glow="top-center" />
 
           <div className="relative flex flex-col items-center gap-10 sm:gap-14 pb-20 sm:pb-28 lg:pb-36">
             {/* Section header */}
@@ -904,13 +812,7 @@ export default function Home() {
 
               {/* Pro */}
               <div className="flex flex-col rounded-2xl border-2 border-primary/30 bg-background p-8 gap-6 relative overflow-hidden">
-                <div
-                  className="absolute inset-0 pointer-events-none"
-                  style={{
-                    background:
-                      "radial-gradient(circle at 50% 0%, color-mix(in oklch, var(--primary) 8%, transparent) 0%, transparent 60%)",
-                  }}
-                />
+                <MarketingGlow glow="top" />
                 <div className="flex flex-col gap-4 relative">
                   <span className="font-mono text-[11px] font-medium uppercase tracking-[1px] text-primary">
                     Pro
@@ -984,23 +886,7 @@ export default function Home() {
       <section className="w-full px-4 sm:px-6 lg:px-0">
         <div className="w-full max-w-424 mx-auto relative pb-20 sm:pb-28 lg:pb-36">
           <div className="relative flex flex-col items-center gap-8 rounded-4xl border border-border ring-1 ring-foreground/5 p-10 sm:p-16 lg:p-20 text-center overflow-hidden max-w-5xl mx-auto shadow-[0_0_60px_-20px_color-mix(in_oklch,var(--primary)_12%,transparent),0_0_20px_-10px_color-mix(in_oklch,var(--primary)_8%,transparent)]">
-            <div
-              className="absolute inset-0 pointer-events-none"
-              style={{
-                background:
-                  "radial-gradient(circle at 50% 100%, color-mix(in oklch, var(--primary) 10%, transparent) 0%, transparent 60%)",
-              }}
-            />
-            <div
-              className="absolute inset-0 pointer-events-none"
-              style={{
-                backgroundImage:
-                  "linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px)",
-                backgroundSize: "40px 40px",
-                maskImage:
-                  "radial-gradient(ellipse at center bottom, black 20%, transparent 70%)",
-              }}
-            />
+            <MarketingBackdrop grid="bottom" glow="bottom" glowIntensity="md-high" />
             <h2 className="relative font-heading text-[24px] sm:text-[32px] lg:text-[44px] font-bold text-foreground leading-[1.15] -tracking-[0.5px] sm:-tracking-[1px]">
               Stop subscribing.{" "}
               <br className="hidden sm:block" />

--- a/apps/web/app/(marketing)/pricing/page.tsx
+++ b/apps/web/app/(marketing)/pricing/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { Tick02Icon, Cancel01Icon } from "@hugeicons/core-free-icons"
+import { MarketingGlow } from "../_components/backdrop"
 
 function Check() {
   return <HugeiconsIcon icon={Tick02Icon} size={16} className="text-green-500 shrink-0" />
@@ -60,12 +61,7 @@ export default function PricingPage() {
 
           {/* Pro Plan */}
           <div className="flex flex-col rounded-2xl border-2 border-primary/30 p-8 gap-8 relative overflow-hidden">
-            <div
-              className="absolute inset-0 pointer-events-none"
-              style={{
-                background: "radial-gradient(circle at 50% 0%, color-mix(in oklch, var(--primary) 8%, transparent) 0%, transparent 60%)",
-              }}
-            />
+            <MarketingGlow glow="top" />
             <div className="flex flex-col gap-4 relative">
               <span className="font-mono text-[11px] font-medium uppercase tracking-[1px] text-primary">Pro</span>
               <div className="flex items-baseline gap-1">
@@ -161,12 +157,7 @@ export default function PricingPage() {
             </div>
 
             <div className="rounded-2xl border-2 border-primary/30 p-6 flex flex-col gap-4 relative overflow-hidden">
-              <div
-                className="absolute inset-0 pointer-events-none"
-                style={{
-                  background: "radial-gradient(circle at 50% 0%, color-mix(in oklch, var(--primary) 6%, transparent) 0%, transparent 60%)",
-                }}
-              />
+              <MarketingGlow glow="top" glowIntensity="sm" />
               <span className="font-mono text-[10px] font-medium uppercase tracking-[1px] text-primary relative">Pro (shared sandbox)</span>
               <div className="flex flex-col gap-2 relative">
                 <div className="flex items-center justify-between">
@@ -330,12 +321,7 @@ export default function PricingPage() {
       {/* CTA */}
       <div className="max-w-5xl mx-auto w-full px-4 pb-24">
         <div className="flex flex-col items-center gap-6 rounded-2xl border border-border p-12 text-center relative overflow-hidden">
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              background: "radial-gradient(circle at 50% 100%, color-mix(in oklch, var(--primary) 6%, transparent) 0%, transparent 60%)",
-            }}
-          />
+          <MarketingGlow glow="bottom" glowIntensity="sm" />
           <h2 className="font-heading text-2xl sm:text-3xl font-bold text-foreground relative">Ready to build?</h2>
           <p className="text-muted-foreground max-w-md relative">
             Start with the free plan and upgrade when you need production features.

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -14,10 +14,16 @@
 
 @theme {
     --font-heading: var(--font-bricolage), "Bricolage Grotesque", system-ui, sans-serif;
+    /* The Sora wordmark stack — consumed via `font-wordmark` in `<Logo>`. */
+    --font-wordmark: var(--font-sora), sans-serif;
 }
 
 @theme inline {
     --font-sans: var(--font-sans);
+    /* Background for rendered code blocks. Matches the OneDark syntax theme
+     * used by `react-syntax-highlighter` in `skill-detail-dialog` so the
+     * surrounding <pre> wrapper blends with the highlighted tokens. */
+    --color-code-background: var(--code-background);
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -91,6 +97,7 @@
     --sidebar-accent-foreground: oklch(0.214 0.009 43.1);
     --sidebar-border: oklch(0.922 0.005 34.3);
     --sidebar-ring: oklch(0.714 0.014 41.2);
+    --code-background: #282c34;
 }
 
 .dark {
@@ -125,6 +132,7 @@
     --sidebar-accent-foreground: oklch(0.986 0.002 67.8);
     --sidebar-border: oklch(1 0 0 / 10%);
     --sidebar-ring: oklch(0.547 0.021 43.1);
+    --code-background: #282c34;
 }
 
 @layer base {
@@ -150,4 +158,137 @@
 
 [data-streamdown="heading-2"] {
   font-size: 16px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Marketing backdrop utilities
+ *
+ * Reusable grid-lines + radial-glow backgrounds used across every marketing
+ * section. Centralising them here replaces dozens of repeated `style={{}}`
+ * inline-style blocks on marketing pages with a single `<MarketingBackdrop>`
+ * component that composes these classes.
+ * ------------------------------------------------------------------------- */
+.marketing-grid {
+  background-image:
+    linear-gradient(var(--border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border) 1px, transparent 1px);
+  background-size: 40px 40px;
+}
+
+.marketing-grid-lg {
+  background-size: 60px 60px;
+}
+
+/*
+ * Agent-detail hero uses a DevOps-blue tint instead of the primary accent
+ * (matches the category palette used in marketplace cards). Fades from the
+ * lower-left because the agent icon sits top-left.
+ */
+.agent-detail-glow-devops {
+  background: radial-gradient(ellipse at 30% 80%, oklch(0.55 0.15 250 / 14%) 0%, transparent 60%);
+}
+
+/*
+ * Smaller grid (24px cells) used inside marketplace agent cards. Applied
+ * directly because only one component uses it and the mask is fixed.
+ */
+.agent-card-grid {
+  background-image:
+    linear-gradient(var(--border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border) 1px, transparent 1px);
+  background-size: 24px 24px;
+  -webkit-mask-image: radial-gradient(ellipse at 70% 50%, black 10%, transparent 60%);
+          mask-image: radial-gradient(ellipse at 70% 50%, black 10%, transparent 60%);
+}
+
+.marketing-grid-mask-center {
+  -webkit-mask-image: radial-gradient(ellipse at center, black, transparent 70%);
+          mask-image: radial-gradient(ellipse at center, black, transparent 70%);
+}
+.marketing-grid-mask-hero {
+  -webkit-mask-image: radial-gradient(ellipse at center, black, transparent 80%);
+          mask-image: radial-gradient(ellipse at center, black, transparent 80%);
+}
+
+.marketing-grid-mask-bottom {
+  -webkit-mask-image: radial-gradient(ellipse at center bottom, black 20%, transparent 70%);
+          mask-image: radial-gradient(ellipse at center bottom, black 20%, transparent 70%);
+}
+
+.marketing-grid-mask-left-bottom {
+  -webkit-mask-image: radial-gradient(ellipse at 30% 50%, black 10%, transparent 60%);
+          mask-image: radial-gradient(ellipse at 30% 50%, black 10%, transparent 60%);
+}
+
+.marketing-grid-mask-right-center {
+  -webkit-mask-image: radial-gradient(ellipse at 70% 50%, black 10%, transparent 50%);
+          mask-image: radial-gradient(ellipse at 70% 50%, black 10%, transparent 50%);
+}
+.marketing-grid-mask-right-50 {
+  -webkit-mask-image: radial-gradient(ellipse at 80% 50%, black 10%, transparent 50%);
+          mask-image: radial-gradient(ellipse at 80% 50%, black 10%, transparent 50%);
+}
+.marketing-grid-mask-right-60 {
+  -webkit-mask-image: radial-gradient(ellipse at 70% 50%, black 10%, transparent 60%);
+          mask-image: radial-gradient(ellipse at 70% 50%, black 10%, transparent 60%);
+}
+.marketing-grid-mask-left-50 {
+  -webkit-mask-image: radial-gradient(ellipse at 30% 80%, black 10%, transparent 50%);
+          mask-image: radial-gradient(ellipse at 30% 80%, black 10%, transparent 50%);
+}
+
+.marketing-grid-mask-top-center {
+  -webkit-mask-image: radial-gradient(ellipse at 50% 100%, black 10%, transparent 60%);
+          mask-image: radial-gradient(ellipse at 50% 100%, black 10%, transparent 60%);
+}
+
+/* Glow intensity — `--glow` is the `color-mix` tint used by each position. */
+.marketing-glow-sm {
+  --glow: color-mix(in oklch, var(--primary) 6%, transparent);
+}
+.marketing-glow-md {
+  --glow: color-mix(in oklch, var(--primary) 8%, transparent);
+}
+.marketing-glow-md-high {
+  --glow: color-mix(in oklch, var(--primary) 10%, transparent);
+}
+.marketing-glow-lg {
+  --glow: color-mix(in oklch, var(--primary) 12%, transparent);
+}
+
+.marketing-glow-top {
+  background: radial-gradient(circle at 50% 0%, var(--glow) 0%, transparent 60%);
+}
+.marketing-glow-top-center {
+  background: radial-gradient(circle at 50% 40%, var(--glow) 0%, transparent 60%);
+}
+.marketing-glow-hero {
+  background: radial-gradient(circle at 50% 40%, var(--glow) 0%, transparent 70%);
+}
+.marketing-glow-center {
+  background: radial-gradient(circle at 50% 50%, var(--glow) 0%, transparent 60%);
+}
+.marketing-glow-center-high {
+  background: radial-gradient(circle at 50% 30%, var(--glow) 0%, transparent 60%);
+}
+.marketing-glow-bottom {
+  background: radial-gradient(circle at 50% 100%, var(--glow) 0%, transparent 60%);
+}
+.marketing-glow-bottom-center {
+  background: radial-gradient(ellipse at 50% 80%, var(--glow) 0%, transparent 60%);
+}
+.marketing-glow-left-bottom {
+  background: radial-gradient(ellipse at 30% 50%, var(--glow) 0%, transparent 70%);
+}
+.marketing-glow-right-center {
+  background: radial-gradient(ellipse at 70% 50%, var(--glow) 0%, transparent 60%);
+}
+.marketing-glow-right-far {
+  background: radial-gradient(ellipse at 80% 50%, var(--glow) 0%, transparent 60%);
+}
+.marketing-glow-right-wide {
+  background: radial-gradient(circle at 70% 50%, var(--glow) 0%, transparent 70%);
+}
+.marketing-glow-left-bottom-far {
+  background: radial-gradient(ellipse at 30% 80%, var(--glow) 0%, transparent 60%);
 }

--- a/apps/web/app/w/agents/[id]/_components/run-panel.tsx
+++ b/apps/web/app/w/agents/[id]/_components/run-panel.tsx
@@ -154,8 +154,9 @@ function ToolCallEvent({ event }: { event: RunEvent }) {
       </button>
 
       <div
-        className="grid transition-all duration-200 ease-out"
-        style={{ gridTemplateRows: expanded ? "1fr" : "0fr" }}
+        className={`grid transition-all duration-200 ease-out ${
+          expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        }`}
       >
         <div className="overflow-hidden">
           <div className="border-t border-border px-4 py-3 flex flex-col gap-3">
@@ -234,8 +235,9 @@ function ApprovalEvent({ event }: { event: RunEvent }) {
       </button>
 
       <div
-        className="grid transition-all duration-200 ease-out"
-        style={{ gridTemplateRows: expanded ? "1fr" : "0fr" }}
+        className={`grid transition-all duration-200 ease-out ${
+          expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        }`}
       >
         <div className="overflow-hidden">
           <div className={`border-t px-4 py-3 flex flex-col gap-3 ${isPending ? "border-yellow-500/20" : "border-border"}`}>

--- a/apps/web/app/w/agents/[id]/conversations/layout.tsx
+++ b/apps/web/app/w/agents/[id]/conversations/layout.tsx
@@ -30,8 +30,7 @@ function ConversationItem({ conversation, isActive, onClick, index }: {
       {isActive && (
         <motion.div
           layoutId="active-pill"
-          className="absolute inset-0 rounded-xl bg-primary/8 border border-primary/12"
-          style={{ zIndex: -1 }}
+          className="absolute inset-0 rounded-xl bg-primary/8 border border-primary/12 -z-[1]"
           transition={{ type: "spring", stiffness: 500, damping: 35 }}
         />
       )}

--- a/apps/web/app/w/agents/_components/create-agent/step-integrations.tsx
+++ b/apps/web/app/w/agents/_components/create-agent/step-integrations.tsx
@@ -307,20 +307,19 @@ function ActionDetailView({
             <p className="text-sm text-muted-foreground">No actions found.</p>
           </div>
         ) : (
-          <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+          // `height` comes from TanStack Virtual — recomputed per render from
+          // row count × estimated row size and changes on scroll/filter.
+          <div className="relative" style={{ height: virtualizer.getTotalSize() }}>
             {virtualizer.getVirtualItems().map((virtualItem) => {
               const action = filteredActions[virtualItem.index]
               const isSelected = selectedActions.has(action.key!)
               return (
+                // `translateY` is the row's live scroll offset from the
+                // virtualizer and changes every frame.
                 <div
                   key={action.key}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    transform: `translateY(${virtualItem.start}px)`,
-                  }}
+                  className="absolute top-0 left-0 w-full"
+                  style={{ transform: `translateY(${virtualItem.start}px)` }}
                 >
                   <button
                     type="button"

--- a/apps/web/app/w/agents/_components/integration-stack.tsx
+++ b/apps/web/app/w/agents/_components/integration-stack.tsx
@@ -7,13 +7,12 @@ export function IntegrationStack({ integrations }: { integrations: string[] }) {
         render={
           <div className="flex items-center cursor-default">
             {integrations.map((integration, i) => (
+              // zIndex depends on the integration's index so earlier ones sit
+              // on top as `-ml-1.5` overlaps the stack.
               <div
                 key={integration}
-                className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-background bg-muted text-[8px] font-bold text-muted-foreground"
-                style={{
-                  marginLeft: i > 0 ? "-6px" : 0,
-                  zIndex: integrations.length - i,
-                }}
+                className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-background bg-muted text-[8px] font-bold text-muted-foreground first:ml-0 -ml-1.5"
+                style={{ zIndex: integrations.length - i }}
               >
                 {integration[0]}
               </div>

--- a/apps/web/app/w/agents/_components/manage-integrations-dialog.tsx
+++ b/apps/web/app/w/agents/_components/manage-integrations-dialog.tsx
@@ -441,26 +441,24 @@ function ActionDetailView({
             <p className="text-sm text-muted-foreground">No actions found.</p>
           </div>
         ) : (
+          // `height` is computed live by TanStack Virtual from the current
+          // row count × estimated row size; it changes on every scroll and
+          // filter edit, so it can't be expressed as a static Tailwind class.
           <div
-            style={{
-              height: virtualizer.getTotalSize(),
-              position: "relative",
-            }}
+            className="relative"
+            style={{ height: virtualizer.getTotalSize() }}
           >
             {virtualizer.getVirtualItems().map((virtualItem) => {
               const action = filteredActions[virtualItem.index]
               const actionKey = action.key ?? ""
               const isSelected = selectedActions.has(actionKey)
               return (
+                // `translateY` is the row's computed scroll offset — truly
+                // dynamic per-frame data from the virtualizer.
                 <div
                   key={actionKey}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    transform: `translateY(${virtualItem.start}px)`,
-                  }}
+                  className="absolute top-0 left-0 w-full"
+                  style={{ transform: `translateY(${virtualItem.start}px)` }}
                 >
                   <button
                     type="button"

--- a/apps/web/app/w/settings/_components/billing-settings.tsx
+++ b/apps/web/app/w/settings/_components/billing-settings.tsx
@@ -144,10 +144,8 @@ export function BillingSettings() {
 
         <div className="rounded-xl border-2 border-primary/30 p-5 space-y-3 relative overflow-hidden">
           <div
-            className="absolute inset-0 pointer-events-none"
-            style={{
-              background: "radial-gradient(circle at 50% 0%, color-mix(in oklch, var(--primary) 6%, transparent) 0%, transparent 60%)",
-            }}
+            aria-hidden="true"
+            className="absolute inset-0 pointer-events-none marketing-glow-top marketing-glow-sm"
           />
           <div className="relative">
             <p className="text-sm font-medium text-foreground">Pro Dedicated</p>

--- a/apps/web/app/w/settings/_components/skill-detail-dialog.tsx
+++ b/apps/web/app/w/settings/_components/skill-detail-dialog.tsx
@@ -128,6 +128,8 @@ function FileTreeItem({ node, depth, selectedPath, onSelect }: FileTreeItemProps
           type="button"
           onClick={() => setExpanded(!expanded)}
           className="flex items-center gap-2 w-full px-2 py-1.5 text-left text-xs text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-lg transition-colors cursor-pointer"
+          // paddingLeft is runtime-computed from tree `depth` to indent nested
+          // nodes; Tailwind can't extract a dynamic numeric value.
           style={{ paddingLeft: `${depth * 12 + 8}px` }}
         >
           <HugeiconsIcon icon={Folder01Icon} size={14} className="shrink-0 text-muted-foreground" />
@@ -156,6 +158,8 @@ function FileTreeItem({ node, depth, selectedPath, onSelect }: FileTreeItemProps
           ? "bg-primary/10 text-foreground"
           : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
       )}
+      // paddingLeft is runtime-computed from tree `depth` to indent nested
+      // nodes; Tailwind can't extract a dynamic numeric value.
       style={{ paddingLeft: `${depth * 12 + 8}px` }}
     >
       <HugeiconsIcon icon={File01Icon} size={14} className="shrink-0" />
@@ -170,7 +174,7 @@ interface MarkdownViewerProps {
 
 function MarkdownViewer({ content }: MarkdownViewerProps) {
   return (
-    <div className="prose prose-sm dark:prose-invert max-w-none prose-headings:font-heading prose-h1:text-xl prose-h2:text-lg prose-h3:text-base prose-p:text-sm prose-p:leading-relaxed prose-li:text-sm prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-pre:bg-[#282c34] prose-pre:rounded-xl prose-table:text-sm prose-th:text-xs prose-td:text-xs">
+    <div className="prose prose-sm dark:prose-invert max-w-none prose-headings:font-heading prose-h1:text-xl prose-h2:text-lg prose-h3:text-base prose-p:text-sm prose-p:leading-relaxed prose-li:text-sm prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-pre:bg-code-background prose-pre:rounded-xl prose-table:text-sm prose-th:text-xs prose-td:text-xs">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{

--- a/apps/web/components/integration-logos.tsx
+++ b/apps/web/components/integration-logos.tsx
@@ -30,16 +30,21 @@ export function IntegrationLogos({ integrations, max = 4, size = 20, className }
       <TooltipTrigger
         render={
           <div className={cn("flex items-center justify-center cursor-default w-fit", className)}>
-            {visible.map((integration, i) => (
+            {visible.map((integration) => (
+              // marginLeft scales with the `size` prop (30%), so earlier
+              // logos overlap later ones. Values come from component props,
+              // not design tokens, so Tailwind can't express this statically.
+              // The `first:ml-0` Tailwind utility handles the leading item.
               <div
                 key={integration.provider}
-                className="rounded-full border-2 border-background"
-                style={{ marginLeft: i === 0 ? 0 : -(size * 0.3) }}
+                className="rounded-full border-2 border-background first:ml-0"
+                style={{ marginLeft: -(size * 0.3) }}
               >
                 <IntegrationLogo provider={integration.provider} size={size} />
               </div>
             ))}
             {overflow > 0 && (
+              // Width/height/margin all scale with the prop-driven `size`.
               <span
                 className="flex items-center justify-center rounded-full border-2 border-background bg-muted text-[10px] font-medium text-muted-foreground"
                 style={{

--- a/apps/web/components/logo.tsx
+++ b/apps/web/components/logo.tsx
@@ -21,7 +21,7 @@ export function Logo({ className = "h-8" }: { className?: string }) {
   return (
     <div className={`flex items-center gap-2.5 ${className}`}>
       <LogoMark className="h-full w-auto shrink-0" />
-      <span className="font-semibold tracking-tight text-foreground text-lg" style={{ fontFamily: "var(--font-sora), sans-serif" }}>
+      <span className="font-semibold tracking-tight text-foreground text-lg font-wordmark">
         hiveloop
       </span>
     </div>

--- a/apps/web/components/ui/chart.tsx
+++ b/apps/web/components/ui/chart.tsx
@@ -312,11 +312,11 @@ function ChartLegendContent({
               {itemConfig?.icon && !hideIcon ? (
                 <itemConfig.icon />
               ) : (
+                // Colour comes from the Recharts legend payload — one colour
+                // per series, assigned at runtime.
                 <div
                   className="h-2 w-2 shrink-0 rounded-[2px]"
-                  style={{
-                    backgroundColor: item.color,
-                  }}
+                  style={{ backgroundColor: item.color }}
                 />
               )}
               {itemConfig?.label}

--- a/apps/web/components/ui/toggle-group.tsx
+++ b/apps/web/components/ui/toggle-group.tsx
@@ -40,6 +40,9 @@ function ToggleGroup({
       data-size={size}
       data-spacing={spacing}
       data-orientation={orientation}
+      // `--gap` is a CSS custom property fed by the runtime `spacing` prop and
+      // consumed by the `gap-[--spacing(var(--gap))]` class below. The value
+      // can't be a static Tailwind class because it's chosen at call-site.
       style={{ "--gap": spacing } as React.CSSProperties}
       className={cn(
         "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] data-[spacing=0]:data-[variant=outline]:rounded-3xl data-vertical:flex-col data-vertical:items-stretch",


### PR DESCRIPTION
## Summary

- Introduces reusable `<MarketingBackdrop>` / `<MarketingGlow>` components (in `app/(marketing)/_components/backdrop.tsx`) backed by CSS utility classes in `globals.css`. This replaces ~35 repeated `style={{}}` blocks that painted the same grid-lines + radial-glow pattern across the home, marketplace, blog, legal, pricing, and agent-detail pages.
- Replaces the remaining ad-hoc inline styles (grid-template-rows toggles, `z-index: -1`, Sora wordmark fontFamily, `#282c34` prose code background, `width: 0%` initial value) with Tailwind utilities or new theme tokens.
- Adds two theme tokens: `--color-code-background` (replaces the hardcoded `#282c34` in `skill-detail-dialog.tsx`) and `--font-wordmark` (for the Sora logo wordmark). Both documented inline in `globals.css`.
- Leaves the 14 genuinely-dynamic `style={{}}` usages intact (TanStack Virtual row offsets/heights, tree-depth padding, index-driven `zIndex`, category-keyed gradients in marketplace cards, prop-scaled margins in `IntegrationLogos`, Recharts legend colors, scroll-driven progress width). Each now carries a short comment explaining why Tailwind cannot express it statically.

## Test plan

- [x] `pnpm --filter web typecheck` — passes
- [x] `pnpm --filter web lint` — unchanged from `origin/main` baseline (same pre-existing errors/warnings, zero new ones)
- [ ] Visual smoke: marketing home hero glow, marketplace featured card glow, blog featured card, blog post hero, legal pages, pricing Pro card, billing settings upgrade card all render identically
- [ ] Run panel expand/collapse animation still smooths `grid-template-rows: 0fr` → `1fr`
- [ ] Reading progress bar fills as expected on blog post scroll
- [ ] Skill detail dialog code blocks still render with the OneDark-matching background

Closes #91