### PR TITLE
fix(security): dedupe invite acceptance, add FOR UPDATE lock, minimize preview/conflict responses

### DIFF
--- a/internal/handler/org_invites.go
+++ b/internal/handler/org_invites.go
@@ -47,11 +47,9 @@ type orgInviteResponse struct {
 }
 
 type orgInvitePreviewResponse struct {
-	OrgID       string `json:"org_id"`
 	OrgName     string `json:"org_name"`
 	InviterName string `json:"inviter_name"`
 	Role        string `json:"role"`
-	Email       string `json:"email"`
 	ExpiresAt   string `json:"expires_at"`
 }
 

--- a/internal/handler/org_invites_create.go
+++ b/internal/handler/org_invites_create.go
@@ -85,8 +85,7 @@ func (h *OrgInviteHandler) Create(w http.ResponseWriter, r *http.Request) {
 		First(&existingInvite).Error
 	if err == nil {
 		writeJSON(w, http.StatusConflict, map[string]string{
-			"error":     "invite already pending",
-			"invite_id": existingInvite.ID.String(),
+			"error": "an invite already exists for this email",
 		})
 		return
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/handler/org_invites_public.go
+++ b/internal/handler/org_invites_public.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/usehiveloop/hiveloop/internal/email"
 	"github.com/usehiveloop/hiveloop/internal/middleware"
@@ -37,11 +38,9 @@ func (h *OrgInviteHandler) Preview(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, orgInvitePreviewResponse{
-		OrgID:       invite.OrgID.String(),
 		OrgName:     invite.Org.Name,
 		InviterName: inviterDisplayName(&invite.InvitedBy),
 		Role:        invite.Role,
-		Email:       invite.Email,
 		ExpiresAt:   invite.ExpiresAt.Format(time.RFC3339),
 	})
 }
@@ -69,11 +68,6 @@ func (h *OrgInviteHandler) Accept(w http.ResponseWriter, r *http.Request) {
 	}
 
 	token := chi.URLParam(r, "token")
-	invite, ok := h.findValidInviteByToken(token)
-	if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "invalid or expired invite"})
-		return
-	}
 
 	var user model.User
 	if err := h.db.Where("id = ?", userID).First(&user).Error; err != nil {
@@ -81,27 +75,61 @@ func (h *OrgInviteHandler) Accept(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if normalizeEmail(user.Email) != normalizeEmail(invite.Email) {
-		writeJSON(w, http.StatusForbidden, map[string]string{
-			"error": fmt.Sprintf("This invite was sent to %s. Sign in with that account to accept.", invite.Email),
-		})
-		return
-	}
+	var (
+		invite        model.OrgInvite
+		inviteFound   bool
+		emailMismatch bool
+		alreadyMember bool
+	)
 
 	now := time.Now()
 	err = h.db.Transaction(func(tx *gorm.DB) error {
-		membership := model.OrgMembership{
-			UserID: user.ID,
-			OrgID:  invite.OrgID,
-			Role:   invite.Role,
+		// Lock the invite row for the duration of the transaction so two
+		// concurrent accept requests can't both pass the validity check.
+		locked, ok := h.findValidInviteByTokenForUpdate(tx, token)
+		if !ok {
+			return nil
 		}
-		if err := tx.Create(&membership).Error; err != nil {
-			if !isDuplicateKeyError(err) {
-				return fmt.Errorf("create membership: %w", err)
+		invite = locked
+		inviteFound = true
+
+		if normalizeEmail(user.Email) != normalizeEmail(invite.Email) {
+			emailMismatch = true
+			return nil
+		}
+
+		// Check whether the user is already a member of the target org. If
+		// they are, mark the invite accepted (idempotent) and skip creating a
+		// second membership to avoid relying on the unique constraint for
+		// de-duplication.
+		var existingCount int64
+		if err := tx.Model(&model.OrgMembership{}).
+			Where("user_id = ? AND org_id = ?", user.ID, invite.OrgID).
+			Count(&existingCount).Error; err != nil {
+			return fmt.Errorf("check existing membership: %w", err)
+		}
+
+		if existingCount == 0 {
+			membership := model.OrgMembership{
+				UserID: user.ID,
+				OrgID:  invite.OrgID,
+				Role:   invite.Role,
 			}
+			if err := tx.Create(&membership).Error; err != nil {
+				if isDuplicateKeyError(err) {
+					// Another transaction created the membership between our
+					// count and insert; treat as already-a-member.
+					alreadyMember = true
+				} else {
+					return fmt.Errorf("create membership: %w", err)
+				}
+			}
+		} else {
+			alreadyMember = true
 		}
+
 		if err := tx.Model(&model.OrgInvite{}).
-			Where("id = ?", invite.ID).
+			Where("id = ? AND accepted_at IS NULL", invite.ID).
 			Update("accepted_at", &now).Error; err != nil {
 			return fmt.Errorf("mark invite accepted: %w", err)
 		}
@@ -110,6 +138,24 @@ func (h *OrgInviteHandler) Accept(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.Error("accept invite", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to accept invite"})
+		return
+	}
+	if !inviteFound {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "invalid or expired invite"})
+		return
+	}
+	if emailMismatch {
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error": fmt.Sprintf("This invite was sent to %s. Sign in with that account to accept.", invite.Email),
+		})
+		return
+	}
+	if alreadyMember {
+		writeJSON(w, http.StatusOK, orgInviteAcceptResponse{
+			OrgID:   invite.OrgID.String(),
+			OrgName: invite.Org.Name,
+			Role:    invite.Role,
+		})
 		return
 	}
 
@@ -196,6 +242,31 @@ func (h *OrgInviteHandler) findValidInviteByToken(token string) (model.OrgInvite
 			hash, time.Now()).
 		First(&invite).Error
 	if err != nil {
+		return model.OrgInvite{}, false
+	}
+	return invite, true
+}
+
+// findValidInviteByTokenForUpdate loads a valid invite within the given
+// transaction and acquires a row-level lock (SELECT ... FOR UPDATE) so
+// concurrent accept requests for the same token serialize.
+func (h *OrgInviteHandler) findValidInviteByTokenForUpdate(tx *gorm.DB, token string) (model.OrgInvite, bool) {
+	if token == "" {
+		return model.OrgInvite{}, false
+	}
+	hash := model.HashInviteToken(token)
+	var invite model.OrgInvite
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("token_hash = ? AND accepted_at IS NULL AND revoked_at IS NULL AND expires_at > ?",
+			hash, time.Now()).
+		First(&invite).Error
+	if err != nil {
+		return model.OrgInvite{}, false
+	}
+	// Preload associations after locking the base row. We use a fresh query
+	// so the lock clause doesn't apply to the joined tables.
+	if err := tx.Preload("Org").Preload("InvitedBy").
+		Where("id = ?", invite.ID).First(&invite).Error; err != nil {
 		return model.OrgInvite{}, false
 	}
 	return invite, true


### PR DESCRIPTION
## Summary
- Wrap invite Accept in a transaction that loads the invite with `SELECT ... FOR UPDATE`, closing the TOCTOU race where two concurrent acceptors both pass the validity check (#72).
- Inside the tx, check whether the user already has a membership in the target org. If so, mark the invite accepted idempotently and return 200 without creating a second membership; a racing duplicate-key error is also translated to the same already-a-member response instead of a 500 (#68).
- Public Preview response now returns only `org_name`, `inviter_name`, `role`, `expires_at`. `org_id` and `email` are removed so a leaked token no longer discloses the invitee's address or the org UUID (#75).
- Create handler's 409 conflict for a pending invite no longer includes `invite_id`; response is `{"error": "an invite already exists for this email"}` (#81).

Closes #68, #72, #75, #81.

## Test plan
- [ ] `go build ./internal/handler/...` passes
- [ ] Accepting an invite as a user already in the org returns 200 with the existing-membership payload and does not create a second `org_memberships` row
- [ ] Two concurrent accepts for the same token: one creates the membership, the other observes `alreadyMember` and both return 200
- [ ] `GET /v1/invites/{token}` response contains `org_name`, `inviter_name`, `role`, `expires_at` and omits `org_id` and `email`
- [ ] `POST /v1/orgs/current/invites` with a duplicate pending email returns 409 without an `invite_id` field