### PR TITLE
fix(security): harden drive upload path (size limits, content-type allowlist, timing-safe compare, force download)

### DIFF
--- a/internal/handler/drive.go
+++ b/internal/handler/drive.go
@@ -26,24 +26,85 @@ func NewDriveHandler(db *gorm.DB, storage *storage.S3Client) *DriveHandler {
 	return &DriveHandler{db: db, storage: storage}
 }
 
+const maxDriveUploadBytes = 50 << 20 // 50 MiB
+
+const maxDriveFileBytes = 50 << 20 // 50 MiB
+
+// "text/" is intentionally NOT a prefix — only specific safe text subtypes
+// are allowed via allowedExactContentTypes, so text/html (and similar
+// browser-executable types) cannot be stored and served back inline via
+// presigned URLs.
 var allowedContentTypePrefixes = []string{
 	"image/",
 	"video/",
 	"audio/",
-	"text/",
-	"application/pdf",
 	"application/vnd.openxmlformats-officedocument.",
-	"application/msword",
+	"application/vnd.oasis.opendocument.",
 	"application/vnd.ms-",
 }
 
-func isAllowedContentType(contentType string) bool {
+var allowedExactContentTypes = map[string]struct{}{
+	"application/pdf":  {},
+	"application/json": {},
+	"application/msword": {},
+	"application/zip":  {},
+	"text/plain":       {},
+	"text/csv":         {},
+	"text/markdown":    {},
+	"text/x-markdown":  {},
+}
+
+// disallowedImageSubtypes are image/* types that can execute script in
+// browsers (SVG) and so must be rejected even though they match image/*.
+var disallowedImageSubtypes = map[string]struct{}{
+	"image/svg+xml": {},
+	"image/svg":     {},
+}
+
+// dangerousExtensions are filename suffixes we refuse regardless of the
+// client-declared content type, to block executable uploads that sneak in
+// under generic types like application/octet-stream.
+var dangerousExtensions = []string{
+	".html", ".htm", ".xhtml", ".svg",
+	".exe", ".dll", ".bat", ".cmd", ".com", ".msi",
+	".sh", ".bash", ".zsh", ".ps1",
+	".js", ".mjs", ".jsp", ".php", ".phtml",
+}
+
+func isAllowedDriveContentType(contentType, filename string) bool {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	if semi := strings.Index(ct, ";"); semi >= 0 {
+		ct = strings.TrimSpace(ct[:semi])
+	}
+	if ct == "" {
+		return false
+	}
+
+	lowerName := strings.ToLower(filename)
+	for _, ext := range dangerousExtensions {
+		if strings.HasSuffix(lowerName, ext) {
+			return false
+		}
+	}
+
+	if _, bad := disallowedImageSubtypes[ct]; bad {
+		return false
+	}
+
 	for _, prefix := range allowedContentTypePrefixes {
-		if strings.HasPrefix(contentType, prefix) {
+		if strings.HasPrefix(ct, prefix) {
 			return true
 		}
 	}
+	if _, ok := allowedExactContentTypes[ct]; ok {
+		return true
+	}
 	return false
+}
+
+// isAllowedContentType is kept for backward compatibility.
+func isAllowedContentType(contentType string) bool {
+	return isAllowedDriveContentType(contentType, "")
 }
 
 type driveAssetResponse struct {
@@ -114,8 +175,12 @@ func (handler *DriveHandler) Upload(writer http.ResponseWriter, request *http.Re
 		return
 	}
 
+	// Cap the entire request body before parsing so oversized uploads are
+	// rejected instead of spilled to a temp file on disk.
+	request.Body = http.MaxBytesReader(writer, request.Body, maxDriveUploadBytes)
+
 	if err := request.ParseMultipartForm(32 << 20); err != nil {
-		writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "invalid multipart form"})
+		writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "invalid multipart form or payload too large"})
 		return
 	}
 
@@ -128,6 +193,13 @@ func (handler *DriveHandler) Upload(writer http.ResponseWriter, request *http.Re
 	var assets []driveAssetResponse
 
 	for _, fileHeader := range files {
+		if fileHeader.Size > maxDriveFileBytes {
+			writeJSON(writer, http.StatusRequestEntityTooLarge, map[string]string{
+				"error": fmt.Sprintf("file %q exceeds the %d MiB per-file limit", fileHeader.Filename, maxDriveFileBytes>>20),
+			})
+			return
+		}
+
 		contentType := fileHeader.Header.Get("Content-Type")
 		if contentType == "" || contentType == "application/octet-stream" {
 			contentType = mime.TypeByExtension(fileHeader.Filename)
@@ -136,7 +208,7 @@ func (handler *DriveHandler) Upload(writer http.ResponseWriter, request *http.Re
 			}
 		}
 
-		if !isAllowedContentType(contentType) {
+		if !isAllowedDriveContentType(contentType, fileHeader.Filename) {
 			writeJSON(writer, http.StatusBadRequest, map[string]string{
 				"error": fmt.Sprintf("file %q: content type %q is not allowed", fileHeader.Filename, contentType),
 			})

--- a/internal/handler/sandbox_drive.go
+++ b/internal/handler/sandbox_drive.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"log/slog"
 	"mime"
@@ -16,6 +17,10 @@ import (
 	"github.com/usehiveloop/hiveloop/internal/model"
 	"github.com/usehiveloop/hiveloop/internal/storage"
 )
+
+const maxSandboxDriveUploadBytes = 50 << 20 // 50 MiB
+
+const maxSandboxDriveFileBytes = 50 << 20 // 50 MiB
 
 // SandboxDriveHandler provides drive access from within sandboxes,
 // authenticated with the Bridge control plane API key.
@@ -73,7 +78,7 @@ func (handler *SandboxDriveHandler) resolveSandboxAgent(writer http.ResponseWrit
 		writeJSON(writer, http.StatusInternalServerError, map[string]string{"error": "failed to verify credentials"})
 		return uuid.Nil, nil, false
 	}
-	if string(decryptedKey) != apiKey {
+	if subtle.ConstantTimeCompare([]byte(decryptedKey), []byte(apiKey)) != 1 {
 		writeJSON(writer, http.StatusUnauthorized, map[string]string{"error": "invalid API key"})
 		return uuid.Nil, nil, false
 	}
@@ -103,8 +108,12 @@ func (handler *SandboxDriveHandler) Upload(writer http.ResponseWriter, request *
 		return
 	}
 
+	// Cap the entire request body before parsing so oversized uploads are
+	// rejected instead of spilled to a temp file on disk.
+	request.Body = http.MaxBytesReader(writer, request.Body, maxSandboxDriveUploadBytes)
+
 	if err := request.ParseMultipartForm(32 << 20); err != nil {
-		writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "invalid multipart form"})
+		writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "invalid multipart form or payload too large"})
 		return
 	}
 
@@ -117,6 +126,13 @@ func (handler *SandboxDriveHandler) Upload(writer http.ResponseWriter, request *
 	var assets []driveAssetResponse
 
 	for _, fileHeader := range files {
+		if fileHeader.Size > maxSandboxDriveFileBytes {
+			writeJSON(writer, http.StatusRequestEntityTooLarge, map[string]string{
+				"error": fmt.Sprintf("file %q exceeds the %d MiB per-file limit", fileHeader.Filename, maxSandboxDriveFileBytes>>20),
+			})
+			return
+		}
+
 		contentType := fileHeader.Header.Get("Content-Type")
 		if contentType == "" || contentType == "application/octet-stream" {
 			contentType = mime.TypeByExtension(fileHeader.Filename)
@@ -125,7 +141,13 @@ func (handler *SandboxDriveHandler) Upload(writer http.ResponseWriter, request *
 			}
 		}
 
-		// Sandbox drive accepts any content type (no allowlist restriction)
+		if !isAllowedDriveContentType(contentType, fileHeader.Filename) {
+			writeJSON(writer, http.StatusBadRequest, map[string]string{
+				"error": fmt.Sprintf("file %q: content type %q is not allowed", fileHeader.Filename, contentType),
+			})
+			return
+		}
+
 		assetID := uuid.New()
 		s3Key := fmt.Sprintf("drives/%s/%s/%s", agent.ID, assetID, fileHeader.Filename)
 

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -73,15 +74,43 @@ func (sc *S3Client) Delete(ctx context.Context, key string) error {
 }
 
 // PresignedURL generates a time-limited GET URL for downloading an object.
+// Forces Content-Disposition: attachment and Content-Type:
+// application/octet-stream to mitigate stored-XSS from any text/html or
+// SVG content still sitting in the bucket from before the upload allowlist
+// was tightened.
 func (sc *S3Client) PresignedURL(ctx context.Context, key string, ttl time.Duration) (string, error) {
 	presigner := s3.NewPresignClient(sc.client)
+
+	filename := key
+	if idx := strings.LastIndex(key, "/"); idx >= 0 && idx < len(key)-1 {
+		filename = key[idx+1:]
+	}
+	disposition := fmt.Sprintf(`attachment; filename="%s"`, sanitizeFilenameForHeader(filename))
+
 	input := &s3.GetObjectInput{
-		Bucket: aws.String(sc.bucket),
-		Key:    aws.String(key),
+		Bucket:                     aws.String(sc.bucket),
+		Key:                        aws.String(key),
+		ResponseContentDisposition: aws.String(disposition),
+		ResponseContentType:        aws.String("application/octet-stream"),
 	}
 	result, err := presigner.PresignGetObject(ctx, input, s3.WithPresignExpires(ttl))
 	if err != nil {
 		return "", fmt.Errorf("s3 presign %q: %w", key, err)
 	}
 	return result.URL, nil
+}
+
+// sanitizeFilenameForHeader replaces characters that would break a
+// Content-Disposition header value with underscores.
+func sanitizeFilenameForHeader(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		if r < 0x20 || r == 0x7f || r == '"' || r == '\\' || r == '\r' || r == '\n' {
+			b.WriteByte('_')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }


### PR DESCRIPTION
## Summary
- **#33** Replace string-comparison of the Bridge API key in `SandboxDriveHandler.resolveSandboxAgent` with `subtle.ConstantTimeCompare`, matching the pattern used by `git_credentials` and `railway_proxy`.
- **#34** Wrap request bodies on both drive upload endpoints with `http.MaxBytesReader` (50 MiB) before `ParseMultipartForm`, plus a per-file `fileHeader.Size` check, so uploads no longer spill unbounded to disk or S3.
- **#36** Tighten the drive content-type allowlist: drop the blanket `text/` prefix, allow only `text/plain`, `text/csv`, `text/markdown`; reject `image/svg+xml` and filenames with HTML/script/executable suffixes. Additionally, `storage.S3Client.PresignedURL` now forces `Content-Disposition: attachment; filename="..."` and `Content-Type: application/octet-stream`, neutering any previously-uploaded HTML still in the bucket when served via cached presigned URLs.
- **#40** Apply the same shared allowlist (`isAllowedDriveContentType`) to the sandbox drive handler so untrusted sandboxes can no longer upload `text/html`, SVG, or executables.

Closes #33, #34, #36, #40.

## Test plan
- [ ] `go build ./internal/...` passes
- [ ] `go vet ./internal/handler/... ./internal/storage/...` passes
- [ ] Upload a 60 MiB file: rejected with 413/400 instead of streamed to S3
- [ ] Upload `evil.html` (`text/html`): rejected on both `/v1/drive/assets` and `/internal/sandbox-drive/{id}/assets`
- [ ] Upload `evil.svg` (`image/svg+xml`): rejected on both endpoints
- [ ] Fetch a presigned URL and confirm the response carries `Content-Disposition: attachment` and `Content-Type: application/octet-stream`
- [ ] Sandbox handler still authenticates valid API keys (constant-time compare is equivalence-preserving)