### PR TITLE
fix(security): prevent CORS wildcard in prod and tighten admin API CORS

### DIFF
--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -143,7 +143,11 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 	r.Use(chimw.RealIP)
 	r.Use(posthogobs.Recoverer(deps.PostHog))
 	r.Use(middleware.SecurityHeaders())
-	r.Use(middleware.CORS(cfg.CORSOrigins))
+	corsMW, err := middleware.CORS(cfg.Environment, cfg.CORSOrigins)
+	if err != nil {
+		return fmt.Errorf("configure CORS middleware: %w", err)
+	}
+	r.Use(corsMW)
 	r.Use(middleware.RequestLog(logger))
 
 	rsaPub := rsaKey.Public().(*rsa.PublicKey)

--- a/cmd/server/serve_routes_admin.go
+++ b/cmd/server/serve_routes_admin.go
@@ -31,6 +31,7 @@ func setupAdminRoutes(
 		adminHandler := handler.NewAdminHandler(database, deps.Orchestrator, deps.NangoClient, deps.ActionsCatalog,
 			deps.RSAKey, deps.SigningKey, cfg.AuthIssuer, cfg.AuthAudience, cfg.AuthAccessTokenTTL, cfg.AuthRefreshTokenTTL, enqueuer)
 		r.Route("/admin/v1", func(r chi.Router) {
+			r.Use(middleware.AdminCORS(cfg.AdminCORSOrigins))
 			r.Use(middleware.RequireAuth(rsaPub, cfg.AuthIssuer, cfg.AuthAudience))
 			r.Use(middleware.RequireEmailConfirmed(database))
 			r.Use(middleware.ResolveUser(database))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,11 @@ type Config struct {
 
 	// CORS
 	CORSOrigins []string `env:"CORS_ORIGINS" envSeparator:","`
+	// AdminCORSOrigins is a stricter allowlist for /admin/v1/* routes. When
+	// empty, admin endpoints emit NO CORS headers — admin APIs are
+	// authenticated-only and not intended to be consumed from arbitrary
+	// browser origins. Should be a documented subset of CORS_ORIGINS.
+	AdminCORSOrigins []string `env:"ADMIN_CORS_ORIGINS" envSeparator:","`
 
 	// Nango (OAuth integration proxy)
 	NangoEndpoint  string `env:"NANGO_ENDPOINT"`    // e.g. http://localhost:3004

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -1,28 +1,85 @@
 package middleware
 
-import "net/http"
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+)
 
-// CORS returns middleware that allows cross-origin requests from the
-// specified origins. If allowedOrigins is empty, all origins are allowed.
-func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
-	allowAll := len(allowedOrigins) == 0
+// devFallbackOrigin is the default origin used when the server is running in
+// development/test and no explicit allowlist was provided. This matches the
+// Next.js dev server port configured in apps/web/package.json.
+const devFallbackOrigin = "http://localhost:30112"
 
+// isDevEnvironment reports whether the given environment string corresponds to
+// a non-production environment where a permissive CORS fallback is acceptable.
+func isDevEnvironment(env string) bool {
+	switch strings.ToLower(strings.TrimSpace(env)) {
+	case "", "dev", "development", "local", "test", "testing":
+		return true
+	default:
+		return false
+	}
+}
+
+// CORS returns middleware that allows cross-origin requests from the specified
+// origins.
+//
+// Behavior when allowedOrigins is empty:
+//   - In a development/test environment, the middleware falls back to a single
+//     localhost origin and logs a warning. This avoids the historical behavior
+//     of emitting a wildcard `*` which would accept requests from any site.
+//   - In any other environment the factory returns an error so the server
+//     refuses to start with an insecure CORS configuration.
+//
+// The returned middleware never emits `Access-Control-Allow-Origin: *` and
+// never pairs `Access-Control-Allow-Credentials: true` with a wildcard origin.
+func CORS(env string, allowedOrigins []string) (func(http.Handler) http.Handler, error) {
+	return newCORS(env, allowedOrigins, false)
+}
+
+// AdminCORS returns a stricter CORS middleware for authenticated-only admin
+// routes. When allowedOrigins is empty the returned middleware does NOT emit
+// any CORS headers — admin endpoints are not expected to be consumed from
+// arbitrary browsers. Preflight OPTIONS requests still receive a 204 to avoid
+// breaking legitimate same-origin tooling.
+func AdminCORS(allowedOrigins []string) func(http.Handler) http.Handler {
+	mw, _ := newCORS("", allowedOrigins, true)
+	return mw
+}
+
+func newCORS(env string, allowedOrigins []string, admin bool) (func(http.Handler) http.Handler, error) {
 	allowed := make(map[string]bool, len(allowedOrigins))
 	for _, o := range allowedOrigins {
+		o = strings.TrimSpace(o)
+		if o == "" {
+			continue
+		}
 		allowed[o] = true
+	}
+
+	if len(allowed) == 0 {
+		if admin {
+			slog.Warn("admin CORS allowlist is empty — admin endpoints will reject all cross-origin browser requests")
+		} else if isDevEnvironment(env) {
+			allowed[devFallbackOrigin] = true
+			slog.Warn("CORS_ORIGINS is empty — falling back to development default",
+				"origin", devFallbackOrigin,
+				"environment", env,
+			)
+		} else {
+			return nil, fmt.Errorf("CORS_ORIGINS must be set in %q environment: refusing to start with a wildcard CORS policy", env)
+		}
 	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
-			if origin != "" && (allowAll || allowed[origin]) {
-				if allowAll {
-					w.Header().Set("Access-Control-Allow-Origin", "*")
-				} else {
-					w.Header().Set("Access-Control-Allow-Origin", origin)
-					w.Header().Set("Access-Control-Allow-Credentials", "true")
-					w.Header().Set("Vary", "Origin")
-				}
+			if origin != "" && allowed[origin] {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				w.Header().Set("Vary", "Origin")
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Org-ID, Last-Event-ID, Cache-Control")
 				w.Header().Set("Access-Control-Max-Age", "300")
@@ -35,5 +92,5 @@ func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 
 			next.ServeHTTP(w, r)
 		})
-	}
+	}, nil
 }


### PR DESCRIPTION
## Summary

Closes #65. Closes #66.

Fixes two CORS misconfigurations where an empty `CORS_ORIGINS` caused the server to emit `Access-Control-Allow-Origin: *` (plus `Access-Control-Allow-Headers: Authorization`) across all routes, including authenticated `/admin/v1/*` endpoints.

- `internal/middleware/cors.go`: CORS factory now returns an error when no origins are configured in non-dev environments — the server refuses to boot instead of silently defaulting to a wildcard. In dev/test it falls back to `http://localhost:30112` (the Next.js dev port in `apps/web/package.json`) and logs a warning. Wildcard `*` origins are never emitted, and `Access-Control-Allow-Credentials` is only set alongside a specifically matched origin.
- New `AdminCORS` middleware, wired in `cmd/server/serve_routes_admin.go`, reads `ADMIN_CORS_ORIGINS` and applies a stricter allowlist only to `/admin/v1/*`. When empty, admin routes emit NO CORS headers — they are authenticated-only and should not be reachable from arbitrary browser origins.
- `cmd/server/serve.go` propagates the CORS factory error so misconfiguration fails fast on startup.
- Added `AdminCORSOrigins []string` (`ADMIN_CORS_ORIGINS`) to `internal/config/config.go`.

## Test plan

- [ ] `go build ./cmd/server/... ./internal/...` succeeds (it does; unrelated `cmd/fetchactions-*` and `skills/upload` build failures pre-exist on `main`)
- [ ] `go test ./internal/config/...` passes
- [ ] With `ENVIRONMENT=production` and `CORS_ORIGINS` unset, the server refuses to start
- [ ] With `ENVIRONMENT=development` and `CORS_ORIGINS` unset, the server starts and accepts only `http://localhost:30112`
- [ ] With `ADMIN_CORS_ORIGINS` unset, requests to `/admin/v1/*` receive no `Access-Control-Allow-*` headers
- [ ] No response ever combines `Access-Control-Allow-Origin: *` with `Access-Control-Allow-Credentials: true`