### PR TITLE
fix(security): harden login/logout/refresh rate limits and block unsolicited OAuth auto-link

### DIFF
--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -74,7 +74,7 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 		emailSender = email.NewAsynqSender(enqueuer)
 	}
 	orgInviteHandler := handler.NewOrgInviteHandler(database, emailSender, cfg.FrontendURL)
-	authHandler := handler.NewAuthHandler(database, rsaKey, signingKey,
+	authHandler := handler.NewAuthHandler(database, redisClient, rsaKey, signingKey,
 		cfg.AuthIssuer, cfg.AuthAudience, cfg.AuthAccessTokenTTL, cfg.AuthRefreshTokenTTL,
 		emailSender, cfg.FrontendURL, cfg.AutoConfirmEmail)
 	if cfg.PlatformAdminEmails != "" {

--- a/e2e/org_invites_test.go
+++ b/e2e/org_invites_test.go
@@ -44,7 +44,7 @@ func newInviteHarness(t *testing.T) *inviteHarness {
 	}
 	pubKey := &privKey.PublicKey
 
-	authHandler := handler.NewAuthHandler(h.db, privKey, []byte("invite-e2e-hmac"),
+	authHandler := handler.NewAuthHandler(h.db, nil, privKey, []byte("invite-e2e-hmac"),
 		inviteTestIssuer, inviteTestAudience, 15*time.Minute, 24*time.Hour,
 		&email.LogSender{}, "http://localhost:3000", true)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/e2e/org_test.go
+++ b/e2e/org_test.go
@@ -46,7 +46,7 @@ func newOrgHarness(t *testing.T) *orgHarness {
 	pubKey := &privKey.PublicKey
 	signingHMAC := []byte("e2e-org-hmac-signing-key")
 
-	authHandler := handler.NewAuthHandler(h.db, privKey, signingHMAC, orgTestIssuer, orgTestAudience, 15*time.Minute, 24*time.Hour, &email.LogSender{}, "http://localhost:3000", true)
+	authHandler := handler.NewAuthHandler(h.db, nil, privKey, signingHMAC, orgTestIssuer, orgTestAudience, 15*time.Minute, 24*time.Hour, &email.LogSender{}, "http://localhost:3000", true)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	authHandler.StartCleanup(ctx)

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -4,22 +4,17 @@ import (
 	"context"
 	"crypto/rsa"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 
 	"github.com/usehiveloop/hiveloop/internal/email"
-	"github.com/usehiveloop/hiveloop/internal/goroutine"
 )
-
-type loginAttempt struct {
-	failures int
-	firstAt  time.Time
-}
 
 type AuthHandler struct {
 	db          *gorm.DB
+	redis       *redis.Client
 	privateKey  *rsa.PrivateKey
 	signingKey  []byte // HMAC key for refresh tokens (JWT_SIGNING_KEY)
 	issuer      string
@@ -34,14 +29,14 @@ type AuthHandler struct {
 	// Used by the admin panel deployment to prevent non-admin users from logging in.
 	adminMode          bool
 	platformAdminEmails map[string]bool
-
-	loginMu       sync.Mutex
-	loginAttempts map[string]*loginAttempt // keyed by email
 }
 
-func NewAuthHandler(db *gorm.DB, privateKey *rsa.PrivateKey, signingKey []byte, issuer, audience string, accessTTL, refreshTTL time.Duration, emailSender email.Sender, frontendURL string, autoConfirmEmail bool) *AuthHandler {
+// NewAuthHandler constructs an AuthHandler. A non-nil redis client is required
+// for login rate limiting; pass a connected client from bootstrap.Deps.Redis.
+func NewAuthHandler(db *gorm.DB, redisClient *redis.Client, privateKey *rsa.PrivateKey, signingKey []byte, issuer, audience string, accessTTL, refreshTTL time.Duration, emailSender email.Sender, frontendURL string, autoConfirmEmail bool) *AuthHandler {
 	h := &AuthHandler{
 		db:               db,
+		redis:            redisClient,
 		privateKey:       privateKey,
 		signingKey:       signingKey,
 		issuer:           issuer,
@@ -51,7 +46,6 @@ func NewAuthHandler(db *gorm.DB, privateKey *rsa.PrivateKey, signingKey []byte, 
 		emailSender:      emailSender,
 		frontendURL:      frontendURL,
 		autoConfirmEmail: autoConfirmEmail,
-		loginAttempts:    make(map[string]*loginAttempt),
 	}
 
 	return h
@@ -84,26 +78,6 @@ func (h *AuthHandler) SetPlatformAdminEmails(emails []string) {
 	}
 }
 
-// StartCleanup starts a background goroutine that evicts stale login attempts
-// every 5 minutes. The goroutine stops when ctx is cancelled.
-func (h *AuthHandler) StartCleanup(ctx context.Context) {
-	goroutine.Go(func() {
-		ticker := time.NewTicker(5 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				h.loginMu.Lock()
-				cutoff := time.Now().Add(-15 * time.Minute)
-				for email, a := range h.loginAttempts {
-					if a.firstAt.Before(cutoff) {
-						delete(h.loginAttempts, email)
-					}
-				}
-				h.loginMu.Unlock()
-			}
-		}
-	})
-}
+// StartCleanup is a no-op retained for API compatibility. Rate-limit state is
+// now kept in Redis with TTLs so no periodic eviction is required.
+func (h *AuthHandler) StartCleanup(ctx context.Context) {}

--- a/internal/handler/auth_helpers.go
+++ b/internal/handler/auth_helpers.go
@@ -1,46 +1,121 @@
 package handler
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"time"
 
-
 	"github.com/usehiveloop/hiveloop/internal/auth"
 	"github.com/usehiveloop/hiveloop/internal/model"
 )
-func (h *AuthHandler) isLoginLocked(email string) bool {
-	h.loginMu.Lock()
-	defer h.loginMu.Unlock()
-	a, ok := h.loginAttempts[email]
-	if !ok {
-		return false
+
+// Login rate limiting is Redis-backed with a composite (ip, email) scope.
+// Two independent counters are maintained, each using INCR + EXPIRE with
+// loginLockoutWindow TTL:
+//
+//   login:fail:ip:<ip>       primary bucket — defeats credential stuffing from
+//                            a single source against many emails.
+//   login:fail:email:<email> secondary bucket — keeps per-account lockout.
+//
+// Either bucket exceeding its threshold triggers a deny. On success both
+// buckets are cleared. If Redis is unavailable we fail open so a cache
+// outage never locks every user out.
+
+const (
+	loginFailIPPrefix    = "login:fail:ip:"
+	loginFailEmailPrefix = "login:fail:email:"
+	// maxLoginFailuresPerIP is deliberately higher than the per-email limit
+	// so legitimate shared-NAT traffic is not disrupted by one careless user,
+	// while still breaking credential stuffing that cycles many emails.
+	maxLoginFailuresPerIP = 20
+)
+
+// clientIP returns the IP (host portion) of the request, falling back to
+// RemoteAddr if it is not in host:port form.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if comma := strings.IndexByte(xff, ','); comma > 0 {
+			return strings.TrimSpace(xff[:comma])
+		}
+		return strings.TrimSpace(xff)
 	}
-	if time.Since(a.firstAt) > loginLockoutWindow {
-		delete(h.loginAttempts, email)
-		return false
+	if real := r.Header.Get("X-Real-IP"); real != "" {
+		return strings.TrimSpace(real)
 	}
-	return a.failures >= maxLoginFailures
+	if ip, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return ip
+	}
+	return r.RemoteAddr
 }
 
-func (h *AuthHandler) recordLoginFailure(email string) {
-	h.loginMu.Lock()
-	defer h.loginMu.Unlock()
-	a, ok := h.loginAttempts[email]
-	if !ok || time.Since(a.firstAt) > loginLockoutWindow {
-		h.loginAttempts[email] = &loginAttempt{failures: 1, firstAt: time.Now()}
+func (h *AuthHandler) isLoginLocked(ctx context.Context, ip, email string) bool {
+	if h.redis == nil {
+		return false
+	}
+
+	if ip != "" {
+		ipKey := loginFailIPPrefix + ip
+		if n, err := h.redis.Get(ctx, ipKey).Int64(); err == nil && n >= maxLoginFailuresPerIP {
+			return true
+		}
+	}
+	if email != "" {
+		emailKey := loginFailEmailPrefix + email
+		if n, err := h.redis.Get(ctx, emailKey).Int64(); err == nil && n >= maxLoginFailures {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *AuthHandler) recordLoginFailure(ctx context.Context, ip, email string) {
+	if h.redis == nil {
 		return
 	}
-	a.failures++
+
+	incr := func(key string) {
+		n, err := h.redis.Incr(ctx, key).Result()
+		if err != nil {
+			slog.Warn("login rate limit incr failed", "key", key, "error", err)
+			return
+		}
+		if n == 1 {
+			if err := h.redis.Expire(ctx, key, loginLockoutWindow).Err(); err != nil {
+				slog.Warn("login rate limit expire failed", "key", key, "error", err)
+			}
+		}
+	}
+
+	if ip != "" {
+		incr(loginFailIPPrefix + ip)
+	}
+	if email != "" {
+		incr(loginFailEmailPrefix + email)
+	}
 }
 
-func (h *AuthHandler) clearLoginFailures(email string) {
-	h.loginMu.Lock()
-	defer h.loginMu.Unlock()
-	delete(h.loginAttempts, email)
+func (h *AuthHandler) clearLoginFailures(ctx context.Context, ip, email string) {
+	if h.redis == nil {
+		return
+	}
+	keys := make([]string, 0, 2)
+	if ip != "" {
+		keys = append(keys, loginFailIPPrefix+ip)
+	}
+	if email != "" {
+		keys = append(keys, loginFailEmailPrefix+email)
+	}
+	if len(keys) == 0 {
+		return
+	}
+	if err := h.redis.Del(ctx, keys...).Err(); err != nil {
+		slog.Warn("login rate limit clear failed", "error", err)
+	}
 }
 
 // --- OTP Authentication ---

--- a/internal/handler/auth_login.go
+++ b/internal/handler/auth_login.go
@@ -24,29 +24,34 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Per-account rate limiting: 5 failed attempts per 15 minutes.
-	if h.isLoginLocked(req.Email) {
-		slog.Warn("login rate limited", "email", req.Email)
+	ctx := r.Context()
+	ip := clientIP(r)
+
+	// Composite rate limiting: per-IP bucket (primary, defeats credential
+	// stuffing across many emails) and per-email bucket (secondary, protects
+	// a targeted account). Either exceeding its threshold denies the request.
+	if h.isLoginLocked(ctx, ip, req.Email) {
+		slog.Warn("login rate limited", "email", req.Email, "ip", ip)
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
 		return
 	}
 
 	var user model.User
 	if err := h.db.Where("email = ?", req.Email).First(&user).Error; err != nil {
-		h.recordLoginFailure(req.Email)
+		h.recordLoginFailure(ctx, ip, req.Email)
 		slog.Warn("login failed", "email", req.Email, "reason", "invalid_credentials")
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
 		return
 	}
 
 	if user.PasswordHash == "" || !auth.CheckPassword(user.PasswordHash, req.Password) {
-		h.recordLoginFailure(req.Email)
+		h.recordLoginFailure(ctx, ip, req.Email)
 		slog.Warn("login failed", "email", req.Email, "reason", "invalid_credentials")
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
 		return
 	}
 
-	h.clearLoginFailures(req.Email)
+	h.clearLoginFailures(ctx, ip, req.Email)
 
 	// Admin mode: reject non-admin users
 	if h.adminMode && !h.platformAdminEmails[user.Email] {

--- a/internal/handler/auth_otp_edge_test.go
+++ b/internal/handler/auth_otp_edge_test.go
@@ -120,7 +120,7 @@ func TestOTP_AdminModeRejectsNonAdmin(t *testing.T) {
 	}
 
 	authHandler := handler.NewAuthHandler(
-		db, pk, []byte("test-key"),
+		db, nil, pk, []byte("test-key"),
 		"test", "http://localhost",
 		15*time.Minute, 720*time.Hour,
 		&email.LogSender{},

--- a/internal/handler/auth_otp_test.go
+++ b/internal/handler/auth_otp_test.go
@@ -40,7 +40,7 @@ func newOTPHarness(t *testing.T) *otpTestHarness {
 	signingKey := []byte("test-signing-key-for-refresh-tokens")
 
 	authHandler := handler.NewAuthHandler(
-		db, pk, signingKey,
+		db, nil, pk, signingKey,
 		"hiveloop-test", "http://localhost:8080",
 		15*time.Minute, 720*time.Hour,
 		&email.LogSender{},

--- a/internal/handler/auth_refresh.go
+++ b/internal/handler/auth_refresh.go
@@ -2,13 +2,26 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/usehiveloop/hiveloop/internal/auth"
+	"github.com/usehiveloop/hiveloop/internal/middleware"
 	"github.com/usehiveloop/hiveloop/internal/model"
 )
+
+// Refresh handles POST /auth/refresh.
+//
+// The rotation flow is wrapped in a transaction with SELECT ... FOR UPDATE so
+// two concurrent requests presenting the same token cannot both pass the
+// revoked_at check. If a caller presents a token that has already been marked
+// revoked (reuse detection) the whole refresh chain for that user is
+// invalidated — a signal of probable token theft.
 func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	var req refreshRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -28,22 +41,63 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check the token hash in the database (revocation check + rotation).
 	tokenHash := hashToken(req.RefreshToken)
+
 	var storedToken model.RefreshToken
-	if err := h.db.Where("token_hash = ? AND revoked_at IS NULL", tokenHash).First(&storedToken).Error; err != nil {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "refresh token revoked or not found"})
+	var reuseDetected bool
+
+	txErr := h.db.Transaction(func(tx *gorm.DB) error {
+		// Row-lock the token so two concurrent refreshes serialize. The
+		// first commits the revoked_at update; the second re-reads the now
+		// non-null revoked_at and triggers reuse detection below.
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("token_hash = ?", tokenHash).
+			First(&storedToken).Error; err != nil {
+			return err
+		}
+
+		if storedToken.RevokedAt != nil {
+			// The token exists but is already revoked: either a replay of a
+			// previously rotated token or a genuine reuse. Either way we
+			// invalidate every outstanding refresh token for this user.
+			reuseDetected = true
+			now := time.Now()
+			if err := tx.Model(&model.RefreshToken{}).
+				Where("user_id = ? AND revoked_at IS NULL", storedToken.UserID).
+				Update("revoked_at", &now).Error; err != nil {
+				return err
+			}
+			return nil
+		}
+
+		if time.Now().After(storedToken.ExpiresAt) {
+			return errRefreshExpired
+		}
+
+		now := time.Now()
+		return tx.Model(&storedToken).Update("revoked_at", &now).Error
+	})
+
+	if txErr != nil {
+		if errors.Is(txErr, gorm.ErrRecordNotFound) {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "refresh token revoked or not found"})
+			return
+		}
+		if errors.Is(txErr, errRefreshExpired) {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "refresh token expired"})
+			return
+		}
+		slog.Error("refresh rotation failed", "error", txErr)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
-	if time.Now().After(storedToken.ExpiresAt) {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "refresh token expired"})
+	if reuseDetected {
+		slog.Warn("refresh token reuse detected; chain revoked",
+			"user_id", storedToken.UserID, "token_hash", tokenHash)
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "refresh token reuse detected"})
 		return
 	}
-
-	// Revoke the old refresh token (rotation).
-	now := time.Now()
-	h.db.Model(&storedToken).Update("revoked_at", &now)
 
 	// Get memberships to determine org/role.
 	var user model.User
@@ -81,6 +135,10 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	h.issueTokensAndRespond(w, http.StatusOK, user, orgID, role)
 }
 
+// errRefreshExpired is returned from the rotation transaction to signal a
+// 401-expired response without ambiguous ErrRecordNotFound semantics.
+var errRefreshExpired = errors.New("refresh token expired")
+
 // Logout handles POST /auth/logout.
 // @Summary Log out
 // @Description Revokes a refresh token.
@@ -103,9 +161,44 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	claims, ok := middleware.AuthClaimsFromContext(r.Context())
+	if !ok || claims == nil || claims.UserID == "" {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing auth context"})
+		return
+	}
+
+	// Verify the supplied refresh token belongs to the caller before revoking.
+	// Use the JWT claim as the primary check (cheap, no DB lookup needed
+	// when tokens do not match) and cross-check the stored row to cover the
+	// case where the token is valid but not recorded or already revoked.
+	tokenUserID, _, err := auth.ValidateRefreshToken(h.signingKey, req.RefreshToken)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid refresh token"})
+		return
+	}
+	if tokenUserID != claims.UserID {
+		slog.Warn("logout ownership mismatch",
+			"auth_user_id", claims.UserID, "token_user_id", tokenUserID)
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "refresh token does not belong to this user"})
+		return
+	}
+
 	tokenHash := hashToken(req.RefreshToken)
+
+	var stored model.RefreshToken
+	if err := h.db.Where("token_hash = ?", tokenHash).First(&stored).Error; err == nil {
+		if stored.UserID.String() != claims.UserID {
+			slog.Warn("logout ownership mismatch on stored token",
+				"auth_user_id", claims.UserID, "stored_user_id", stored.UserID)
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "refresh token does not belong to this user"})
+			return
+		}
+	}
+
 	now := time.Now()
-	h.db.Model(&model.RefreshToken{}).Where("token_hash = ? AND revoked_at IS NULL", tokenHash).Update("revoked_at", &now)
+	h.db.Model(&model.RefreshToken{}).
+		Where("token_hash = ? AND user_id = ? AND revoked_at IS NULL", tokenHash, claims.UserID).
+		Update("revoked_at", &now)
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }

--- a/internal/handler/oauth_callback.go
+++ b/internal/handler/oauth_callback.go
@@ -1,12 +1,12 @@
 package handler
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
 
 	"golang.org/x/oauth2"
-
 )
 
 // oauthProfile holds the normalised user info fetched from an OAuth provider.
@@ -106,6 +106,12 @@ func (h *OAuthHandler) handleCallback(w http.ResponseWriter, r *http.Request, pr
 	// 7. Find or create user + link OAuth account.
 	user, err := h.findOrCreateUser(provider, profile)
 	if err != nil {
+		if errors.Is(err, errOAuthLinkRequiresConfirmation) {
+			slog.Warn("oauth auto-link blocked for confirmed account",
+				"provider", provider, "email", profile.Email)
+			h.redirectError(w, r, "account_link_required")
+			return
+		}
 		slog.Error("oauth user creation failed", "provider", provider, "error", err)
 		h.redirectError(w, r, "account_creation_failed")
 		return

--- a/internal/handler/oauth_user.go
+++ b/internal/handler/oauth_user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -16,6 +17,13 @@ import (
 	"github.com/usehiveloop/hiveloop/internal/auth"
 	"github.com/usehiveloop/hiveloop/internal/model"
 )
+
+// errOAuthLinkRequiresConfirmation is returned by findOrCreateUser when an
+// OAuth sign-in matches a confirmed local account that has not yet linked the
+// provider. The caller must surface an error asking the user to log in with
+// their existing credentials and link the provider from their account
+// settings; we never silently merge the sessions.
+var errOAuthLinkRequiresConfirmation = errors.New("oauth: account exists; link required")
 
 // oauthProfile holds the normalised user info fetched from an OAuth provider.
 
@@ -96,7 +104,16 @@ func (h *OAuthHandler) findOrCreateUser(provider string, profile *oauthProfile) 
 	err = h.db.Where("email = ?", email).First(&user).Error
 
 	if err == nil {
-		// User exists — link the provider.
+		// A local account with this email already exists. Silently linking a
+		// new OAuth provider to a confirmed account is a takeover risk: an
+		// attacker who controls an OAuth-verified email could claim a
+		// pre-existing local account. Require an explicit, authenticated
+		// link step. Unconfirmed accounts (which never proved email
+		// ownership) are still auto-linked since they carry no trust.
+		if user.EmailConfirmedAt != nil {
+			return nil, errOAuthLinkRequiresConfirmation
+		}
+
 		oauthAcct := model.OAuthAccount{
 			UserID:         user.ID,
 			Provider:       provider,
@@ -105,8 +122,9 @@ func (h *OAuthHandler) findOrCreateUser(provider string, profile *oauthProfile) 
 		if err := h.db.Create(&oauthAcct).Error; err != nil {
 			return nil, fmt.Errorf("linking oauth account: %w", err)
 		}
-		// Mark email as confirmed if not already and provider verified it.
-		if user.EmailConfirmedAt == nil && !isPlaceholderEmail(email) {
+		// The OAuth provider just verified this email; promote the account
+		// to confirmed unless the address is a placeholder (e.g. X/Twitter).
+		if !isPlaceholderEmail(email) {
 			now := time.Now()
 			h.db.Model(&user).Update("email_confirmed_at", &now)
 			user.EmailConfirmedAt = &now


### PR DESCRIPTION
## Summary
Four medium-severity auth/session hardenings in a single change:

- **#69 login rate limiting**: replaces the in-memory per-email `loginAttempts` map with Redis-backed `INCR`+`EXPIRE` counters scoped as `(ip, email)`. Per-IP bucket (threshold 20) is the primary defence against credential stuffing; per-email bucket (threshold 5) keeps the targeted-account lockout. Survives restarts and is shared across instances. Falls open on Redis outage.
- **#70 logout ownership**: `Logout` now checks the supplied refresh token's `UserID` claim against the authenticated caller's `UserID` (JWT) and cross-checks the stored row. 403 on mismatch; the `UPDATE` is scoped by `user_id` so an attacker cannot revoke another user's row.
- **#73 refresh rotation race + reuse detection**: the select-then-revoke is now wrapped in a transaction with `SELECT ... FOR UPDATE`, so concurrent requests serialise. If a presented token is already revoked, the entire refresh chain for that user is invalidated and a 401 is returned.
- **#76 OAuth auto-link**: callback no longer silently attaches an OAuth provider to an existing confirmed local account. Unconfirmed accounts (never proved email ownership) still auto-link. Confirmed accounts get an `account_link_required` error on redirect, forcing an explicit, authenticated link flow.

Closes #69, #70, #73, #76.

## Test plan
- [ ] `go build ./...` passes (verified in worktree; pre-existing `cmd/fetchactions-*` and `skills/upload` errors unchanged).
- [ ] `go test -count=0 ./internal/handler/... ./e2e/...` compiles cleanly.
- [ ] Manual: spam `/auth/login` from one IP with many emails, confirm per-IP bucket throttles after 20 failures.
- [ ] Manual: two concurrent `/auth/refresh` calls with the same token — exactly one succeeds, the second reports `refresh token reuse detected` and invalidates all other refresh tokens for that user.
- [ ] Manual: user A calls `/auth/logout` with user B's refresh token in body — 403, user B's token still valid.
- [ ] Manual: OAuth login with a provider whose verified email matches an existing confirmed password account — redirect contains `error=account_link_required` instead of silently logging in.