### PR TITLE
fix(security): require admin review before marketplace agent publish

### DIFF
--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -126,7 +126,11 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 	}
 	agentHandler := handler.NewAgentHandler(database, reg, pusherForHandler, sandboxEncKey, enqueuer)
 	agentHandler.SetCatalog(actionsCatalog)
-	marketplaceHandler := handler.NewMarketplaceHandler(database, redisClient)
+	var platformAdminEmails []string
+	if cfg.PlatformAdminEmails != "" {
+		platformAdminEmails = strings.Split(cfg.PlatformAdminEmails, ",")
+	}
+	marketplaceHandler := handler.NewMarketplaceHandler(database, redisClient, platformAdminEmails)
 
 	var driveHandler *handler.DriveHandler
 	if deps.S3Client != nil {
@@ -155,10 +159,6 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 	setupAuthRoutes(r, ctx, cfg, rsaPub, authHandler, oauthHandler)
 	setupV1Routes(r, cfg, rsaPub, database, apiKeyCache, enqueuer, orgHandler, orgInviteHandler, usageHandler, auditHandler, reportingHandler, generationHandler, apiKeyHandler, billingHandler, credHandler, tokenHandler, sandboxTemplateHandler, skillHandler, subagentHandler, agentHandler, marketplaceHandler, conversationHandler, systemConvHandler, routerHandler, customDomainHandler, orchestrator, auditWriter)
 
-	var platformAdminEmails []string
-	if cfg.PlatformAdminEmails != "" {
-		platformAdminEmails = strings.Split(cfg.PlatformAdminEmails, ",")
-	}
 	setupConnectRoutes(r, cfg, rsaPub, database, platformAdminEmails, inIntegrationHandler, inConnectionHandler)
 	setupAdminRoutes(r, cfg, deps, rsaPub, database, platformAdminEmails, enqueuer, marketplaceHandler)
 	setupProxyAndAuxRoutes(r, cfg, deps, signingKey, database, proxyHandler, driveHandler, sandboxEncKey, auditWriter, generationWriter, ctr)

--- a/cmd/server/serve_routes_admin.go
+++ b/cmd/server/serve_routes_admin.go
@@ -101,6 +101,7 @@ func setupAdminRoutes(
 			r.Delete("/workspace-storage/{id}", adminHandler.DeleteWorkspaceStorage)
 			r.Get("/marketplace/agents", marketplaceHandler.AdminList)
 			r.Put("/marketplace/agents/{id}", marketplaceHandler.AdminUpdate)
+			r.Post("/marketplace/agents/{id}/publish", marketplaceHandler.AdminPublish)
 			r.Delete("/marketplace/agents/{id}", marketplaceHandler.AdminDelete)
 			r.Post("/marketplace/cache/bust", marketplaceHandler.BustCache)
 		})

--- a/internal/handler/marketplace.go
+++ b/internal/handler/marketplace.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -20,12 +21,27 @@ const (
 
 // MarketplaceHandler manages the agent marketplace.
 type MarketplaceHandler struct {
-	db    *gorm.DB
-	redis *redis.Client
+	db           *gorm.DB
+	redis        *redis.Client
+	adminEmails  map[string]bool
 }
 
-func NewMarketplaceHandler(db *gorm.DB, redisClient *redis.Client) *MarketplaceHandler {
-	return &MarketplaceHandler{db: db, redis: redisClient}
+func NewMarketplaceHandler(db *gorm.DB, redisClient *redis.Client, platformAdminEmails []string) *MarketplaceHandler {
+	emailSet := make(map[string]bool, len(platformAdminEmails))
+	for _, e := range platformAdminEmails {
+		trimmed := strings.TrimSpace(e)
+		if trimmed != "" {
+			emailSet[trimmed] = true
+		}
+	}
+	return &MarketplaceHandler{db: db, redis: redisClient, adminEmails: emailSet}
+}
+
+func (h *MarketplaceHandler) isPlatformAdmin(email string) bool {
+	if h == nil || h.adminEmails == nil {
+		return false
+	}
+	return h.adminEmails[email]
 }
 
 type createMarketplaceAgentRequest struct {

--- a/internal/handler/marketplace_admin.go
+++ b/internal/handler/marketplace_admin.go
@@ -143,6 +143,44 @@ func (h *MarketplaceHandler) AdminUpdate(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, toMarketplaceAgentResponse(ma))
 }
 
+// AdminPublish handles POST /admin/v1/marketplace/agents/{id}/publish.
+// @Summary Admin publish marketplace agent
+// @Description Approves a marketplace listing and flips its status to published.
+// @Tags admin
+// @Produce json
+// @Param id path string true "Marketplace agent ID"
+// @Success 200 {object} marketplaceAgentResponse
+// @Failure 404 {object} errorResponse
+// @Security BearerAuth
+// @Router /admin/v1/marketplace/agents/{id}/publish [post]
+func (h *MarketplaceHandler) AdminPublish(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var ma model.MarketplaceAgent
+	if err := h.db.Where("id = ?", id).First(&ma).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "marketplace agent not found"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to find marketplace agent"})
+		return
+	}
+
+	updates := map[string]any{"status": "published"}
+	if ma.PublishedAt == nil {
+		now := time.Now()
+		updates["published_at"] = &now
+	}
+
+	if err := h.db.Model(&ma).Updates(updates).Error; err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to publish marketplace agent"})
+		return
+	}
+
+	h.db.Preload("Publisher").Where("id = ?", id).First(&ma)
+	slog.Info("admin: marketplace agent published", "marketplace_id", ma.ID)
+	writeJSON(w, http.StatusOK, toMarketplaceAgentResponse(ma))
+}
+
 // AdminDelete handles DELETE /admin/v1/marketplace/agents/{id}.
 // @Summary Admin delete marketplace agent
 // @Description Permanently deletes a marketplace agent.

--- a/internal/handler/marketplace_auth.go
+++ b/internal/handler/marketplace_auth.go
@@ -83,8 +83,24 @@ func (h *MarketplaceHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Status != nil {
 		status := *req.Status
-		if status != "draft" && status != "published" && status != "archived" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "status must be draft, published, or archived"})
+		isAdmin := h.isPlatformAdmin(user.Email)
+		switch status {
+		case "draft", "pending_review", "archived":
+		case "published":
+			// Only platform admins can directly publish. Publisher requests are
+			// downgraded to pending_review for moderator approval.
+			if !isAdmin {
+				status = "pending_review"
+			}
+		case "unlisted":
+			// Owner may unlist only if currently published (unpublish their own);
+			// admins may set unlisted at any time.
+			if !isAdmin && ma.Status != "published" {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": "only admins can set unlisted unless transitioning from published"})
+				return
+			}
+		default:
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "status must be draft, pending_review, published, unlisted, or archived"})
 			return
 		}
 		updates["status"] = status


### PR DESCRIPTION
## Summary

Closes #55.

`PUT /v1/marketplace/agents/{id}` previously let the publisher flip their own listing from `draft` to `published`, putting unreviewed agents on the public marketplace and bypassing the moderation pipeline entirely (featured / verified / flagged were all gated on admin review, but `status` was not).

## Changes

- `internal/handler/marketplace_auth.go`: status transitions are now role-aware.
  - Publishers may set `draft`, `pending_review`, or `archived` directly.
  - A publisher submitting `status=published` is downgraded server-side to `pending_review`.
  - Platform admins retain the ability to set `published` directly via the user-facing endpoint.
  - `unlisted` is only accepted from non-admins when transitioning away from the publisher's own `published` listing (lets owners voluntarily pull a listing without re-publishing).
- `internal/handler/marketplace_admin.go`: new `AdminPublish` handler for `POST /admin/v1/marketplace/agents/{id}/publish` that flips status to `published` and stamps `published_at`.
- `cmd/server/serve_routes_admin.go`: mounts the new route under the existing `/admin/v1` middleware stack (RequireAuth + RequirePlatformAdmin + AdminAudit).
- `internal/handler/marketplace.go` + `cmd/server/serve.go`: `NewMarketplaceHandler` now takes the platform-admin email allowlist so the publisher-facing handler can detect admin callers; the email set is shared with `RequirePlatformAdmin` semantics.

No data migration: existing `status=published` rows are untouched; only new publish attempts go through review.

## Test plan

- [ ] Non-admin PUT with `status=published` persists as `pending_review` and does not appear on `GET /v1/marketplace/agents`
- [ ] Non-admin PUT with `status=draft` / `pending_review` / `archived` works unchanged
- [ ] Admin PUT with `status=published` publishes immediately
- [ ] `POST /admin/v1/marketplace/agents/{id}/publish` flips a `pending_review` listing to `published` and sets `published_at`
- [ ] Non-admin cannot reach `/admin/v1/marketplace/agents/{id}/publish` (403 via `RequirePlatformAdmin`)
- [ ] Publisher can set their own published listing to `unlisted`; non-publisher/non-admin cannot set `unlisted` from non-published
- [ ] `go build ./cmd/server/... ./internal/...` passes