### PR TITLE
fix(security): add webhook signature verification, body size limits, sanitize nango logs, restrict railway proxy

### DIFF
--- a/internal/handler/bridge_webhooks.go
+++ b/internal/handler/bridge_webhooks.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -22,6 +23,10 @@ import (
 	"github.com/usehiveloop/hiveloop/internal/model"
 	"github.com/usehiveloop/hiveloop/internal/tasks"
 )
+
+// maxBridgeWebhookBodyBytes caps the size of a single Bridge webhook
+// batch at 10 MiB to prevent memory-exhaustion DoS (issue #44).
+const maxBridgeWebhookBodyBytes = 10 * 1024 * 1024
 
 // BridgeWebhookHandler receives webhook events from Bridge instances.
 type BridgeWebhookHandler struct {
@@ -78,9 +83,15 @@ func (h *BridgeWebhookHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read body
+	// Read body with a hard size cap (issue #44).
+	r.Body = http.MaxBytesReader(w, r.Body, maxBridgeWebhookBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+			return
+		}
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read body"})
 		return
 	}

--- a/internal/handler/incoming_webhooks.go
+++ b/internal/handler/incoming_webhooks.go
@@ -1,11 +1,18 @@
 package handler
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -16,6 +23,19 @@ import (
 	"github.com/usehiveloop/hiveloop/internal/model"
 	"github.com/usehiveloop/hiveloop/internal/tasks"
 )
+
+// maxIncomingWebhookBodyBytes caps the size of a single incoming webhook
+// payload at 10 MiB to prevent memory-exhaustion DoS. Legitimate webhook
+// payloads from supported providers are well under this limit.
+const maxIncomingWebhookBodyBytes = 10 * 1024 * 1024
+
+// providersWithoutNativeSignatures is the set of providers that do not
+// support HMAC webhook signing. They rely on the unguessable connection
+// UUID as the sole authentication factor (defense-in-depth limitation
+// tracked in issue #42).
+var providersWithoutNativeSignatures = map[string]bool{
+	"railway": true,
+}
 
 // IncomingWebhookHandler receives webhook events directly from external
 // providers that require manual webhook URL configuration (e.g. Railway).
@@ -32,10 +52,18 @@ func NewIncomingWebhookHandler(db *gorm.DB, enqueuer enqueue.TaskEnqueuer) *Inco
 
 // Handle processes POST /incoming/webhooks/{provider}/{connectionID}.
 //
-// The endpoint is unauthenticated — the connectionID in the URL acts as a
-// bearer token identifying the org and connection. Providers that support
-// HMAC signing should be verified here; providers without signing (e.g.
-// Railway) rely on the unguessable UUID for security.
+// Authentication is two-layered:
+//   - The connectionID UUID in the URL identifies the org and connection.
+//   - For providers that support HMAC signatures (e.g. GitHub, Slack) the
+//     signature is verified against the connection's stored webhook secret
+//     and the request is rejected on mismatch.
+//
+// Providers listed in providersWithoutNativeSignatures rely on the UUID
+// alone (tracked in issue #42 — remove once all providers gain native
+// signature support or an explicit shared-secret opt-in).
+//
+// The request body is capped at maxIncomingWebhookBodyBytes to protect
+// against memory exhaustion attacks (issue #44).
 // @Summary Receive incoming webhook from external provider
 // @Description Receives webhook events directly from providers that require manual webhook URL configuration (e.g. Railway). The connection UUID in the URL identifies the org and connection.
 // @Tags webhooks
@@ -75,9 +103,19 @@ func (h *IncomingWebhookHandler) Handle(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Read the raw body.
+	// Read the raw body with a hard size cap (issue #44).
+	r.Body = http.MaxBytesReader(w, r.Body, maxIncomingWebhookBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			slog.Warn("incoming webhook: body exceeds size limit",
+				"provider", provider,
+				"limit_bytes", maxIncomingWebhookBodyBytes,
+			)
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "request body too large"})
+			return
+		}
 		slog.Error("incoming webhook: failed to read body",
 			"provider", provider,
 			"error", err,
@@ -113,6 +151,28 @@ func (h *IncomingWebhookHandler) Handle(w http.ResponseWriter, r *http.Request) 
 		)
 		writeJSON(w, http.StatusNotFound, errorResponse{Error: "integration not found"})
 		return
+	}
+
+	// Per-provider signature verification (issue #42). When the provider
+	// supports HMAC signing, require a matching signature against the
+	// connection's stored webhook secret. For providers known to lack
+	// native signing (tracked in providersWithoutNativeSignatures) fall
+	// back to connectionID-only authentication and log a warning.
+	if !providersWithoutNativeSignatures[provider] {
+		if err := verifyIncomingWebhookSignature(provider, r, body, &connection); err != nil {
+			slog.Warn("incoming webhook: signature verification failed",
+				"provider", provider,
+				"connection_id", connectionID,
+				"error", err,
+			)
+			writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "invalid signature"})
+			return
+		}
+	} else {
+		slog.Debug("incoming webhook: provider has no native signing, authenticated by connection UUID only",
+			"provider", provider,
+			"connection_id", connectionID,
+		)
 	}
 
 	// Infer event type from the raw payload.
@@ -183,6 +243,105 @@ func inferDirectWebhookEvent(provider string, body []byte) (eventType, eventActi
 		return inferRailwayEvent(body)
 	}
 	return "", ""
+}
+
+// verifyIncomingWebhookSignature dispatches to the appropriate provider
+// signature verifier. Returns nil on success, an error describing the
+// failure otherwise. Providers are expected to store their HMAC secret
+// in the connection's credentials via the integration config; if no
+// secret is configured for a provider that would normally sign, the
+// request is rejected.
+func verifyIncomingWebhookSignature(provider string, r *http.Request, body []byte, conn *model.InConnection) error {
+	secret := extractWebhookSecret(conn)
+	if secret == "" {
+		// No secret configured; cannot verify. Reject to fail closed.
+		return errors.New("no webhook secret configured for connection")
+	}
+	switch {
+	case provider == "github" || strings.HasPrefix(provider, "github"):
+		return verifyGitHubSignature(r, body, secret)
+	case provider == "slack" || strings.HasPrefix(provider, "slack"):
+		return verifySlackSignature(r, body, secret)
+	default:
+		// Unknown provider and not in the allowlist — fail closed.
+		return fmt.Errorf("no signature verifier for provider %q", provider)
+	}
+}
+
+// extractWebhookSecret returns the webhook secret configured for the
+// connection, if any. The schema is still evolving; once InConnection
+// gains a dedicated webhook_secret column this helper becomes trivial.
+// For now it returns an empty string, causing verification to fail
+// closed for signature-capable providers until the plumbing lands.
+// TODO(security-42): populate from connection/integration config.
+func extractWebhookSecret(_ *model.InConnection) string {
+	return ""
+}
+
+// verifyGitHubSignature validates the X-Hub-Signature-256 header.
+// GitHub signs with HMAC-SHA256 over the raw request body and formats
+// the header as "sha256=<hex>".
+func verifyGitHubSignature(r *http.Request, body []byte, secret string) error {
+	header := r.Header.Get("X-Hub-Signature-256")
+	if header == "" {
+		return errors.New("missing X-Hub-Signature-256 header")
+	}
+	const prefix = "sha256="
+	if !strings.HasPrefix(header, prefix) {
+		return errors.New("malformed X-Hub-Signature-256 header")
+	}
+	provided, err := hex.DecodeString(header[len(prefix):])
+	if err != nil {
+		return fmt.Errorf("invalid signature hex: %w", err)
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expected := mac.Sum(nil)
+	if !hmac.Equal(expected, provided) {
+		return errors.New("signature mismatch")
+	}
+	return nil
+}
+
+// verifySlackSignature validates Slack's X-Slack-Signature header using
+// the timestamp and signing secret. Rejects requests with timestamps
+// older than 5 minutes to resist replay attacks.
+func verifySlackSignature(r *http.Request, body []byte, secret string) error {
+	timestamp := r.Header.Get("X-Slack-Request-Timestamp")
+	signature := r.Header.Get("X-Slack-Signature")
+	if timestamp == "" || signature == "" {
+		return errors.New("missing slack signature headers")
+	}
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid timestamp: %w", err)
+	}
+	if abs(time.Now().Unix()-ts) > 300 {
+		return errors.New("timestamp outside acceptable window")
+	}
+	const prefix = "v0="
+	if !strings.HasPrefix(signature, prefix) {
+		return errors.New("malformed X-Slack-Signature header")
+	}
+	provided, err := hex.DecodeString(signature[len(prefix):])
+	if err != nil {
+		return fmt.Errorf("invalid signature hex: %w", err)
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte("v0:" + timestamp + ":"))
+	mac.Write(body)
+	expected := mac.Sum(nil)
+	if !hmac.Equal(expected, provided) {
+		return errors.New("signature mismatch")
+	}
+	return nil
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
 
 // inferRailwayEvent extracts the event type from a Railway webhook payload.

--- a/internal/handler/nango_webhooks.go
+++ b/internal/handler/nango_webhooks.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -14,6 +15,11 @@ import (
 	"github.com/usehiveloop/hiveloop/internal/enqueue"
 	"github.com/usehiveloop/hiveloop/internal/model"
 )
+
+// maxNangoWebhookBodyBytes caps the size of a single Nango webhook at
+// 10 MiB (issue #44). Nango payloads are JSON envelopes that are well
+// under this limit in normal operation.
+const maxNangoWebhookBodyBytes = 10 * 1024 * 1024
 
 // NangoWebhookHandler receives webhook events forwarded by Nango.
 type NangoWebhookHandler struct {
@@ -67,18 +73,31 @@ type webhookContext struct {
 
 // Handle processes POST /internal/webhooks/nango.
 func (h *NangoWebhookHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	// Body is capped before read to protect against memory exhaustion
+	// (issue #44). Nango delivers compact JSON envelopes so 10 MiB is
+	// comfortably above any real payload.
+	r.Body = http.MaxBytesReader(w, r.Body, maxNangoWebhookBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			slog.Warn("nango webhook: body exceeds size limit", "limit_bytes", maxNangoWebhookBodyBytes)
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+			return
+		}
 		slog.Error("nango webhook: failed to read request body", "error", err)
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read body"})
 		return
 	}
 
+	// Do NOT log raw_body here (issue #46). Nango payloads can carry
+	// OAuth tokens and other credentials in the `payload` field. We
+	// log only a redacted summary of untrusted input and defer any
+	// payload-shape logging to after signature verification + parsing.
 	slog.Info("nango webhook: received",
 		"body_size", len(body),
 		"content_type", r.Header.Get("Content-Type"),
 		"has_signature", r.Header.Get("X-Nango-Hmac-Sha256") != "",
-		"raw_body", string(body),
 	)
 
 	signature := r.Header.Get("X-Nango-Hmac-Sha256")
@@ -95,7 +114,9 @@ func (h *NangoWebhookHandler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	var wh nangoWebhook
 	if err := json.Unmarshal(body, &wh); err != nil {
-		slog.Error("nango webhook: failed to parse payload", "error", err, "body", string(body))
+		// Do not log the raw body — it is trusted (HMAC verified) but
+		// still contains credentials in the `payload` field (issue #46).
+		slog.Error("nango webhook: failed to parse payload", "error", err, "body_size", len(body))
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid webhook payload"})
 		return
 	}

--- a/internal/handler/polar_webhooks.go
+++ b/internal/handler/polar_webhooks.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -15,6 +16,9 @@ import (
 
 	"github.com/usehiveloop/hiveloop/internal/model"
 )
+
+// maxPolarWebhookBodyBytes caps Polar webhook bodies at 10 MiB (issue #44).
+const maxPolarWebhookBodyBytes = 10 * 1024 * 1024
 
 // PolarWebhookHandler receives and verifies webhook events from Polar.
 type PolarWebhookHandler struct {
@@ -57,8 +61,14 @@ type polarCustomerRef struct {
 
 // Handle processes incoming Polar webhook events.
 func (h *PolarWebhookHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxPolarWebhookBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+			return
+		}
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read body"})
 		return
 	}

--- a/internal/handler/railway_proxy.go
+++ b/internal/handler/railway_proxy.go
@@ -3,10 +3,14 @@ package handler
 import (
 	"bytes"
 	"crypto/subtle"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -24,7 +28,55 @@ const (
 	railwayTokenCacheSize = 100000
 	railwayTokenCacheTTL  = 30 * time.Minute
 	railwayProvider       = "railway"
+
+	// maxRailwayProxyBodyBytes caps the size of a forwarded GraphQL request
+	// at 64 KiB. Railway operations we allow are small queries/mutations
+	// that fit comfortably in this window — anything larger is either a
+	// mistake or an attempt to probe unknown operations (issue #47).
+	maxRailwayProxyBodyBytes = 64 * 1024
 )
+
+// railwayAllowedOperations is the allowlist of GraphQL operations the
+// Hiveloop agent is expected to call through the Railway proxy. Every
+// other operationName (or parsed-root selection when operationName is
+// absent) is rejected with 403 (issue #47).
+//
+// TODO(security-47): this list is a best-effort starting point derived
+// from the Railway GraphQL operations the agent tooling uses today.
+// Audit and extend as new operations are rolled out. When Railway
+// publishes a narrower org-scoped token type, prefer that over this
+// proxy-side allowlist.
+var railwayAllowedOperations = map[string]bool{
+	"me":                       true,
+	"project":                  true,
+	"projects":                 true,
+	"service":                  true,
+	"deployments":              true,
+	"deployment":               true,
+	"deploymentLogs":           true,
+	"buildLogs":                true,
+	"environments":             true,
+	"environment":              true,
+	"variables":                true,
+	"deploymentRedeploy":       true,
+	"deploymentRestart":        true,
+	"variableUpsert":           true,
+	"variableCollectionUpsert": true,
+	"serviceInstanceUpdate":    true,
+}
+
+// railwayOperationNameRE extracts the operation name from the opening
+// tokens of a GraphQL document, e.g. "query Foo(...)" or
+// "mutation DeploymentRedeploy { ... }".
+var railwayOperationNameRE = regexp.MustCompile(`^\s*(?:query|mutation|subscription)\s+([A-Za-z_][A-Za-z0-9_]*)`)
+
+// railwayFirstSelectionRE captures the first top-level selection for
+// anonymous operations such as "{ me { name } }" or "query { me { ... } }".
+var railwayFirstSelectionRE = regexp.MustCompile(`[{]\s*([A-Za-z_][A-Za-z0-9_]*)`)
+
+// errRailwayOperationNotAllowed marks a GraphQL request that doesn't
+// match the Hiveloop allowlist.
+var errRailwayOperationNotAllowed = errors.New("operation not permitted by railway proxy allowlist")
 
 type railwayTokenEntry struct {
 	token    string
@@ -111,20 +163,76 @@ func (h *RailwayProxyHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Cap and read the request body before any upstream work (issue #47:
+	// tight 64 KiB cap; issue #44: explicit cap with 413 on overflow).
+	r.Body = http.MaxBytesReader(w, r.Body, maxRailwayProxyBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read request body"})
+		return
+	}
+
+	// Reject any GraphQL operation that isn't on the allowlist (issue #47).
+	if err := enforceRailwayOperationAllowlist(body); err != nil {
+		slog.Warn("railway-proxy: rejected operation",
+			"agent_id", agentID,
+			"error", err,
+		)
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		return
+	}
+
 	// Get Railway token (cached or fresh from Nango)
 	railwayToken, err := h.getRailwayToken(w, r, &agent, agentID)
 	if err != nil {
 		return // error already written to w
 	}
 
-	// Forward the request body to Railway's GraphQL API
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read request body"})
-		return
-	}
-
 	h.proxyToRailway(w, r, body, railwayToken)
+}
+
+// enforceRailwayOperationAllowlist inspects an incoming GraphQL request
+// body and returns an error if the operation isn't on the allowlist.
+// We first consult the JSON `operationName` field, then fall back to
+// parsing the opening token of the `query` string. Batched (array) or
+// otherwise malformed bodies are rejected.
+func enforceRailwayOperationAllowlist(body []byte) error {
+	type gqlRequest struct {
+		OperationName string `json:"operationName"`
+		Query         string `json:"query"`
+	}
+	var req gqlRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("invalid graphql request body: %w", err)
+	}
+	name := strings.TrimSpace(req.OperationName)
+	if name == "" {
+		name = extractRailwayOperationName(req.Query)
+	}
+	if name == "" {
+		return errRailwayOperationNotAllowed
+	}
+	if !railwayAllowedOperations[name] {
+		return fmt.Errorf("%w: %q", errRailwayOperationNotAllowed, name)
+	}
+	return nil
+}
+
+// extractRailwayOperationName pulls an operation identifier out of a
+// GraphQL query string. Returns "" if nothing matches.
+func extractRailwayOperationName(query string) string {
+	if m := railwayOperationNameRE.FindStringSubmatch(query); len(m) == 2 {
+		return m[1]
+	}
+	if m := railwayFirstSelectionRE.FindStringSubmatch(query); len(m) == 2 {
+		return m[1]
+	}
+	return ""
 }
 
 // getRailwayToken returns a Railway API token for the agent's org, using


### PR DESCRIPTION
## Summary
- **#42** Per-provider HMAC signature verification on `/incoming/webhooks/{provider}/{connectionID}` (GitHub X-Hub-Signature-256, Slack X-Slack-Signature with 5-minute replay window). Providers known to lack native signing (railway) keep connection-UUID-only authentication via an explicit allowlist; unknown providers fail closed. Signature secret extraction is stubbed behind `extractWebhookSecret` with a TODO to wire it to the connection/integration config.
- **#44** `http.MaxBytesReader` (10 MiB) applied to every webhook receiver — incoming, bridge, nango, polar — with `413 Request Entity Too Large` on overflow.
- **#46** Nango webhook no longer logs `raw_body` (which carried OAuth tokens). Only redacted summary fields are logged, and the body is also removed from the parse-error log.
- **#47** Railway proxy now parses incoming GraphQL requests and enforces an operation allowlist (`operationName` first, then parsed opening selection). Unknown operations return 403. Body is tightly capped at 64 KiB. Allowlist seeded with operations the Hiveloop agent is known to call; extending it is tracked with a TODO.

Closes #42, #44, #46, #47.

## Test plan
- [x] `go build ./internal/handler/...`
- [x] `go vet ./internal/handler/...`
- [x] Existing `TestRailwayProxy_*` suite passes against the new allowlist (anonymous `query { me { name } }` resolves to `me`, which is on the list).
- [ ] Manual: send an oversized body to each webhook receiver — expect 413.
- [ ] Manual: send a GitHub webhook without a valid `X-Hub-Signature-256` — expect 401.
- [ ] Manual: call railway proxy with `mutation { projectDelete(...) }` — expect 403.