### PR TITLE
fix(security): authenticate spider endpoints and record usage

### DIFF
--- a/cmd/server/serve_routes_admin.go
+++ b/cmd/server/serve_routes_admin.go
@@ -151,13 +151,13 @@ func setupProxyAndAuxRoutes(
 
 	if deps.SpiderClient != nil {
 		spiderHandler := handler.NewSpiderHandler(deps.SpiderClient, deps.ToolUsageWriter, database)
-		r.Route("/spider", func(r chi.Router) {
+		r.Route("/v1/spider", func(r chi.Router) {
+			r.Use(middleware.TokenAuth(signingKey, database))
 			r.Post("/crawl", spiderHandler.Crawl)
 			r.Post("/search", spiderHandler.Search)
 			r.Post("/links", spiderHandler.Links)
 			r.Post("/screenshot", spiderHandler.Screenshot)
 			r.Post("/transform", spiderHandler.Transform)
 		})
-		slog.Info("spider routes registered (NO AUTH - temporary)")
 	}
 }

--- a/internal/handler/spider.go
+++ b/internal/handler/spider.go
@@ -194,10 +194,7 @@ func (handler *SpiderHandler) recordUsage(r *http.Request, toolName, input strin
 
 // recordUsageCount is the core usage recording method that takes an explicit result count.
 func (handler *SpiderHandler) recordUsageCount(r *http.Request, toolName, input string, resultCount int, callErr error, duration time.Duration) {
-	claims, ok := middleware.ClaimsFromContext(r.Context())
-	if !ok {
-		return
-	}
+	claims, _ := middleware.ClaimsFromContext(r.Context())
 
 	orgID, _ := uuid.Parse(claims.OrgID)
 	agentID := handler.lookupAgentID(claims.JTI)


### PR DESCRIPTION
## Summary
- Move `/spider/*` routes into the authenticated `/v1/spider` group using `middleware.TokenAuth(signingKey, database)`, matching `/v1/proxy` and `/v1/drive`.
- Drop the temporary `"spider routes registered (NO AUTH - temporary)"` log line.
- Remove the early-return in `SpiderHandler.recordUsageCount` that skipped usage tracking when no claims were in context. With auth enforced, claims are always present and every call is now recorded.

## Test plan
- [x] `go build ./cmd/server ./internal/handler`
- [x] `go vet ./cmd/server/... ./internal/handler/...`
- [ ] Verify unauthenticated `POST /v1/spider/crawl` returns 401
- [ ] Verify authenticated call succeeds and a `ToolUsage` row is written

Closes #30
Closes #31