### PR TITLE
fix(security): validate org ownership on router default_agent, rule agent, and trigger connection IDs

### DIFF
--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -135,6 +135,13 @@ func (handler *RouterHandler) UpdateRouter(writer http.ResponseWriter, request *
 				writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "invalid default_agent_id"})
 				return
 			}
+			// Verify the agent belongs to the caller's org to prevent
+			// cross-tenant routing (see security issue #48).
+			var agent model.Agent
+			if err := handler.db.Select("id").Where("id = ? AND org_id = ?", parsed, org.ID).First(&agent).Error; err != nil {
+				writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "invalid default_agent_id"})
+				return
+			}
 			updates["default_agent_id"] = parsed
 		}
 	}
@@ -220,6 +227,13 @@ func (handler *RouterHandler) CreateTrigger(writer http.ResponseWriter, request 
 		}
 		connectionID, err := uuid.Parse(body.ConnectionID)
 		if err != nil {
+			writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "invalid connection_id"})
+			return
+		}
+		// Verify the connection belongs to the caller's org to prevent
+		// cross-tenant trigger references (see security issue #54).
+		var connection model.InConnection
+		if err := handler.db.Select("id").Where("id = ? AND org_id = ?", connectionID, org.ID).First(&connection).Error; err != nil {
 			writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "invalid connection_id"})
 			return
 		}
@@ -350,6 +364,14 @@ func (handler *RouterHandler) CreateRule(writer http.ResponseWriter, request *ht
 
 	agentID, err := uuid.Parse(body.AgentID)
 	if err != nil {
+		writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "invalid agent_id"})
+		return
+	}
+
+	// Verify the agent belongs to the caller's org to prevent cross-tenant
+	// routing rules (see security issue #49).
+	var agent model.Agent
+	if err := handler.db.Select("id").Where("id = ? AND org_id = ?", agentID, org.ID).First(&agent).Error; err != nil {
 		writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "invalid agent_id"})
 		return
 	}


### PR DESCRIPTION
## Summary

Three router endpoints accepted UUIDs referencing resources in other orgs without checking ownership, enabling cross-tenant routing. Each now verifies `org_id` matches the caller before persisting.

- `PUT /v1/router` — `default_agent_id` checked against `agents.org_id` (#48, Critical)
- `POST /v1/router/triggers/{id}/rules` — `agent_id` checked against `agents.org_id` (#49, Critical)
- `POST /v1/router/triggers` — `connection_id` checked against `in_connections.org_id` for webhook triggers; http/cron triggers skip the check since they do not reference a connection (#54, High)

All three return a generic `400` on mismatch to avoid leaking whether a foreign UUID exists.

Closes #48
Closes #49
Closes #54

## Test plan

- [ ] Org A cannot set `default_agent_id` to an Org B agent via `PUT /v1/router`
- [ ] Org A cannot create a rule on its trigger with an Org B `agent_id`
- [ ] Org A cannot create a webhook trigger referencing an Org B `connection_id`
- [ ] Same-org references for all three endpoints still succeed
- [ ] `http` and `cron` trigger creation still works without `connection_id`