### PR TITLE
fix(security): harden impersonation (claims, TTL, confirmed-email), admin email casing, LIKE escaping, list pagination

### DIFF
--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -13,22 +13,37 @@ type AuthClaims struct {
 	UserID string `json:"user_id"`
 	OrgID  string `json:"org_id"`
 	Role   string `json:"role"`
+	// ImpersonationOf, if non-empty, indicates this token was issued by a
+	// platform admin impersonating the user identified by UserID. The value
+	// is the admin user ID that initiated the impersonation session.
+	ImpersonationOf string `json:"impersonation_of,omitempty"`
 	jwt.RegisteredClaims
 }
 
 // RefreshClaims represents the claims embedded in a refresh token.
 type RefreshClaims struct {
 	UserID string `json:"user_id"`
+	// ImpersonationOf, if non-empty, marks this refresh token as belonging
+	// to an impersonation session initiated by the given admin user ID.
+	ImpersonationOf string `json:"impersonation_of,omitempty"`
 	jwt.RegisteredClaims
 }
 
 // IssueAccessToken creates an RS256-signed JWT access token scoped to a specific org.
 func IssueAccessToken(key *rsa.PrivateKey, issuer, audience, userID, orgID, role string, ttl time.Duration) (string, error) {
+	return IssueAccessTokenWithImpersonation(key, issuer, audience, userID, orgID, role, "", ttl)
+}
+
+// IssueAccessTokenWithImpersonation creates an RS256-signed JWT access token,
+// optionally tagging it as an impersonation session via impersonationOf (the
+// admin user ID).
+func IssueAccessTokenWithImpersonation(key *rsa.PrivateKey, issuer, audience, userID, orgID, role, impersonationOf string, ttl time.Duration) (string, error) {
 	now := time.Now()
 	claims := AuthClaims{
-		UserID: userID,
-		OrgID:  orgID,
-		Role:   role,
+		UserID:          userID,
+		OrgID:           orgID,
+		Role:            role,
+		ImpersonationOf: impersonationOf,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    issuer,
 			Audience:  jwt.ClaimStrings{audience},
@@ -45,9 +60,16 @@ func IssueAccessToken(key *rsa.PrivateKey, issuer, audience, userID, orgID, role
 
 // IssueRefreshToken creates an HS256-signed refresh token for token rotation.
 func IssueRefreshToken(hmacKey []byte, userID string, ttl time.Duration) (string, error) {
+	return IssueRefreshTokenWithImpersonation(hmacKey, userID, "", ttl)
+}
+
+// IssueRefreshTokenWithImpersonation creates an HS256-signed refresh token,
+// optionally tagging it as belonging to an impersonation session.
+func IssueRefreshTokenWithImpersonation(hmacKey []byte, userID, impersonationOf string, ttl time.Duration) (string, error) {
 	now := time.Now()
 	claims := RefreshClaims{
-		UserID: userID,
+		UserID:          userID,
+		ImpersonationOf: impersonationOf,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   userID,
 			IssuedAt:  jwt.NewNumericDate(now),

--- a/internal/handler/admin_domains_audit_usage.go
+++ b/internal/handler/admin_domains_audit_usage.go
@@ -163,18 +163,33 @@ func (h *AdminHandler) ListUsage(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"data": results})
 }
 // ListWorkspaceStorage handles GET /admin/v1/workspace-storage.
-// @Summary List all workspace storage
-// @Description Returns all provisioned workspace databases.
+// @Summary List workspace storage
+// @Description Returns provisioned workspace databases with cursor pagination (default limit 100, max 500).
 // @Tags admin
 // @Produce json
+// @Param limit query int false "Page size (default 100, max 500)"
+// @Param cursor query string false "Pagination cursor"
 // @Success 200 {object} map[string]any
 // @Security BearerAuth
 // @Router /admin/v1/workspace-storage [get]
 func (h *AdminHandler) ListWorkspaceStorage(w http.ResponseWriter, r *http.Request) {
+	limit, cursor, err := parsePaginationLimits(r, 100, 500)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	q := applyPagination(h.db.Model(&model.WorkspaceStorage{}), cursor, limit)
+
 	var storages []model.WorkspaceStorage
-	if err := h.db.Order("created_at DESC").Find(&storages).Error; err != nil {
+	if err := q.Find(&storages).Error; err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list workspace storage"})
 		return
+	}
+
+	hasMore := len(storages) > limit
+	if hasMore {
+		storages = storages[:limit]
 	}
 
 	resp := make([]adminWorkspaceStorageResponse, len(storages))
@@ -182,7 +197,12 @@ func (h *AdminHandler) ListWorkspaceStorage(w http.ResponseWriter, r *http.Reque
 		resp[i] = toAdminWorkspaceStorageResponse(ws)
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"data": resp})
+	body := map[string]any{"data": resp, "has_more": hasMore}
+	if hasMore {
+		last := storages[len(storages)-1]
+		body["next_cursor"] = encodeCursor(last.CreatedAt, last.ID)
+	}
+	writeJSON(w, http.StatusOK, body)
 }
 
 // DeleteWorkspaceStorage handles DELETE /admin/v1/workspace-storage/{id}.

--- a/internal/handler/admin_impersonate.go
+++ b/internal/handler/admin_impersonate.go
@@ -13,11 +13,16 @@ import (
 	"github.com/usehiveloop/hiveloop/internal/model"
 )
 
+// impersonationAccessTTL caps the lifetime of impersonation access tokens to
+// reduce the window of abuse if a token leaks. Normal user sessions keep their
+// configured TTL; this override applies only to /admin/v1/users/{id}/impersonate.
+const impersonationAccessTTL = 30 * time.Minute
+
 // Impersonate issues tokens for the target user, allowing a platform admin
 // to view the application as that user.
 //
 // @Summary Impersonate a user
-// @Description Issues access and refresh tokens for the target user. Requires platform admin privileges.
+// @Description Issues short-lived access and refresh tokens tagged as an impersonation session. Requires platform admin privileges.
 // @Tags admin
 // @Accept json
 // @Produce json
@@ -47,6 +52,11 @@ func (h *AdminHandler) Impersonate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if targetUser.EmailConfirmedAt == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "cannot impersonate a user with unconfirmed email"})
+		return
+	}
+
 	var memberships []model.OrgMembership
 	h.db.Preload("Org").Where("user_id = ?", targetUser.ID).Find(&memberships)
 
@@ -58,14 +68,27 @@ func (h *AdminHandler) Impersonate(w http.ResponseWriter, r *http.Request) {
 	orgID := memberships[0].OrgID.String()
 	role := memberships[0].Role
 
-	accessToken, err := auth.IssueAccessToken(h.privateKey, h.issuer, h.audience, targetUser.ID.String(), orgID, role, h.accessTTL)
+	admin, _ := middleware.UserFromContext(r.Context())
+	adminEmail := ""
+	adminID := ""
+	if admin != nil {
+		adminEmail = admin.Email
+		adminID = admin.ID.String()
+	}
+
+	accessTTL := h.accessTTL
+	if accessTTL > impersonationAccessTTL {
+		accessTTL = impersonationAccessTTL
+	}
+
+	accessToken, err := auth.IssueAccessTokenWithImpersonation(h.privateKey, h.issuer, h.audience, targetUser.ID.String(), orgID, role, adminID, accessTTL)
 	if err != nil {
 		slog.Error("impersonate: failed to issue access token", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
-	refreshToken, err := auth.IssueRefreshToken(h.signingKey, targetUser.ID.String(), h.refreshTTL)
+	refreshToken, err := auth.IssueRefreshTokenWithImpersonation(h.signingKey, targetUser.ID.String(), adminID, h.refreshTTL)
 	if err != nil {
 		slog.Error("impersonate: failed to issue refresh token", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
@@ -83,16 +106,13 @@ func (h *AdminHandler) Impersonate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	admin, _ := middleware.UserFromContext(r.Context())
-	adminEmail := ""
-	if admin != nil {
-		adminEmail = admin.Email
-	}
 	middleware.SetAdminAuditChanges(r, middleware.AdminAuditChanges{
-		"action":        map[string]any{"old": nil, "new": "impersonate"},
-		"target_user_id":    map[string]any{"old": nil, "new": targetUser.ID.String()},
-		"target_email":      map[string]any{"old": nil, "new": targetUser.Email},
+		"action":             map[string]any{"old": nil, "new": "impersonate"},
+		"target_user_id":     map[string]any{"old": nil, "new": targetUser.ID.String()},
+		"target_email":       map[string]any{"old": nil, "new": targetUser.Email},
+		"impersonator_id":    map[string]any{"old": nil, "new": adminID},
 		"impersonator_email": map[string]any{"old": nil, "new": adminEmail},
+		"access_ttl_seconds": map[string]any{"old": nil, "new": int(accessTTL.Seconds())},
 	})
 
 	orgs := make([]orgMemberDTO, 0, len(memberships))
@@ -104,18 +124,29 @@ func (h *AdminHandler) Impersonate(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	slog.Info("admin impersonating user", "admin_email", adminEmail, "target_user_id", targetUser.ID, "target_email", targetUser.Email)
+	slog.Info("admin impersonation token issued",
+		"admin_id", adminID,
+		"admin_email", adminEmail,
+		"target_user_id", targetUser.ID,
+		"target_email", targetUser.Email,
+		"access_ttl_seconds", int(accessTTL.Seconds()),
+	)
 
-	writeJSON(w, http.StatusOK, authResponse{
-		AccessToken:  accessToken,
-		RefreshToken: refreshToken,
-		ExpiresIn:    int(h.accessTTL.Seconds()),
-		User: userResponse{
-			ID:             targetUser.ID.String(),
-			Email:          targetUser.Email,
-			Name:           targetUser.Name,
-			EmailConfirmed: targetUser.EmailConfirmedAt != nil,
+	// Use a minimal user payload here: the standard userResponse includes an
+	// email_confirmed bool that always serializes (no omitempty on primitive),
+	// which would leak confirmation status. Since impersonation now requires
+	// confirmed email, there is no reason to echo it back.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token":     accessToken,
+		"refresh_token":    refreshToken,
+		"expires_in":       int(accessTTL.Seconds()),
+		"impersonation":    true,
+		"impersonation_of": adminID,
+		"user": map[string]any{
+			"id":    targetUser.ID.String(),
+			"email": targetUser.Email,
+			"name":  targetUser.Name,
 		},
-		Orgs: orgs,
+		"orgs": orgs,
 	})
 }

--- a/internal/handler/admin_integrations.go
+++ b/internal/handler/admin_integrations.go
@@ -9,17 +9,32 @@ import (
 
 // ListInIntegrations handles GET /admin/v1/in-integrations.
 // @Summary List platform integrations
-// @Description Returns all app-owned (platform) integrations.
+// @Description Returns app-owned (platform) integrations with cursor pagination (default limit 100, max 500).
 // @Tags admin
 // @Produce json
+// @Param limit query int false "Page size (default 100, max 500)"
+// @Param cursor query string false "Pagination cursor"
 // @Success 200 {object} map[string]any
 // @Security BearerAuth
 // @Router /admin/v1/in-integrations [get]
 func (h *AdminHandler) ListInIntegrations(w http.ResponseWriter, r *http.Request) {
+	limit, cursor, err := parsePaginationLimits(r, 100, 500)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	q := applyPagination(h.db.Model(&model.InIntegration{}), cursor, limit)
+
 	var integrations []model.InIntegration
-	if err := h.db.Order("created_at DESC").Find(&integrations).Error; err != nil {
+	if err := q.Find(&integrations).Error; err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list in-integrations"})
 		return
+	}
+
+	hasMore := len(integrations) > limit
+	if hasMore {
+		integrations = integrations[:limit]
 	}
 
 	resp := make([]adminInIntegrationResponse, len(integrations))
@@ -27,7 +42,12 @@ func (h *AdminHandler) ListInIntegrations(w http.ResponseWriter, r *http.Request
 		resp[i] = toAdminInIntegrationResponse(integ)
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"data": resp})
+	body := map[string]any{"data": resp, "has_more": hasMore}
+	if hasMore {
+		last := integrations[len(integrations)-1]
+		body["next_cursor"] = encodeCursor(last.CreatedAt, last.ID)
+	}
+	writeJSON(w, http.StatusOK, body)
 }
 
 // ListInConnections handles GET /admin/v1/in-connections.

--- a/internal/handler/admin_orgs.go
+++ b/internal/handler/admin_orgs.go
@@ -35,7 +35,7 @@ func (h *AdminHandler) ListOrgs(w http.ResponseWriter, r *http.Request) {
 	q := h.db.Model(&model.Org{})
 
 	if search := r.URL.Query().Get("search"); search != "" {
-		q = q.Where("name ILIKE ?", "%"+search+"%")
+		q = q.Where("name ILIKE ?", "%"+escapeLike(search)+"%")
 	}
 	if r.URL.Query().Get("active") == "true" {
 		q = q.Where("active = true")

--- a/internal/handler/admin_skills.go
+++ b/internal/handler/admin_skills.go
@@ -44,7 +44,8 @@ func (h *AdminHandler) ListSkills(w http.ResponseWriter, r *http.Request) {
 		q = q.Where("source_type = ?", sourceType)
 	}
 	if search := r.URL.Query().Get("q"); search != "" {
-		q = q.Where("name ILIKE ? OR slug ILIKE ?", "%"+search+"%", "%"+search+"%")
+		pattern := "%" + escapeLike(search) + "%"
+		q = q.Where("name ILIKE ? OR slug ILIKE ?", pattern, pattern)
 	}
 
 	q = applyPagination(q, cursor, limit)

--- a/internal/handler/admin_users.go
+++ b/internal/handler/admin_users.go
@@ -30,7 +30,8 @@ func (h *AdminHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	q := h.db.Model(&model.User{})
 
 	if search := r.URL.Query().Get("search"); search != "" {
-		q = q.Where("email ILIKE ? OR name ILIKE ?", "%"+search+"%", "%"+search+"%")
+		pattern := "%" + escapeLike(search) + "%"
+		q = q.Where("email ILIKE ? OR name ILIKE ?", pattern, pattern)
 	}
 	if r.URL.Query().Get("banned") == "true" {
 		q = q.Where("banned_at IS NOT NULL")

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -58,30 +58,48 @@ func NewAuthHandler(db *gorm.DB, privateKey *rsa.PrivateKey, signingKey []byte, 
 }
 
 // SetAdminMode restricts login to the given platform admin emails only.
-// When enabled, non-admin users receive a 403 on login/register.
+// When enabled, non-admin users receive a 403 on login/register. Emails are
+// stored lowercased so lookups are case-insensitive; use isPlatformAdminEmail
+// at call sites to normalize the runtime value.
 func (h *AuthHandler) SetAdminMode(emails []string) {
 	h.adminMode = true
 	h.platformAdminEmails = make(map[string]bool, len(emails))
 	for _, e := range emails {
-		trimmed := strings.TrimSpace(e)
-		if trimmed != "" {
-			h.platformAdminEmails[trimmed] = true
+		normalized := normalizePlatformAdminEmail(e)
+		if normalized != "" {
+			h.platformAdminEmails[normalized] = true
 		}
 	}
 }
 
 // SetPlatformAdminEmails records which emails are platform admins so that
 // /auth/me can return is_platform_admin without enabling admin-only login mode.
+// Emails are stored lowercased for case-insensitive matching.
 func (h *AuthHandler) SetPlatformAdminEmails(emails []string) {
 	if h.platformAdminEmails == nil {
 		h.platformAdminEmails = make(map[string]bool, len(emails))
 	}
 	for _, e := range emails {
-		trimmed := strings.TrimSpace(e)
-		if trimmed != "" {
-			h.platformAdminEmails[trimmed] = true
+		normalized := normalizePlatformAdminEmail(e)
+		if normalized != "" {
+			h.platformAdminEmails[normalized] = true
 		}
 	}
+}
+
+// normalizePlatformAdminEmail lowercases and trims an email so equality checks
+// against the platform admin allowlist are case-insensitive.
+func normalizePlatformAdminEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+// isPlatformAdminEmail returns true when the given email (any case) is in the
+// platform admin allowlist.
+func (h *AuthHandler) isPlatformAdminEmail(email string) bool {
+	if len(h.platformAdminEmails) == 0 {
+		return false
+	}
+	return h.platformAdminEmails[normalizePlatformAdminEmail(email)]
 }
 
 // StartCleanup starts a background goroutine that evicts stale login attempts

--- a/internal/handler/auth_login.go
+++ b/internal/handler/auth_login.go
@@ -49,7 +49,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	h.clearLoginFailures(req.Email)
 
 	// Admin mode: reject non-admin users
-	if h.adminMode && !h.platformAdminEmails[user.Email] {
+	if h.adminMode && !h.isPlatformAdminEmail(user.Email) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "admin access required"})
 		return
 	}

--- a/internal/handler/auth_me.go
+++ b/internal/handler/auth_me.go
@@ -32,7 +32,7 @@ func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	isPlatformAdmin := len(h.platformAdminEmails) > 0 && h.platformAdminEmails[user.Email]
+	isPlatformAdmin := h.isPlatformAdminEmail(user.Email)
 
 	writeJSON(w, http.StatusOK, meResponse{
 		User: userResponse{

--- a/internal/handler/auth_otp.go
+++ b/internal/handler/auth_otp.go
@@ -27,7 +27,7 @@ func (h *AuthHandler) OTPRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Admin mode: reject non-admin emails
-	if h.adminMode && !h.platformAdminEmails[req.Email] {
+	if h.adminMode && !h.isPlatformAdminEmail(req.Email) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "admin access required"})
 		return
 	}
@@ -169,7 +169,7 @@ func (h *AuthHandler) OTPVerify(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Admin mode check
-	if h.adminMode && !h.platformAdminEmails[user.Email] {
+	if h.adminMode && !h.isPlatformAdminEmail(user.Email) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "admin access required"})
 		return
 	}

--- a/internal/handler/auth_register.go
+++ b/internal/handler/auth_register.go
@@ -34,7 +34,7 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Admin mode: reject non-admin users
-	if h.adminMode && !h.platformAdminEmails[req.Email] {
+	if h.adminMode && !h.isPlatformAdminEmail(req.Email) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "admin access required"})
 		return
 	}

--- a/internal/handler/auth_types.go
+++ b/internal/handler/auth_types.go
@@ -33,6 +33,12 @@ type authResponse struct {
 	ExpiresIn    int            `json:"expires_in"` // seconds
 	User         userResponse   `json:"user"`
 	Orgs         []orgMemberDTO `json:"orgs"`
+	// Impersonation is true when the tokens were issued by a platform admin
+	// impersonating the user. Clients can surface a visible banner when set.
+	Impersonation bool `json:"impersonation,omitempty"`
+	// ImpersonationOf is the admin user ID that initiated the session, when
+	// Impersonation is true. Empty for regular sessions.
+	ImpersonationOf string `json:"impersonation_of,omitempty"`
 }
 
 type userResponse struct {

--- a/internal/handler/pagination.go
+++ b/internal/handler/pagination.go
@@ -5,11 +5,29 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
+
+// likePatternEscaper escapes SQL LIKE/ILIKE wildcard metacharacters so that
+// user-supplied search terms are treated as literal substrings rather than as
+// patterns. The default Postgres LIKE escape character is backslash, which we
+// rely on here. Callers must wrap the result in `%...%` themselves.
+var likePatternEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`%`, `\%`,
+	`_`, `\_`,
+)
+
+// escapeLike escapes wildcard characters (%, _, \) in a user-supplied string
+// so it can be safely interpolated into a `%...%` LIKE/ILIKE pattern without
+// allowing the caller to alter the query's match semantics.
+func escapeLike(s string) string {
+	return likePatternEscaper.Replace(s)
+}
 
 type paginationCursor struct {
 	CreatedAt time.Time
@@ -23,14 +41,21 @@ type paginatedResponse[T any] struct {
 }
 
 func parsePagination(r *http.Request) (int, *paginationCursor, error) {
-	limit := 50
+	return parsePaginationLimits(r, 50, 100)
+}
+
+// parsePaginationLimits is a variant of parsePagination that lets callers pick
+// the default and maximum page size. Values outside [1, max] are clamped to
+// max; an invalid (non-numeric or negative) limit returns an error.
+func parsePaginationLimits(r *http.Request, defaultLimit, maxLimit int) (int, *paginationCursor, error) {
+	limit := defaultLimit
 	if l := r.URL.Query().Get("limit"); l != "" {
 		n, err := strconv.Atoi(l)
 		if err != nil || n < 1 {
 			return 0, nil, fmt.Errorf("invalid limit")
 		}
-		if n > 100 {
-			n = 100
+		if n > maxLimit {
+			n = maxLimit
 		}
 		limit = n
 	}

--- a/internal/handler/skills_crud.go
+++ b/internal/handler/skills_crud.go
@@ -51,7 +51,7 @@ func (h *SkillHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if searchTerm := strings.TrimSpace(r.URL.Query().Get("q")); searchTerm != "" {
-		like := "%" + searchTerm + "%"
+		like := "%" + escapeLike(searchTerm) + "%"
 		q = q.Where("name ILIKE ? OR description ILIKE ?", like, like)
 	}
 	q = applyPagination(q, cursor, limit)

--- a/internal/handler/subagents_crud.go
+++ b/internal/handler/subagents_crud.go
@@ -69,7 +69,7 @@ func (h *SubagentHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if searchTerm := strings.TrimSpace(r.URL.Query().Get("q")); searchTerm != "" {
-		like := "%" + searchTerm + "%"
+		like := "%" + escapeLike(searchTerm) + "%"
 		query = query.Where("name ILIKE ? OR description ILIKE ?", like, like)
 	}
 	query = applyPagination(query, cursor, limit)

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -170,13 +170,15 @@ func RequireOrgAdmin(db *gorm.DB) func(http.Handler) http.Handler {
 }
 
 // RequirePlatformAdmin returns middleware that checks if the authenticated user's
-// email is in the platform admin allowlist.
+// email is in the platform admin allowlist. The comparison is case-insensitive
+// (emails are normalized to lowercase on both sides) to avoid lockouts when the
+// identity provider or config entry differs only in casing.
 func RequirePlatformAdmin(adminEmails []string) func(http.Handler) http.Handler {
 	emailSet := make(map[string]bool, len(adminEmails))
 	for _, e := range adminEmails {
-		trimmed := strings.TrimSpace(e)
-		if trimmed != "" {
-			emailSet[trimmed] = true
+		normalized := normalizeEmail(e)
+		if normalized != "" {
+			emailSet[normalized] = true
 		}
 	}
 	return func(next http.Handler) http.Handler {
@@ -187,7 +189,7 @@ func RequirePlatformAdmin(adminEmails []string) func(http.Handler) http.Handler 
 				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
 				return
 			}
-			if !emailSet[user.Email] {
+			if !emailSet[normalizeEmail(user.Email)] {
 				slog.Warn("platform admin check: email not in allowlist", "email", user.Email, "path", r.URL.Path)
 				writeJSON(w, http.StatusForbidden, map[string]string{"error": "platform admin access required"})
 				return
@@ -195,4 +197,10 @@ func RequirePlatformAdmin(adminEmails []string) func(http.Handler) http.Handler 
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// normalizeEmail lowercases and trims an email address so equality checks work
+// regardless of how the user typed or how the identity provider stored it.
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
 }


### PR DESCRIPTION
## Summary

Bundles five admin-surface security fixes:

- **#58 [Critical]** Impersonation tokens now carry an `impersonation_of` claim (admin user ID) on both access and refresh tokens, are capped to a 30m access TTL (vs. the default session TTL), and the response body surfaces `impersonation: true` and `impersonation_of` so clients can show a visible banner. Each issuance is logged with admin + target identity and the applied TTL.
- **#63 [High]** `RequirePlatformAdmin` middleware and the `AuthHandler` admin-email allowlist now lowercase+trim on both allowlist construction and runtime lookup (new `normalizeEmail` / `isPlatformAdminEmail` helpers). Fixes the case-sensitivity lockout/bypass risk.
- **#71 [Medium]** New `escapeLike` helper escapes `\`, `%`, `_` before user input is wrapped in `%...%`. Applied to admin users/orgs/skills search and to skills_crud + subagents_crud list endpoints.
- **#74 [Medium]** `GET /admin/v1/in-integrations` and `GET /admin/v1/workspace-storage` now use cursor pagination (default 100, max 500) via a new `parsePaginationLimits` helper.
- **#79 [Low]** Impersonation rejects unconfirmed users with `400` before minting tokens, and the response no longer leaks `email_confirmed`.

## Test plan

- [ ] `go build ./internal/... ./cmd/server/...` passes (pre-existing unrelated errors remain in `cmd/fetchactions-*` and `skills/upload` on main)
- [ ] Impersonation issues tokens containing `impersonation_of` claim with <= 30m expiry
- [ ] Mixed-case platform admin email in config still grants access
- [ ] `/admin/v1/users?search=%25` no longer acts as a wildcard
- [ ] `/admin/v1/in-integrations?limit=600` caps at 500 and returns a cursor
- [ ] Impersonating an unconfirmed user returns 400

Closes #58
Closes #63
Closes #71
Closes #74
Closes #79