### PR TITLE
fix(security): enforce org scoping on skills/subagents/connections and verify Nango session

### DIFF
--- a/internal/handler/agents_helpers.go
+++ b/internal/handler/agents_helpers.go
@@ -87,7 +87,10 @@ func (h *AgentHandler) loadAgentTriggers(agentIDs ...uuid.UUID) map[uuid.UUID][]
 }
 
 // loadAgentSubagents batch-loads attached subagent summaries for one or more agents.
-func (h *AgentHandler) loadAgentSubagents(agentIDs ...uuid.UUID) map[uuid.UUID][]agentSubagentSummary {
+// Subagent details are filtered by org (defense-in-depth): only subagents owned by
+// the caller's org or published public subagents (org_id IS NULL AND status = 'active')
+// are returned, even if a stray cross-org link was somehow created.
+func (h *AgentHandler) loadAgentSubagents(orgID uuid.UUID, agentIDs ...uuid.UUID) map[uuid.UUID][]agentSubagentSummary {
 	if len(agentIDs) == 0 {
 		return nil
 	}
@@ -103,7 +106,10 @@ func (h *AgentHandler) loadAgentSubagents(agentIDs ...uuid.UUID) map[uuid.UUID][
 		subIDs[index] = link.SubagentID
 	}
 	var subs []model.Agent
-	if err := h.db.Select("id, name, description, model").Where("id IN ?", subIDs).Find(&subs).Error; err != nil {
+	if err := h.db.
+		Select("id, name, description, model").
+		Where("id IN ? AND (org_id = ? OR (org_id IS NULL AND status = ?))", subIDs, orgID, "active").
+		Find(&subs).Error; err != nil {
 		return nil
 	}
 	subByID := make(map[uuid.UUID]model.Agent, len(subs))
@@ -127,7 +133,10 @@ func (h *AgentHandler) loadAgentSubagents(agentIDs ...uuid.UUID) map[uuid.UUID][
 }
 
 // loadAgentSkills batch-loads attached skill summaries for one or more agents.
-func (h *AgentHandler) loadAgentSkills(agentIDs ...uuid.UUID) map[uuid.UUID][]agentSkillSummary {
+// Skill details are filtered by org (defense-in-depth): only skills owned by the
+// caller's org or published public skills (org_id IS NULL AND status = 'published')
+// are returned, even if a stray cross-org link was somehow created.
+func (h *AgentHandler) loadAgentSkills(orgID uuid.UUID, agentIDs ...uuid.UUID) map[uuid.UUID][]agentSkillSummary {
 	if len(agentIDs) == 0 {
 		return nil
 	}
@@ -143,7 +152,10 @@ func (h *AgentHandler) loadAgentSkills(agentIDs ...uuid.UUID) map[uuid.UUID][]ag
 		skillIDs[index] = link.SkillID
 	}
 	var skills []model.Skill
-	if err := h.db.Select("id, name, description, source_type").Where("id IN ?", skillIDs).Find(&skills).Error; err != nil {
+	if err := h.db.
+		Select("id, name, description, source_type").
+		Where("id IN ? AND (org_id = ? OR (org_id IS NULL AND status = ?))", skillIDs, orgID, model.SkillStatusPublished).
+		Find(&skills).Error; err != nil {
 		return nil
 	}
 	skillByID := make(map[uuid.UUID]model.Skill, len(skills))

--- a/internal/handler/agents_list_get.go
+++ b/internal/handler/agents_list_get.go
@@ -68,8 +68,8 @@ func (h *AgentHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	// Batch load triggers, subagents, and skills for all agents.
 	triggersMap := h.loadAgentTriggers(agentIDs...)
-	subagentsMap := h.loadAgentSubagents(agentIDs...)
-	skillsMap := h.loadAgentSkills(agentIDs...)
+	subagentsMap := h.loadAgentSubagents(org.ID, agentIDs...)
+	skillsMap := h.loadAgentSkills(org.ID, agentIDs...)
 	for index, agent := range agents {
 		resp[index].Triggers = triggersMap[agent.ID]
 		resp[index].AttachedSubagents = subagentsMap[agent.ID]
@@ -116,8 +116,8 @@ func (h *AgentHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	resp := toAgentResponse(agent)
 	resp.Triggers = h.loadAgentTriggers(agent.ID)[agent.ID]
-	resp.AttachedSubagents = h.loadAgentSubagents(agent.ID)[agent.ID]
-	resp.AttachedSkills = h.loadAgentSkills(agent.ID)[agent.ID]
+	resp.AttachedSubagents = h.loadAgentSubagents(org.ID, agent.ID)[agent.ID]
+	resp.AttachedSkills = h.loadAgentSkills(org.ID, agent.ID)[agent.ID]
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/handler/agents_update.go
+++ b/internal/handler/agents_update.go
@@ -234,15 +234,45 @@ func (h *AgentHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.SkillIDs != nil {
+		skillUUIDs := make([]uuid.UUID, 0, len(*req.SkillIDs))
+		seen := make(map[uuid.UUID]struct{}, len(*req.SkillIDs))
+		for _, rawID := range *req.SkillIDs {
+			parsed, parseErr := uuid.Parse(rawID)
+			if parseErr != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid skill_id %q", rawID)})
+				return
+			}
+			if _, dup := seen[parsed]; dup {
+				continue
+			}
+			seen[parsed] = struct{}{}
+			skillUUIDs = append(skillUUIDs, parsed)
+		}
+
+		// Validate each skill belongs to this org or is a published public skill,
+		// matching the visibility rule used in agents_create.go.
+		if len(skillUUIDs) > 0 {
+			var visibleSkills []model.Skill
+			if err := h.db.
+				Select("id").
+				Where("id IN ? AND (org_id = ? OR (org_id IS NULL AND status = ?))",
+					skillUUIDs, org.ID, model.SkillStatusPublished).
+				Find(&visibleSkills).Error; err != nil {
+				slog.Error("failed to validate skill_ids during update", "agent_id", agent.ID, "error", err)
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to validate skills"})
+				return
+			}
+			if len(visibleSkills) != len(skillUUIDs) {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "one or more skill_ids are not visible to this org"})
+				return
+			}
+		}
+
 		if err := h.db.Transaction(func(tx *gorm.DB) error {
 			if err := tx.Where("agent_id = ?", agent.ID).Delete(&model.AgentSkill{}).Error; err != nil {
 				return err
 			}
-			for _, rawID := range *req.SkillIDs {
-				skillUUID, parseErr := uuid.Parse(rawID)
-				if parseErr != nil {
-					continue
-				}
+			for _, skillUUID := range skillUUIDs {
 				if err := tx.Create(&model.AgentSkill{
 					AgentID: agent.ID,
 					SkillID: skillUUID,
@@ -258,6 +288,6 @@ func (h *AgentHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	resp := toAgentResponse(agent)
 	resp.Triggers = h.loadAgentTriggers(agent.ID)[agent.ID]
-	resp.AttachedSkills = h.loadAgentSkills(agent.ID)[agent.ID]
+	resp.AttachedSkills = h.loadAgentSkills(org.ID, agent.ID)[agent.ID]
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/handler/in_connections_create.go
+++ b/internal/handler/in_connections_create.go
@@ -70,6 +70,27 @@ func (h *InConnectionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Verify the nango_connection_id belongs to the calling user. Without this check,
+	// an attacker can pass a foreign org's Nango connection ID and create a local
+	// InConnection pointing at another tenant's OAuth credentials.
+	//
+	// Nango persists the `end_user.id` we supplied when creating the connect session
+	// (see CreateConnectSession — we set it to user.ID.String()). Fetch the Nango
+	// connection and confirm the end_user matches the authenticated caller.
+	nk := inNangoKey(integ.UniqueKey)
+	nangoConn, err := h.nango.GetConnection(r.Context(), req.NangoConnectionID, nk)
+	if err != nil {
+		slog.Warn("nango connection verification failed", "error", err, "org_id", org.ID, "user_id", user.ID, "nango_connection_id", req.NangoConnectionID)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "nango_connection_id is not valid for this integration"})
+		return
+	}
+	if !nangoConnectionBelongsToUser(nangoConn, user.ID.String()) {
+		slog.Warn("nango connection end_user mismatch — possible cross-tenant attempt",
+			"org_id", org.ID, "user_id", user.ID, "nango_connection_id", req.NangoConnectionID)
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "nango_connection_id does not belong to the requesting user"})
+		return
+	}
+
 	conn := model.InConnection{
 		ID:                uuid.New(),
 		OrgID:             org.ID,

--- a/internal/handler/in_connections_session.go
+++ b/internal/handler/in_connections_session.go
@@ -81,6 +81,11 @@ func (h *InConnectionHandler) CreateReconnectSession(w http.ResponseWriter, r *h
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing user context"})
 		return
 	}
+	org, ok := middleware.OrgFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing org context"})
+		return
+	}
 
 	connID := chi.URLParam(r, "id")
 	if connID == "" {
@@ -89,7 +94,7 @@ func (h *InConnectionHandler) CreateReconnectSession(w http.ResponseWriter, r *h
 	}
 
 	var conn model.InConnection
-	if err := h.db.Preload("InIntegration").Where("id = ? AND revoked_at IS NULL", connID).First(&conn).Error; err != nil {
+	if err := h.db.Preload("InIntegration").Where("id = ? AND org_id = ? AND revoked_at IS NULL", connID, org.ID).First(&conn).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "connection not found"})
 			return

--- a/internal/handler/in_integrations.go
+++ b/internal/handler/in_integrations.go
@@ -103,3 +103,37 @@ func toInIntegrationAvailableResponse(integ model.InIntegration) inIntegrationAv
 func inNangoKey(uniqueKey string) string {
 	return "in_" + uniqueKey
 }
+
+// nangoConnectionBelongsToUser inspects a Nango GetConnection response and
+// returns true if its end_user.id matches the expected authenticated user.
+// When creating a connect session we supply `end_user.id = user.ID.String()`,
+// and Nango persists that identifier against the resulting connection. A
+// connection whose end_user does not match the caller must be treated as
+// foreign and rejected.
+//
+// Nango's response shape for GET /connection/{id} nests data under either
+// "data" or is returned at the top level depending on version; we accept both.
+func nangoConnectionBelongsToUser(resp map[string]any, expectedUserID string) bool {
+	if resp == nil || expectedUserID == "" {
+		return false
+	}
+	candidates := []map[string]any{resp}
+	if inner, ok := resp["data"].(map[string]any); ok {
+		candidates = append(candidates, inner)
+	}
+	if inner, ok := resp["connection"].(map[string]any); ok {
+		candidates = append(candidates, inner)
+	}
+	for _, c := range candidates {
+		if eu, ok := c["end_user"].(map[string]any); ok {
+			if id, _ := eu["id"].(string); id != "" && id == expectedUserID {
+				return true
+			}
+		}
+		// Some Nango responses surface end_user_id as a top-level string.
+		if id, ok := c["end_user_id"].(string); ok && id != "" && id == expectedUserID {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes four tenant-isolation issues in a single change:

- **#35 (High)** `agents_update` skill reconciliation was un-scoped. Now validates each `skill_id` against the same visibility rule as `agents_create` (`org_id = ? OR (org_id IS NULL AND status = 'published')`) before recreating `AgentSkill` links. Bad IDs are rejected with 400.
- **#45 (Low)** `loadAgentSubagents` and `loadAgentSkills` were loading entities by ID with no tenant check. Both now require an `orgID` and filter by `org_id = ? OR (org_id IS NULL AND status = ...)`. All call sites (`agents_list_get` List/Get, `agents_update`) thread `org.ID`.
- **#52 (High)** `POST /v1/in/connections/{id}/reconnect-session` looked up `InConnection` by id only — any user could mint a reconnect token for any org's connection. Now pulls org from context and filters `WHERE id = ? AND org_id = ? AND revoked_at IS NULL`.
- **#61 (Medium)** `POST /v1/in/integrations/{id}/connections` accepted a client-supplied `nango_connection_id` with no verification. Now calls `nango.GetConnection` and confirms the connection's `end_user.id` matches the authenticated `user.ID` (which we set at connect-session creation). Mismatches return 403.

Closes #35
Closes #45
Closes #52
Closes #61

## Test plan

- [ ] `go build ./internal/...` passes (pre-existing `cmd/fetchactions-*` and `skills/upload` build failures are unrelated to this change and exist on `main`).
- [ ] Update an agent with a foreign org's skill ID — expect 400 "one or more skill_ids are not visible to this org".
- [ ] `GET /v1/agents/{id}` no longer returns subagent/skill metadata for links that point out-of-org.
- [ ] `POST /v1/in/connections/{foreignOrgConnID}/reconnect-session` returns 404.
- [ ] `POST /v1/in/integrations/{id}/connections` with a Nango connection ID created by another user returns 403.