### PR TITLE
fix(security): restrict admin-only v1 routes, rate-limit invite endpoints, cap org creation

### DIFF
--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -153,7 +153,7 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 	// HTTP triggers: unauthenticated endpoint, trigger UUID acts as bearer token.
 	r.Post("/incoming/triggers/{triggerID}", httpTriggerHandler.Handle)
 	setupAuthRoutes(r, ctx, cfg, rsaPub, authHandler, oauthHandler)
-	setupV1Routes(r, cfg, rsaPub, database, apiKeyCache, enqueuer, orgHandler, orgInviteHandler, usageHandler, auditHandler, reportingHandler, generationHandler, apiKeyHandler, billingHandler, credHandler, tokenHandler, sandboxTemplateHandler, skillHandler, subagentHandler, agentHandler, marketplaceHandler, conversationHandler, systemConvHandler, routerHandler, customDomainHandler, orchestrator, auditWriter)
+	setupV1Routes(r, ctx, cfg, rsaPub, database, apiKeyCache, enqueuer, orgHandler, orgInviteHandler, usageHandler, auditHandler, reportingHandler, generationHandler, apiKeyHandler, billingHandler, credHandler, tokenHandler, sandboxTemplateHandler, skillHandler, subagentHandler, agentHandler, marketplaceHandler, conversationHandler, systemConvHandler, routerHandler, customDomainHandler, orchestrator, auditWriter)
 
 	var platformAdminEmails []string
 	if cfg.PlatformAdminEmails != "" {

--- a/cmd/server/serve_routes_v1.go
+++ b/cmd/server/serve_routes_v1.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rsa"
 
 	"github.com/go-chi/chi/v5"
@@ -16,6 +17,7 @@ import (
 
 func setupV1Routes(
 	r chi.Router,
+	ctx context.Context,
 	cfg *config.Config,
 	rsaPub *rsa.PublicKey,
 	database *gorm.DB,
@@ -47,11 +49,15 @@ func setupV1Routes(
 		r.Use(middleware.MultiAuth(rsaPub, cfg.AuthIssuer, cfg.AuthAudience, database, apiKeyCache, enqueuer))
 		r.Use(middleware.RequireEmailConfirmed(database))
 
-		r.Post("/orgs", orgHandler.Create)
-
-		// Authenticated invite accept/decline — user-scoped, no org context required.
-		r.Post("/invites/{token}/accept", orgInviteHandler.Accept)
-		r.Post("/invites/{token}/decline", orgInviteHandler.Decline)
+		// Org creation and invite accept/decline sit outside the per-org
+		// RateLimit group (they have no org context yet). Guard them with
+		// a per-IP AuthRateLimit instead (see issues #59 and #62).
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.AuthRateLimit(ctx, 10, 20))
+			r.Post("/orgs", orgHandler.Create)
+			r.Post("/invites/{token}/accept", orgInviteHandler.Accept)
+			r.Post("/invites/{token}/decline", orgInviteHandler.Decline)
+		})
 
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.ResolveOrgFlexible(database))
@@ -61,7 +67,6 @@ func setupV1Routes(
 			r.Get("/orgs/current", orgHandler.Current)
 			r.Get("/orgs/current/members", orgInviteHandler.ListMembers)
 
-			// Admin-only org invite management.
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.RequireOrgAdmin(database))
 				r.Post("/orgs/current/invites", orgInviteHandler.Create)
@@ -69,35 +74,54 @@ func setupV1Routes(
 				r.Delete("/orgs/current/invites/{id}", orgInviteHandler.Revoke)
 				r.Post("/orgs/current/invites/{id}/resend", orgInviteHandler.Resend)
 			})
-			r.Get("/usage", usageHandler.Get)
-			r.Get("/audit", auditHandler.List)
-			r.Get("/reporting", reportingHandler.Get)
-			r.Get("/generations", generationHandler.List)
-			r.Get("/generations/{id}", generationHandler.Get)
 
-			r.Post("/api-keys", apiKeyHandler.Create)
+			// Admin-only sensitive data reads, credential/API-key/token mutations,
+			// and billing management (see issues #50, #51, #53, #56).
+			r.Group(func(r chi.Router) {
+				r.Use(middleware.RequireOrgAdmin(database))
+
+				r.Get("/usage", usageHandler.Get)
+				r.Get("/audit", auditHandler.List)
+				r.Get("/reporting", reportingHandler.Get)
+				r.Get("/generations", generationHandler.List)
+				r.Get("/generations/{id}", generationHandler.Get)
+
+				r.Post("/api-keys", apiKeyHandler.Create)
+				r.Delete("/api-keys/{id}", apiKeyHandler.Revoke)
+
+				if billingHandler != nil {
+					r.Post("/billing/checkout", billingHandler.CreateCheckout)
+					r.Post("/billing/portal", billingHandler.CreatePortal)
+				}
+
+				r.Group(func(r chi.Router) {
+					r.Use(middleware.RequireAPIKeyScopeOrJWT("credentials"))
+					r.Post("/credentials", credHandler.Create)
+					r.Delete("/credentials/{id}", credHandler.Revoke)
+				})
+
+				r.Group(func(r chi.Router) {
+					r.Use(middleware.RequireAPIKeyScopeOrJWT("tokens"))
+					r.Post("/tokens", tokenHandler.Mint)
+					r.Delete("/tokens/{jti}", tokenHandler.Revoke)
+				})
+			})
+
 			r.Get("/api-keys", apiKeyHandler.List)
-			r.Delete("/api-keys/{id}", apiKeyHandler.Revoke)
 
 			if billingHandler != nil {
-				r.Post("/billing/checkout", billingHandler.CreateCheckout)
 				r.Get("/billing/subscription", billingHandler.GetSubscription)
-				r.Post("/billing/portal", billingHandler.CreatePortal)
 			}
 
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.RequireAPIKeyScopeOrJWT("credentials"))
-				r.Post("/credentials", credHandler.Create)
 				r.Get("/credentials", credHandler.List)
 				r.Get("/credentials/{id}", credHandler.Get)
-				r.Delete("/credentials/{id}", credHandler.Revoke)
 			})
 
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.RequireAPIKeyScopeOrJWT("tokens"))
 				r.Get("/tokens", tokenHandler.List)
-				r.Post("/tokens", tokenHandler.Mint)
-				r.Delete("/tokens/{jti}", tokenHandler.Revoke)
 			})
 
 			r.Group(func(r chi.Router) {

--- a/internal/handler/orgs.go
+++ b/internal/handler/orgs.go
@@ -14,6 +14,10 @@ import (
 	"github.com/usehiveloop/hiveloop/internal/model"
 )
 
+// maxOrgsOwnedPerUser caps how many organizations a single user may own.
+// Enforced by OrgHandler.Create to prevent resource-exhaustion abuse (see #62).
+const maxOrgsOwnedPerUser = 10
+
 type OrgHandler struct {
 	db *gorm.DB
 }
@@ -64,6 +68,25 @@ func (h *OrgHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Per-user org creation quota (see #62).
+	userID, parseErr := uuid.Parse(claims.UserID)
+	if parseErr != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid user id"})
+		return
+	}
+	var ownedCount int64
+	if err := h.db.Model(&model.OrgMembership{}).
+		Where("user_id = ? AND role = ?", userID, "owner").
+		Count(&ownedCount).Error; err != nil {
+		slog.Error("failed to count owned orgs", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create organization"})
+		return
+	}
+	if ownedCount >= int64(maxOrgsOwnedPerUser) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "organization creation limit reached"})
+		return
+	}
+
 	var org model.Org
 	var membership model.OrgMembership
 
@@ -76,7 +99,7 @@ func (h *OrgHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 
 		membership = model.OrgMembership{
-			UserID: uuid.MustParse(claims.UserID),
+			UserID: userID,
 			OrgID:  org.ID,
 			Role:   "owner",
 		}


### PR DESCRIPTION
## Summary

Consolidates 6 RBAC + rate-limit fixes at the v1 route mount site.

- Wraps sensitive reads (`GET /usage`, `/audit`, `/reporting`, `/generations`, `/generations/{id}`) and admin-only mutations (`POST/DELETE /api-keys`, `POST/DELETE /credentials`, `POST/DELETE /tokens`, `POST /billing/checkout`, `POST /billing/portal`) in a `RequireOrgAdmin` sub-group. List endpoints (`GET /credentials`, `/tokens`, `/api-keys`, `/billing/subscription`) remain available to all org members.
- Moves `POST /v1/invites/{token}/accept`, `/decline`, and `POST /v1/orgs` into a per-IP `AuthRateLimit(10, 20)` group. They cannot use the existing per-org `RateLimit` middleware because they have no org context yet (accept/decline is how the user joins; org creation has not happened).
- Caps per-user owned organizations at 10 in `OrgHandler.Create`; beyond the limit returns HTTP 403.

Closes #50, #51, #53, #56, #59, #62.

## Test plan
- [ ] `go build ./cmd/server` passes
- [ ] `go vet ./cmd/server/... ./internal/handler/...` passes
- [ ] Manual: viewer-role user is rejected (403) for the admin-only endpoints listed above
- [ ] Manual: viewer-role user can still `GET /credentials`, `/tokens`, `/api-keys`, `/billing/subscription`
- [ ] Manual: invite accept/decline rate-limits at ~10 rps/IP
- [ ] Manual: creating the 11th org for a single user returns 403