### PR TITLE
refactor(frontend): migrate raw fetch/useQuery calls to $api hooks

### DIFF
--- a/apps/web/app/w/agents/_components/configure-resources-dialog.tsx
+++ b/apps/web/app/w/agents/_components/configure-resources-dialog.tsx
@@ -19,7 +19,6 @@ import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { ChoiceCard } from "./create-agent/choice-card"
 import { $api } from "@/lib/api/hooks"
-import { api } from "@/lib/api/client"
 import { useQueryClient, useQueries } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { extractErrorMessage } from "@/lib/api/error"
@@ -363,18 +362,14 @@ export function ConfigureResourcesDialog({ open, onOpenChange, agent: agentProp 
   }, [resources])
 
   const reachabilityQueries = useQueries({
-    queries: statePairs.map(({ connId, resourceType }) => ({
-      queryKey: ["resources-reachability", connId, resourceType],
-      queryFn: async () => {
-        const res = await api.GET("/v1/in/connections/{id}/resources/{type}", {
-          params: { path: { id: connId, type: resourceType } },
-        })
-        if (res.error) throw res.error
-        return res.data
-      },
-      enabled: open,
-      staleTime: 60_000,
-    })),
+    queries: statePairs.map(({ connId, resourceType }) =>
+      $api.queryOptions(
+        "get",
+        "/v1/in/connections/{id}/resources/{type}",
+        { params: { path: { id: connId, type: resourceType } } },
+        { enabled: open, staleTime: 60_000 },
+      ),
+    ),
   })
 
   const reachableSets = useMemo(() => {

--- a/apps/web/app/w/connections/_hooks/use-connect-integration.ts
+++ b/apps/web/app/w/connections/_hooks/use-connect-integration.ts
@@ -1,10 +1,10 @@
 "use client"
 
 import { useState } from "react"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import Nango, { AuthError } from "@nangohq/frontend"
 import { toast } from "sonner"
-import { api } from "@/lib/api/client"
+import { $api } from "@/lib/api/hooks"
 import { extractErrorMessage } from "@/lib/api/error"
 
 interface ConnectOptions {
@@ -17,22 +17,42 @@ export function useConnectIntegration() {
   const queryClient = useQueryClient()
   const [connectingId, setConnectingId] = useState<string | null>(null)
 
-  const mutation = useMutation({
-    mutationFn: async ({
-      integrationId,
-      options,
-    }: {
-      integrationId: string
-      options?: ConnectOptions
-    }) => {
-      const session = await api.POST("/v1/in/integrations/{id}/connect-session", {
+  // Two typed $api mutations are composed into a single connect flow: create a
+  // Nango connect-session, run the Nango auth popup, then persist the resulting
+  // connection. mutateAsync lets us sequence them with the external SDK call in
+  // between without falling back to a raw useMutation + api.POST.
+  const createSession = $api.useMutation(
+    "post",
+    "/v1/in/integrations/{id}/connect-session",
+  )
+  const saveConnection = $api.useMutation(
+    "post",
+    "/v1/in/integrations/{id}/connections",
+  )
+
+  async function connect(
+    integrationId: string,
+    optionsOrOnSuccess?: ConnectOptions & { onSuccess?: () => void } | (() => void),
+  ) {
+    let options: ConnectOptions | undefined
+    let onSuccess: (() => void) | undefined
+
+    if (typeof optionsOrOnSuccess === "function") {
+      onSuccess = optionsOrOnSuccess
+    } else if (optionsOrOnSuccess) {
+      const { onSuccess: onSuccessFn, ...rest } = optionsOrOnSuccess
+      onSuccess = onSuccessFn
+      if (Object.keys(rest).length > 0) options = rest
+    }
+
+    setConnectingId(integrationId)
+    try {
+      const session = await createSession.mutateAsync({
         params: { path: { id: integrationId } },
       })
 
-      if (session.error) throw new Error("Failed to create session")
-
       const { token, provider_config_key: providerConfigKey } =
-        session.data as { token: string; provider_config_key: string }
+        session as { token: string; provider_config_key: string }
 
       const nango = new Nango({
         connectSessionToken: token,
@@ -48,47 +68,20 @@ export function useConnectIntegration() {
         ? await nango.auth(providerConfigKey, authOptions)
         : await nango.auth(providerConfigKey)
 
-      const connection = await api.POST("/v1/in/integrations/{id}/connections", {
+      await saveConnection.mutateAsync({
         params: { path: { id: integrationId } },
         body: { nango_connection_id: authResult.connectionId } as never,
       })
 
-      if (connection.error) throw new Error("Failed to save connection")
-
-      return connection.data
-    },
-    onMutate: ({ integrationId }) => {
-      setConnectingId(integrationId)
-    },
-    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["get", "/v1/in/connections"] })
       toast.success("Connection added successfully")
-    },
-    onError: (error) => {
+      onSuccess?.()
+    } catch (error) {
       if (error instanceof AuthError && error.type === "window_closed") return
       toast.error(extractErrorMessage(error, "Connection failed. Please try again."))
-    },
-    onSettled: () => {
+    } finally {
       setConnectingId(null)
-    },
-  })
-
-  function connect(
-    integrationId: string,
-    optionsOrOnSuccess?: ConnectOptions & { onSuccess?: () => void } | (() => void),
-  ) {
-    let options: ConnectOptions | undefined
-    let onSuccess: (() => void) | undefined
-
-    if (typeof optionsOrOnSuccess === "function") {
-      onSuccess = optionsOrOnSuccess
-    } else if (optionsOrOnSuccess) {
-      const { onSuccess: onSuccessFn, ...rest } = optionsOrOnSuccess
-      onSuccess = onSuccessFn
-      if (Object.keys(rest).length > 0) options = rest
     }
-
-    mutation.mutate({ integrationId, options }, { onSuccess })
   }
 
   return { connect, connectingId }

--- a/apps/web/app/w/connections/_hooks/use-reconnect-integration.ts
+++ b/apps/web/app/w/connections/_hooks/use-reconnect-integration.ts
@@ -1,26 +1,32 @@
 "use client"
 
 import { useState } from "react"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import Nango, { AuthError } from "@nangohq/frontend"
 import { toast } from "sonner"
-import { api } from "@/lib/api/client"
+import { $api } from "@/lib/api/hooks"
 import { extractErrorMessage } from "@/lib/api/error"
 
 export function useReconnectIntegration() {
   const queryClient = useQueryClient()
   const [reconnectingId, setReconnectingId] = useState<string | null>(null)
 
-  const mutation = useMutation({
-    mutationFn: async ({ connectionId }: { connectionId: string }) => {
-      const session = await api.POST("/v1/in/connections/{id}/reconnect-session", {
+  // Typed $api mutation sequenced with a Nango reconnect() call — composed
+  // rather than wrapped in a raw useMutation + api.POST.
+  const createReconnectSession = $api.useMutation(
+    "post",
+    "/v1/in/connections/{id}/reconnect-session",
+  )
+
+  async function reconnect(connectionId: string) {
+    setReconnectingId(connectionId)
+    try {
+      const session = await createReconnectSession.mutateAsync({
         params: { path: { id: connectionId } },
       })
 
-      if (session.error) throw new Error("Failed to create reconnect session")
-
       const { token, provider_config_key: providerConfigKey } =
-        session.data as { token: string; provider_config_key: string }
+        session as { token: string; provider_config_key: string }
 
       const nango = new Nango({
         connectSessionToken: token,
@@ -28,25 +34,15 @@ export function useReconnectIntegration() {
       })
 
       await nango.reconnect(providerConfigKey)
-    },
-    onMutate: ({ connectionId }) => {
-      setReconnectingId(connectionId)
-    },
-    onSuccess: () => {
+
       queryClient.invalidateQueries({ queryKey: ["get", "/v1/in/connections"] })
       toast.success("Connection refreshed successfully")
-    },
-    onError: (error) => {
+    } catch (error) {
       if (error instanceof AuthError && error.type === "window_closed") return
       toast.error(extractErrorMessage(error, "Reconnect failed. Please try again."))
-    },
-    onSettled: () => {
+    } finally {
       setReconnectingId(null)
-    },
-  })
-
-  function reconnect(connectionId: string) {
-    mutation.mutate({ connectionId })
+    }
   }
 
   return { reconnect, reconnectingId }

--- a/apps/web/app/w/settings/_components/sandbox-templates/create-modal.tsx
+++ b/apps/web/app/w/settings/_components/sandbox-templates/create-modal.tsx
@@ -29,7 +29,7 @@ import {
   useTriggerBuild,
   useRetryBuild,
   usePublicTemplates,
-  createSandboxTemplate,
+  useCreateSandboxTemplate,
   type SandboxTemplate,
 } from "@/hooks/use-sandbox-template"
 
@@ -77,6 +77,7 @@ export function CreateSandboxTemplateModal({ open, onOpenChange, onSuccess }: Cr
 
   const triggerBuild = useTriggerBuild()
   const retryBuild = useRetryBuild()
+  const createTemplate = useCreateSandboxTemplate()
 
   useEffect(() => {
     if (!template || !isBuilding || hasShownSuccessRef.current) return
@@ -126,11 +127,13 @@ export function CreateSandboxTemplateModal({ open, onOpenChange, onSuccess }: Cr
     }
 
     try {
-      const createdTemplate = await createSandboxTemplate({
-        name: name.trim(),
-        build_commands: filteredCommands,
-        base_template_id: selectedBaseTemplate || undefined,
-      })
+      const createdTemplate = (await createTemplate.mutateAsync({
+        body: {
+          name: name.trim(),
+          build_commands: filteredCommands,
+          base_template_id: selectedBaseTemplate || undefined,
+        },
+      })) as SandboxTemplate
 
       if (!createdTemplate.id) {
         toast.error("Failed to get template ID")
@@ -148,7 +151,7 @@ export function CreateSandboxTemplateModal({ open, onOpenChange, onSuccess }: Cr
 
       setBuildTemplateId(createdTemplate.id)
       setIsBuilding(true)
-    } catch (err) {
+    } catch {
       toast.error("Failed to create template")
     }
   }

--- a/apps/web/components/create-workspace-dialog.tsx
+++ b/apps/web/components/create-workspace-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { toast } from "sonner"
-import { api } from "@/lib/api/client"
+import { $api } from "@/lib/api/hooks"
 import { useAuth } from "@/lib/auth/auth-context"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -24,30 +24,27 @@ interface CreateWorkspaceDialogProps {
 export function CreateWorkspaceDialog({ open, onOpenChange }: CreateWorkspaceDialogProps) {
   const { addOrg } = useAuth()
   const [name, setName] = useState("")
-  const [loading, setLoading] = useState(false)
+  const createOrg = $api.useMutation("post", "/v1/orgs")
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
     if (!name.trim()) return
 
-    setLoading(true)
-
-    const response = await api.POST("/v1/orgs", {
-      body: { name: name.trim() } as never,
-    })
-
-    if (response.error) {
-      toast.error("Failed to create workspace")
-      setLoading(false)
-      return
-    }
-
-    const created = response.data as { id: string; name: string }
-    addOrg({ id: created.id, name: created.name, role: "admin" })
-    toast.success(`Workspace "${created.name}" created`)
-    setName("")
-    setLoading(false)
-    onOpenChange(false)
+    createOrg.mutate(
+      { body: { name: name.trim() } as never },
+      {
+        onSuccess: (data) => {
+          const created = data as { id: string; name: string }
+          addOrg({ id: created.id, name: created.name, role: "admin" })
+          toast.success(`Workspace "${created.name}" created`)
+          setName("")
+          onOpenChange(false)
+        },
+        onError: () => {
+          toast.error("Failed to create workspace")
+        },
+      },
+    )
   }
 
   return (
@@ -80,7 +77,7 @@ export function CreateWorkspaceDialog({ open, onOpenChange }: CreateWorkspaceDia
           </div>
 
           <DialogFooter>
-            <Button type="submit" loading={loading}>
+            <Button type="submit" loading={createOrg.isPending}>
               Create workspace
             </Button>
           </DialogFooter>

--- a/apps/web/components/impersonate-user-dialog.tsx
+++ b/apps/web/components/impersonate-user-dialog.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect } from "react"
 import { toast } from "sonner"
 import { useAuth } from "@/lib/auth/auth-context"
+import { $api } from "@/lib/api/hooks"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -27,52 +28,36 @@ interface ImpersonateUserDialogProps {
 export function ImpersonateUserDialog({ open, onOpenChange }: ImpersonateUserDialogProps) {
   const { impersonate } = useAuth()
   const [search, setSearch] = useState("")
-  const [results, setResults] = useState<AdminUser[]>([])
-  const [searching, setSearching] = useState(false)
+  const [debouncedSearch, setDebouncedSearch] = useState("")
   const [impersonating, setImpersonating] = useState<string | null>(null)
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  useEffect(() => {
-    if (!open) {
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
       setSearch("")
-      setResults([])
-      setSearching(false)
+      setDebouncedSearch("")
       setImpersonating(null)
     }
-  }, [open])
+    onOpenChange(nextOpen)
+  }
 
+  // Debounce search input so we only fire one query per pause in typing.
   useEffect(() => {
-    if (debounceTimer.current) {
-      clearTimeout(debounceTimer.current)
-    }
-
-    if (!search.trim()) {
-      setResults([])
-      setSearching(false)
-      return
-    }
-
-    setSearching(true)
-    debounceTimer.current = setTimeout(async () => {
-      try {
-        const response = await fetch(`/api/proxy/admin/v1/users?search=${encodeURIComponent(search.trim())}&limit=10`)
-        if (response.ok) {
-          const data = await response.json()
-          setResults(data.data ?? [])
-        }
-      } catch {
-        // Silently fail — user will see empty results
-      } finally {
-        setSearching(false)
-      }
-    }, 300)
-
-    return () => {
-      if (debounceTimer.current) {
-        clearTimeout(debounceTimer.current)
-      }
-    }
+    const trimmed = search.trim()
+    const timer = setTimeout(() => setDebouncedSearch(trimmed), trimmed ? 300 : 0)
+    return () => clearTimeout(timer)
   }, [search])
+
+  const usersQuery = $api.useQuery(
+    "get",
+    "/admin/v1/users",
+    { params: { query: { search: debouncedSearch, limit: 10 } } },
+    { enabled: open && debouncedSearch.length > 0 },
+  )
+
+  const results = ((usersQuery.data?.data ?? []) as AdminUser[])
+  const searching =
+    search.trim().length > 0 &&
+    (search.trim() !== debouncedSearch || usersQuery.isFetching)
 
   async function handleImpersonate(user: AdminUser) {
     setImpersonating(user.id)
@@ -85,7 +70,7 @@ export function ImpersonateUserDialog({ open, onOpenChange }: ImpersonateUserDia
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Impersonate User</DialogTitle>

--- a/apps/web/hooks/use-conversation-stream.ts
+++ b/apps/web/hooks/use-conversation-stream.ts
@@ -12,6 +12,11 @@ interface StreamToken {
   expires_at: number
 }
 
+// `/api/auth/stream-token` is a local Next.js route handler (see
+// app/api/auth/stream-token/route.ts) that mints a short-lived bearer token for
+// direct backend SSE connections. It reads/refreshes session cookies, so it is
+// outside the OpenAPI schema and must be called with raw fetch rather than the
+// typed `$api` client.
 async function fetchStreamToken(): Promise<StreamToken> {
   const res = await fetch("/api/auth/stream-token")
   if (!res.ok) {

--- a/apps/web/hooks/use-sandbox-template.ts
+++ b/apps/web/hooks/use-sandbox-template.ts
@@ -1,43 +1,37 @@
 "use client"
 
-import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { api } from "@/lib/api/client"
+import { useQueryClient } from "@tanstack/react-query"
 import { $api } from "@/lib/api/hooks"
 import type { components } from "@/lib/api/schema"
 
 export type SandboxTemplate = components["schemas"]["sandboxTemplateResponse"]
 
-// Uses manual useQuery because $api.useQuery doesn't support refetchInterval as a function,
-// which is needed to poll only while the template is building.
+// Uses $api.useQuery with a custom refetchInterval function to poll only while
+// the template is building. react-query accepts the function form regardless of
+// the typed wrapper, so we cast to satisfy openapi-react-query's stricter typing.
 export function useSandboxTemplate(
   templateId: string | null,
   options: { enabled?: boolean } = {}
 ) {
   const { enabled = true } = options
 
-  return useQuery({
-    queryKey: ["get", "/v1/sandbox-templates/{id}", { params: { path: { id: templateId } } }],
-    queryFn: async () => {
-      if (!templateId) return null
-      const response = await api.GET("/v1/sandbox-templates/{id}", {
-        params: { path: { id: templateId } },
-      })
-      if (response.error) {
-        throw response.error
-      }
-      return response.data as SandboxTemplate
+  return $api.useQuery(
+    "get",
+    "/v1/sandbox-templates/{id}",
+    { params: { path: { id: templateId ?? "" } } },
+    {
+      enabled: enabled && templateId !== null,
+      refetchInterval: ((query: { state: { data?: SandboxTemplate } }) => {
+        const data = query.state.data
+        if (!data) return false
+        if (data.build_status === "ready" || data.build_status === "failed") {
+          return false
+        }
+        return 3000
+      }) as unknown as number | false,
+      refetchIntervalInBackground: false,
     },
-    enabled: enabled && templateId !== null,
-    refetchInterval: (query) => {
-      const data = query.state.data
-      if (!data) return false
-      if (data.build_status === "ready" || data.build_status === "failed") {
-        return false
-      }
-      return 3000
-    },
-    refetchIntervalInBackground: false,
-  })
+  )
 }
 
 export function useSandboxTemplates() {
@@ -80,16 +74,12 @@ export function usePublicTemplates() {
 
 export type PublicTemplate = components["schemas"]["publicTemplateResponse"]
 
-export async function createSandboxTemplate(data: {
-  name: string
-  build_commands: string[]
-  base_template_id?: string
-}): Promise<SandboxTemplate> {
-  const response = await api.POST("/v1/sandbox-templates", {
-    body: data,
+export function useCreateSandboxTemplate() {
+  const queryClient = useQueryClient()
+
+  return $api.useMutation("post", "/v1/sandbox-templates", {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["get", "/v1/sandbox-templates"] })
+    },
   })
-  if (response.error) {
-    throw response.error
-  }
-  return response.data as SandboxTemplate
 }

--- a/apps/web/lib/auth/auth-context.tsx
+++ b/apps/web/lib/auth/auth-context.tsx
@@ -110,6 +110,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     router.replace("/auth")
   }, [router])
 
+  // `/api/auth/impersonate` and `/api/auth/stop-impersonate` are local Next.js
+  // route handlers (see app/api/auth/…/route.ts). They mutate session cookies
+  // before/after proxying to the backend, so they live outside the OpenAPI
+  // schema and cannot go through the typed `$api` client. Raw fetch is the
+  // correct path here.
   const impersonate = useCallback(async (userId: string) => {
     const response = await fetch("/api/auth/impersonate", {
       method: "POST",


### PR DESCRIPTION
## Summary
- Replace raw `fetch()`, imperative `api.POST()`/`api.GET()`, and raw `useMutation`/`useQuery` calls with the typed `$api` wrapper around the OpenAPI client.
- Call sites migrated: admin user search in impersonate dialog, workspace creation, resource-reachability parallel queries (`$api.queryOptions` + `useQueries`), sandbox template polling (custom `refetchInterval`), sandbox template creation (new `useCreateSandboxTemplate` hook), and connect/reconnect integration flows (composed `$api.useMutation` + `mutateAsync` around the external Nango SDK).
- `/api/auth/impersonate`, `/api/auth/stop-impersonate`, and `/api/auth/stream-token` are local Next.js route handlers that manage session cookies and are therefore outside the OpenAPI schema — raw `fetch()` is preserved with a comment explaining why.

## Test plan
- [ ] `pnpm --filter web typecheck` passes (verified locally)
- [ ] `pnpm --filter web lint` produces no new errors (went from 79→78 problems; 41 errors unchanged, 38→37 warnings)
- [ ] Manual smoke: open impersonate dialog, create workspace, configure agent resources, start a sandbox template build, connect and reconnect an integration

Closes #93