### PR TITLE
fix(security): rate limit OTP request and verify with per-email lockout

### DIFF
--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -37,6 +37,9 @@ type AuthHandler struct {
 
 	loginMu       sync.Mutex
 	loginAttempts map[string]*loginAttempt // keyed by email
+
+	otpVerifyMu       sync.Mutex
+	otpVerifyAttempts map[string]*loginAttempt // keyed by email
 }
 
 func NewAuthHandler(db *gorm.DB, privateKey *rsa.PrivateKey, signingKey []byte, issuer, audience string, accessTTL, refreshTTL time.Duration, emailSender email.Sender, frontendURL string, autoConfirmEmail bool) *AuthHandler {
@@ -50,8 +53,9 @@ func NewAuthHandler(db *gorm.DB, privateKey *rsa.PrivateKey, signingKey []byte, 
 		refreshTTL:       refreshTTL,
 		emailSender:      emailSender,
 		frontendURL:      frontendURL,
-		autoConfirmEmail: autoConfirmEmail,
-		loginAttempts:    make(map[string]*loginAttempt),
+		autoConfirmEmail:  autoConfirmEmail,
+		loginAttempts:     make(map[string]*loginAttempt),
+		otpVerifyAttempts: make(map[string]*loginAttempt),
 	}
 
 	return h
@@ -95,14 +99,22 @@ func (h *AuthHandler) StartCleanup(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				h.loginMu.Lock()
 				cutoff := time.Now().Add(-15 * time.Minute)
+				h.loginMu.Lock()
 				for email, a := range h.loginAttempts {
 					if a.firstAt.Before(cutoff) {
 						delete(h.loginAttempts, email)
 					}
 				}
 				h.loginMu.Unlock()
+
+				h.otpVerifyMu.Lock()
+				for email, a := range h.otpVerifyAttempts {
+					if a.firstAt.Before(cutoff) {
+						delete(h.otpVerifyAttempts, email)
+					}
+				}
+				h.otpVerifyMu.Unlock()
 			}
 		}
 	})

--- a/internal/handler/auth_otp.go
+++ b/internal/handler/auth_otp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,7 +14,28 @@ import (
 	"github.com/usehiveloop/hiveloop/internal/email"
 	"github.com/usehiveloop/hiveloop/internal/model"
 )
+
+const (
+	// Request path: per-email throttle to prevent email bombing. Mirrors the
+	// pattern used by ForgotPassword (3 per 15 minutes).
+	otpRequestMaxPerWindow = 3
+	otpRequestWindow       = 15 * time.Minute
+
+	// Verify path: per-email brute-force lockout. After this many failed
+	// verify attempts within otpVerifyWindow the email is locked for
+	// otpVerifyLockout. A 6-digit code has only 1,000,000 combinations so
+	// we must be aggressive here.
+	otpVerifyMaxFailures = 5
+	otpVerifyWindow      = 10 * time.Minute
+	otpVerifyLockout     = 15 * time.Minute
+)
+
 func (h *AuthHandler) OTPRequest(w http.ResponseWriter, r *http.Request) {
+	// Generic body returned for both success and rate-limited responses so
+	// that an attacker can't use response content to enumerate emails or
+	// infer throttle state. Only the status code / Retry-After header differs.
+	genericBody := map[string]string{"status": "ok"}
+
 	var req otpRequestPayload
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -29,6 +51,31 @@ func (h *AuthHandler) OTPRequest(w http.ResponseWriter, r *http.Request) {
 	// Admin mode: reject non-admin emails
 	if h.adminMode && !h.platformAdminEmails[req.Email] {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "admin access required"})
+		return
+	}
+
+	// Per-email throttle to prevent email bombing. We count OTPCode rows
+	// created for this email within the window; we do NOT look up the user
+	// first, so this runs identically for existing and non-existing emails
+	// (anti-enumeration). Limit mirrors ForgotPassword: 3 per 15 minutes.
+	var recentCount int64
+	cutoff := time.Now().Add(-otpRequestWindow)
+	h.db.Model(&model.OTPCode{}).
+		Where("email = ? AND created_at > ?", req.Email, cutoff).
+		Count(&recentCount)
+	if recentCount >= otpRequestMaxPerWindow {
+		var oldest model.OTPCode
+		retryAfter := int(otpRequestWindow.Seconds())
+		if err := h.db.Where("email = ? AND created_at > ?", req.Email, cutoff).
+			Order("created_at ASC").
+			First(&oldest).Error; err == nil {
+			remaining := time.Until(oldest.CreatedAt.Add(otpRequestWindow))
+			if remaining > 0 {
+				retryAfter = int(remaining.Seconds()) + 1
+			}
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+		writeJSON(w, http.StatusTooManyRequests, genericBody)
 		return
 	}
 
@@ -71,7 +118,7 @@ func (h *AuthHandler) OTPRequest(w http.ResponseWriter, r *http.Request) {
 		slog.Error("failed to enqueue OTP email", "error", err, "email", req.Email)
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, genericBody)
 }
 
 // OTPVerify handles POST /auth/otp/verify.
@@ -84,6 +131,7 @@ func (h *AuthHandler) OTPRequest(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} authResponse
 // @Failure 400 {object} errorResponse
 // @Failure 401 {object} errorResponse
+// @Failure 429 {object} errorResponse
 // @Router /auth/otp/verify [post]
 func (h *AuthHandler) OTPVerify(w http.ResponseWriter, r *http.Request) {
 	var req otpVerifyPayload
@@ -100,16 +148,27 @@ func (h *AuthHandler) OTPVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Per-email lockout to prevent brute-force of the 6-digit code space.
+	// A 6-digit OTP has only 1,000,000 possible values; without per-email
+	// tracking the global per-IP rate limit is insufficient (see #60).
+	if locked, retryAfter := h.isOTPVerifyLocked(req.Email); locked {
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+		writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": "too many failed attempts, please try again later"})
+		return
+	}
+
 	// Look up the OTP by hash
 	codeHash := model.HashOTPCode(req.Code)
 	var otp model.OTPCode
 	err := h.db.Where("email = ? AND token_hash = ? AND used_at IS NULL", req.Email, codeHash).First(&otp).Error
 	if err != nil {
+		h.recordOTPVerifyFailureAndRotate(req.Email)
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid or expired code"})
 		return
 	}
 
 	if time.Now().After(otp.ExpiresAt) {
+		h.recordOTPVerifyFailureAndRotate(req.Email)
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid or expired code"})
 		return
 	}
@@ -117,6 +176,8 @@ func (h *AuthHandler) OTPVerify(w http.ResponseWriter, r *http.Request) {
 	// Mark code as used
 	now := time.Now()
 	h.db.Model(&otp).Update("used_at", &now)
+
+	h.clearOTPVerifyFailures(req.Email)
 
 	// Find or create user
 	var user model.User
@@ -185,6 +246,62 @@ func (h *AuthHandler) OTPVerify(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("user logged in via OTP", "user_id", user.ID, "email", user.Email)
 	h.issueTokensAndRespond(w, http.StatusOK, user, memberships[0].OrgID.String(), memberships[0].Role)
+}
+
+// isOTPVerifyLocked reports whether this email is currently locked out due
+// to too many failed verify attempts. Returns the Retry-After seconds when
+// locked.
+func (h *AuthHandler) isOTPVerifyLocked(email string) (bool, int) {
+	h.otpVerifyMu.Lock()
+	defer h.otpVerifyMu.Unlock()
+	a, ok := h.otpVerifyAttempts[email]
+	if !ok {
+		return false, 0
+	}
+	if time.Since(a.firstAt) > otpVerifyLockout {
+		delete(h.otpVerifyAttempts, email)
+		return false, 0
+	}
+	if a.failures >= otpVerifyMaxFailures {
+		remaining := time.Until(a.firstAt.Add(otpVerifyLockout))
+		if remaining < 0 {
+			remaining = 0
+		}
+		return true, int(remaining.Seconds()) + 1
+	}
+	return false, 0
+}
+
+// recordOTPVerifyFailureAndRotate bumps the failure counter for this email
+// and invalidates any outstanding OTP code so a leaked code can't be used
+// later. Rotating on every failure means an attacker brute-forcing the
+// code space burns the victim's real code as collateral damage, but more
+// importantly it ensures that once we start seeing failures the code in
+// flight is no longer valid.
+func (h *AuthHandler) recordOTPVerifyFailureAndRotate(email string) {
+	h.otpVerifyMu.Lock()
+	a, ok := h.otpVerifyAttempts[email]
+	if !ok || time.Since(a.firstAt) > otpVerifyWindow {
+		h.otpVerifyAttempts[email] = &loginAttempt{failures: 1, firstAt: time.Now()}
+	} else {
+		a.failures++
+	}
+	h.otpVerifyMu.Unlock()
+
+	// Invalidate any unused OTP codes for this email so a leaked or
+	// partially-guessed code is no longer usable. Best-effort: errors are
+	// logged but do not block the response.
+	if err := h.db.Model(&model.OTPCode{}).
+		Where("email = ? AND used_at IS NULL", email).
+		Update("used_at", time.Now()).Error; err != nil {
+		slog.Warn("failed to rotate OTP after failed verify", "error", err, "email", email)
+	}
+}
+
+func (h *AuthHandler) clearOTPVerifyFailures(email string) {
+	h.otpVerifyMu.Lock()
+	defer h.otpVerifyMu.Unlock()
+	delete(h.otpVerifyAttempts, email)
 }
 
 // --- Helpers ---


### PR DESCRIPTION
## Summary
- Per-email throttle on `POST /auth/otp/request` (3 per 15 min), 429 + `Retry-After`, identical body to success to avoid enumeration. Closes #64.
- Per-email failure lockout on `POST /auth/otp/verify` (5 failures / 10 min -> 15 min lockout), 429 + `Retry-After`, and every failed verify rotates/invalidates the outstanding OTP so a leaked code stops being useful. Closes #60.
- Reuses the in-memory `loginAttempt` pattern already used by password login; the existing `StartCleanup` goroutine evicts stale verify counters.

## Test plan
- [x] `go build ./internal/handler/...`
- [x] `go vet ./internal/handler/...`
- [ ] Manual: hit `/auth/otp/request` 4x -> 4th returns 429 with `Retry-After`, body is `{"status":"ok"}`.
- [ ] Manual: hit `/auth/otp/verify` with wrong code 5x -> 6th returns 429 with `Retry-After`; outstanding OTP is invalidated on the first failure.
- [ ] Manual: successful verify clears the failure counter.