### PR TITLE
fix(security): redact per-user PII from usage and generations endpoints for non-admins

### DIFF
--- a/internal/handler/generations.go
+++ b/internal/handler/generations.go
@@ -46,6 +46,32 @@ type generationResponse struct {
 	CreatedAt       string   `json:"created_at"`
 }
 
+// redactedGenerationResponse mirrors generationResponse but omits fields that
+// identify the originating user (user_id) or reveal network-level PII
+// (ip_address). It is returned to callers who are not admin/owner of the org.
+type redactedGenerationResponse struct {
+	ID              string   `json:"id"`
+	OrgID           string   `json:"org_id"`
+	CredentialID    string   `json:"credential_id"`
+	TokenJTI        string   `json:"token_jti"`
+	ProviderID      string   `json:"provider_id"`
+	Model           string   `json:"model"`
+	RequestPath     string   `json:"request_path"`
+	IsStreaming     bool     `json:"is_streaming"`
+	InputTokens     int      `json:"input_tokens"`
+	OutputTokens    int      `json:"output_tokens"`
+	CachedTokens    int      `json:"cached_tokens"`
+	ReasoningTokens int      `json:"reasoning_tokens"`
+	Cost            float64  `json:"cost"`
+	TTFBMs          *int     `json:"ttfb_ms,omitempty"`
+	TotalMs         int      `json:"total_ms"`
+	UpstreamStatus  int      `json:"upstream_status"`
+	Tags            []string `json:"tags,omitempty"`
+	ErrorType       string   `json:"error_type,omitempty"`
+	ErrorMessage    string   `json:"error_message,omitempty"`
+	CreatedAt       string   `json:"created_at"`
+}
+
 func toGenerationResponse(g model.Generation) generationResponse {
 	resp := generationResponse{
 		ID:              g.ID,
@@ -69,6 +95,35 @@ func toGenerationResponse(g model.Generation) generationResponse {
 		ErrorType:       g.ErrorType,
 		ErrorMessage:    g.ErrorMessage,
 		IPAddress:       g.IPAddress,
+		CreatedAt:       g.CreatedAt.Format(time.RFC3339),
+	}
+	if resp.Tags == nil {
+		resp.Tags = []string{}
+	}
+	return resp
+}
+
+func toRedactedGenerationResponse(g model.Generation) redactedGenerationResponse {
+	resp := redactedGenerationResponse{
+		ID:              g.ID,
+		OrgID:           g.OrgID.String(),
+		CredentialID:    g.CredentialID.String(),
+		TokenJTI:        g.TokenJTI,
+		ProviderID:      g.ProviderID,
+		Model:           g.Model,
+		RequestPath:     g.RequestPath,
+		IsStreaming:     g.IsStreaming,
+		InputTokens:     g.InputTokens,
+		OutputTokens:    g.OutputTokens,
+		CachedTokens:    g.CachedTokens,
+		ReasoningTokens: g.ReasoningTokens,
+		Cost:            g.Cost,
+		TTFBMs:          g.TTFBMs,
+		TotalMs:         g.TotalMs,
+		UpstreamStatus:  g.UpstreamStatus,
+		Tags:            g.Tags,
+		ErrorType:       g.ErrorType,
+		ErrorMessage:    g.ErrorMessage,
 		CreatedAt:       g.CreatedAt.Format(time.RFC3339),
 	}
 	if resp.Tags == nil {
@@ -107,7 +162,11 @@ func (h *GenerationHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, toGenerationResponse(gen))
+	if middleware.IsOrgAdmin(h.db, r.Context()) {
+		writeJSON(w, http.StatusOK, toGenerationResponse(gen))
+		return
+	}
+	writeJSON(w, http.StatusOK, toRedactedGenerationResponse(gen))
 }
 
 // List handles GET /v1/generations.
@@ -180,21 +239,34 @@ func (h *GenerationHandler) List(w http.ResponseWriter, r *http.Request) {
 		gens = gens[:limit]
 	}
 
-	items := make([]generationResponse, len(gens))
-	for i, g := range gens {
-		items[i] = toGenerationResponse(g)
-	}
-
-	resp := paginatedResponse[generationResponse]{
-		Data:    items,
-		HasMore: hasMore,
-	}
+	var nextCursor *string
 	if hasMore && len(gens) > 0 {
 		last := gens[len(gens)-1]
 		// Use string cursor for generation IDs (not UUID)
 		c := encodeCursor(last.CreatedAt, last.OrgID) // reuse org_id as placeholder for cursor encoding
-		resp.NextCursor = &c
+		nextCursor = &c
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	if middleware.IsOrgAdmin(h.db, r.Context()) {
+		items := make([]generationResponse, len(gens))
+		for i, g := range gens {
+			items[i] = toGenerationResponse(g)
+		}
+		writeJSON(w, http.StatusOK, paginatedResponse[generationResponse]{
+			Data:       items,
+			HasMore:    hasMore,
+			NextCursor: nextCursor,
+		})
+		return
+	}
+
+	redacted := make([]redactedGenerationResponse, len(gens))
+	for i, g := range gens {
+		redacted[i] = toRedactedGenerationResponse(g)
+	}
+	writeJSON(w, http.StatusOK, paginatedResponse[redactedGenerationResponse]{
+		Data:       redacted,
+		HasMore:    hasMore,
+		NextCursor: nextCursor,
+	})
 }

--- a/internal/handler/usage.go
+++ b/internal/handler/usage.go
@@ -107,8 +107,11 @@ type usageResponse struct {
 	TokenVolumes   []tokenVolumes  `json:"token_volumes"`
 	Latency        []latencyStats  `json:"latency"`
 	TopModels      []topModel      `json:"top_models"`
-	TopUsers       []topUser       `json:"top_users"`
-	ErrorRates     []errorRate     `json:"error_rates"`
+	// TopUsers contains per-user request counts and cost attribution. It is
+	// only populated for callers with owner/admin role in the org so we do
+	// not leak individual spending patterns or user IDs to regular members.
+	TopUsers   []topUser   `json:"top_users"`
+	ErrorRates []errorRate `json:"error_rates"`
 }
 
 // Get handles GET /v1/usage.
@@ -133,6 +136,8 @@ func (h *UsageHandler) Get(w http.ResponseWriter, r *http.Request) {
 	last7d := today.AddDate(0, 0, -7)
 	last30d := today.AddDate(0, 0, -30)
 	orgID := org.ID
+
+	isAdmin := middleware.IsOrgAdmin(h.db, r.Context())
 
 	var resp usageResponse
 	p := pool.New().WithErrors().WithMaxGoroutines(12)
@@ -187,11 +192,13 @@ func (h *UsageHandler) Get(w http.ResponseWriter, r *http.Request) {
 		resp.TopModels, err = h.queryTopModels(orgID, last30d)
 		return err
 	})
-	p.Go(func() error {
-		var err error
-		resp.TopUsers, err = h.queryTopUsers(orgID, last30d)
-		return err
-	})
+	if isAdmin {
+		p.Go(func() error {
+			var err error
+			resp.TopUsers, err = h.queryTopUsers(orgID, last30d)
+			return err
+		})
+	}
 	p.Go(func() error {
 		var err error
 		resp.ErrorRates, err = h.queryErrorRates(orgID, last30d)

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -169,6 +169,29 @@ func RequireOrgAdmin(db *gorm.DB) func(http.Handler) http.Handler {
 	}
 }
 
+// IsOrgAdmin reports whether the caller is an "owner" or "admin" of the
+// organization resolved on the request context. Intended for handlers that
+// need field-level filtering based on role without rejecting the request
+// outright (unlike RequireOrgAdmin).
+func IsOrgAdmin(db *gorm.DB, ctx context.Context) bool {
+	if db == nil || ctx == nil {
+		return false
+	}
+	claims, ok := AuthClaimsFromContext(ctx)
+	if !ok || claims == nil || claims.UserID == "" {
+		return false
+	}
+	org, ok := OrgFromContext(ctx)
+	if !ok || org == nil {
+		return false
+	}
+	var m model.OrgMembership
+	if err := db.Where("user_id = ? AND org_id = ?", claims.UserID, org.ID).First(&m).Error; err != nil {
+		return false
+	}
+	return m.Role == "owner" || m.Role == "admin"
+}
+
 // RequirePlatformAdmin returns middleware that checks if the authenticated user's
 // email is in the platform admin allowlist.
 func RequirePlatformAdmin(adminEmails []string) func(http.Handler) http.Handler {


### PR DESCRIPTION
## Summary
- Closes #82 and #83.
- Strips per-user cost/identity data (`top_users`) from `GET /v1/usage` when the caller is not an org owner/admin.
- Strips `user_id` and `ip_address` from `GET /v1/generations` and `GET /v1/generations/{id}` for non-admin callers via a new `redactedGenerationResponse` shape.
- Adds `middleware.IsOrgAdmin(db, ctx) bool` so handlers can do field-level filtering without blocking the request (complement to the existing `RequireOrgAdmin` middleware).

This is defense-in-depth alongside the RBAC consolidation in #50: even if those endpoints stay reachable to regular members, the response no longer leaks per-user PII. Org-level aggregates (total cost, tokens, latency, top models, error rates) remain visible to all members.

## Test plan
- [ ] `go build ./internal/handler/... ./internal/middleware/...` passes.
- [ ] As a non-admin member, `GET /v1/usage` returns `top_users: []` and keeps org-level aggregates.
- [ ] As an owner/admin, `GET /v1/usage` returns a populated `top_users` array as before.
- [ ] As a non-admin, `GET /v1/generations` and `GET /v1/generations/{id}` no longer include `user_id` or `ip_address` in the payload; pagination cursor still works.
- [ ] As an admin, both generations endpoints return the full response shape.