### PR TITLE
fix(security): strip public marketplace fields, opaque health responses, optional URL allowlist, role-scoped API keys

### DIFF
--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -43,6 +43,9 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 
 	logger := slog.Default()
 
+	// Apply credential base_url host allowlist (empty = dev-mode, no host filter).
+	proxy.SetAllowedBaseURLHosts(cfg.AllowedBaseURLs)
+
 	// Start cache invalidation subscriber (per-instance, real-time pub/sub)
 	goroutine.Go(func() {
 		if err := cacheManager.Invalidator().Subscribe(ctx); err != nil {

--- a/cmd/server/serve_health.go
+++ b/cmd/server/serve_health.go
@@ -1,37 +1,50 @@
 package main
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 )
 
+// healthz is a public liveness probe. The response body is intentionally
+// opaque so it cannot be used by unauthenticated callers to enumerate
+// infrastructure or distinguish dependency states.
 func healthz(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(`{"status":"ok"}`))
 }
 
+// readyz is a public readiness probe. Failures are logged with full detail
+// server-side but the response body is opaque — it only signals ready/not
+// ready and never discloses which backing service (db, redis, etc.) caused
+// the failure.
 func readyz(database *gorm.DB, rc *redis.Client) http.HandlerFunc {
+	const notReadyBody = `{"status":"not ready"}`
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		sqlDB, err := database.DB()
 		if err != nil {
+			slog.Warn("readiness check: db handle unavailable", "error", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte(`{"status":"error","detail":"db connection failed"}`))
+			_, _ = w.Write([]byte(notReadyBody))
 			return
 		}
 		if err := sqlDB.Ping(); err != nil {
+			slog.Warn("readiness check: db ping failed", "error", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte(`{"status":"error","detail":"db ping failed"}`))
+			_, _ = w.Write([]byte(notReadyBody))
 			return
 		}
 
 		if err := rc.Ping(r.Context()).Err(); err != nil {
+			slog.Warn("readiness check: redis ping failed", "error", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte(`{"status":"error","detail":"redis ping failed"}`))
+			_, _ = w.Write([]byte(notReadyBody))
 			return
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,12 @@ type Config struct {
 	// CORS
 	CORSOrigins []string `env:"CORS_ORIGINS" envSeparator:","`
 
+	// Provider base_url allowlist (hostnames only, case-insensitive). When
+	// empty, no host-level allowlist is enforced on credential base_urls —
+	// useful for local/self-hosted dev. In production, set this to the
+	// known LLM-provider hostnames (e.g. api.openai.com,api.anthropic.com).
+	AllowedBaseURLs []string `env:"ALLOWED_BASE_URLS" envSeparator:","`
+
 	// Nango (OAuth integration proxy)
 	NangoEndpoint  string `env:"NANGO_ENDPOINT"`    // e.g. http://localhost:3004
 	NangoSecretKey string `env:"NANGO_SECRET_KEY"`  // Nango secret key for API auth

--- a/internal/handler/api_keys.go
+++ b/internal/handler/api_keys.go
@@ -21,6 +21,19 @@ type APIKeyHandler struct {
 	cacheManager *cache.Manager
 }
 
+// memberAllowedAPIKeyScopes is the narrow set of scopes a non-admin
+// organization member (role != "owner"/"admin") may request when minting an
+// API key. Admins and owners may request any scope in model.ValidAPIKeyScopes.
+//
+// "connect" covers the public-facing connect flows and is considered safe for
+// non-admin members to delegate to an API key. Sensitive scopes such as
+// "credentials", "tokens", "integrations", "agents", and "all" require an
+// admin/owner role so a lower-privileged member cannot mint a key that
+// exceeds their own permissions.
+var memberAllowedAPIKeyScopes = map[string]bool{
+	"connect": true,
+}
+
 func NewAPIKeyHandler(db *gorm.DB, keyCache *cache.APIKeyCache, cm *cache.Manager) *APIKeyHandler {
 	return &APIKeyHandler{db: db, keyCache: keyCache, cacheManager: cm}
 }
@@ -93,6 +106,11 @@ func (h *APIKeyHandler) Create(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid scope: " + s})
 			return
 		}
+	}
+
+	if !requesterCanGrantScopes(r, h.db, org.ID, req.Scopes) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "role does not permit requested scopes; admin/owner required"})
+		return
 	}
 
 	plaintext, hash, prefix, err := model.GenerateAPIKey()
@@ -271,4 +289,44 @@ func (h *APIKeyHandler) Revoke(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("api key revoked", "org_id", org.ID, "key_id", keyID)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
+}
+
+// requesterCanGrantScopes enforces role-based restrictions on which scopes a
+// caller may assign to a new API key. Owners and admins may assign any valid
+// scope. Other members are restricted to memberAllowedAPIKeyScopes.
+//
+// For API-key-authenticated requests (no JWT claims on the context), the
+// minting API key must itself carry the "all" scope to grant elevated scopes.
+func requesterCanGrantScopes(r *http.Request, db *gorm.DB, orgID uuid.UUID, requested []string) bool {
+	allMemberAllowed := true
+	for _, s := range requested {
+		if !memberAllowedAPIKeyScopes[s] {
+			allMemberAllowed = false
+			break
+		}
+	}
+	if allMemberAllowed {
+		return true
+	}
+
+	if claims, ok := middleware.AuthClaimsFromContext(r.Context()); ok && claims != nil && claims.UserID != "" {
+		var m model.OrgMembership
+		userUUID, err := uuid.Parse(claims.UserID)
+		if err != nil {
+			return false
+		}
+		if err := db.Where("user_id = ? AND org_id = ?", userUUID, orgID).First(&m).Error; err != nil {
+			return false
+		}
+		return m.Role == "owner" || m.Role == "admin"
+	}
+
+	if apiClaims, ok := middleware.APIKeyClaimsFromContext(r.Context()); ok && apiClaims != nil {
+		for _, s := range apiClaims.Scopes {
+			if s == "all" {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/handler/marketplace.go
+++ b/internal/handler/marketplace.go
@@ -32,6 +32,66 @@ type createMarketplaceAgentRequest struct {
 	AgentID string `json:"agent_id"`
 }
 
+// marketplacePublicAgentResponse is the sanitized "discovery card" shape
+// returned to unauthenticated callers. It intentionally excludes fields that
+// disclose internal agent configuration — system prompts, tools, MCP servers,
+// agent config, permissions, instructions, provider prompts, and source
+// agent linkage. Authenticated marketplace consumers (e.g. install flows)
+// continue to receive the full marketplaceAgentResponse shape.
+type marketplacePublicAgentResponse struct {
+	ID                   string   `json:"id"`
+	Slug                 string   `json:"slug"`
+	Name                 string   `json:"name"`
+	Description          *string  `json:"description,omitempty"`
+	Avatar               *string  `json:"avatar,omitempty"`
+	Model                string   `json:"model"`
+	Team                 string   `json:"team"`
+	RequiredIntegrations []string `json:"required_integrations"`
+	Tags                 []string `json:"tags"`
+	Status               string   `json:"status"`
+	Featured             bool     `json:"featured"`
+	Popular              bool     `json:"popular"`
+	Verified             bool     `json:"verified"`
+	InstallCount         int      `json:"install_count"`
+	PublisherName        string   `json:"publisher_name,omitempty"`
+	PublishedAt          *string  `json:"published_at,omitempty"`
+	CreatedAt            string   `json:"created_at"`
+	UpdatedAt            string   `json:"updated_at"`
+}
+
+func toMarketplacePublicAgentResponse(ma model.MarketplaceAgent) marketplacePublicAgentResponse {
+	resp := marketplacePublicAgentResponse{
+		ID:                   ma.ID.String(),
+		Slug:                 ma.Slug,
+		Name:                 ma.Name,
+		Description:          ma.Description,
+		Avatar:               ma.Avatar,
+		Model:                ma.Model,
+		Team:                 ma.Team,
+		RequiredIntegrations: ma.RequiredIntegrations,
+		Tags:                 ma.Tags,
+		Status:               ma.Status,
+		Featured:             ma.Featured,
+		Popular:              ma.Popular,
+		Verified:             ma.VerifiedAt != nil,
+		InstallCount:         ma.InstallCount,
+		PublisherName:        ma.Publisher.Name,
+		CreatedAt:            ma.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:            ma.UpdatedAt.Format(time.RFC3339),
+	}
+	if ma.PublishedAt != nil {
+		s := ma.PublishedAt.Format(time.RFC3339)
+		resp.PublishedAt = &s
+	}
+	if resp.RequiredIntegrations == nil {
+		resp.RequiredIntegrations = []string{}
+	}
+	if resp.Tags == nil {
+		resp.Tags = []string{}
+	}
+	return resp
+}
+
 func toMarketplaceAgentResponse(ma model.MarketplaceAgent) marketplaceAgentResponse {
 	resp := marketplaceAgentResponse{
 		ID:                   ma.ID.String(),

--- a/internal/handler/marketplace_public.go
+++ b/internal/handler/marketplace_public.go
@@ -60,7 +60,7 @@ type marketplaceAgentResponse struct {
 // @Param verified query bool false "Filter verified agents"
 // @Param limit query int false "Page size"
 // @Param cursor query string false "Pagination cursor"
-// @Success 200 {object} paginatedResponse[marketplaceAgentResponse]
+// @Success 200 {object} paginatedResponse[marketplacePublicAgentResponse]
 // @Router /v1/marketplace/agents [get]
 func (h *MarketplaceHandler) List(w http.ResponseWriter, r *http.Request) {
 	cacheKey := h.listCacheKey(r)
@@ -114,12 +114,12 @@ func (h *MarketplaceHandler) List(w http.ResponseWriter, r *http.Request) {
 		agents = agents[:limit]
 	}
 
-	resp := make([]marketplaceAgentResponse, len(agents))
+	resp := make([]marketplacePublicAgentResponse, len(agents))
 	for i, agent := range agents {
-		resp[i] = toMarketplaceAgentResponse(agent)
+		resp[i] = toMarketplacePublicAgentResponse(agent)
 	}
 
-	result := paginatedResponse[marketplaceAgentResponse]{Data: resp, HasMore: hasMore}
+	result := paginatedResponse[marketplacePublicAgentResponse]{Data: resp, HasMore: hasMore}
 	if hasMore {
 		last := agents[len(agents)-1]
 		c := encodeCursor(last.CreatedAt, last.ID)
@@ -140,7 +140,7 @@ func (h *MarketplaceHandler) List(w http.ResponseWriter, r *http.Request) {
 // @Tags marketplace
 // @Produce json
 // @Param slug path string true "Agent slug"
-// @Success 200 {object} marketplaceAgentResponse
+// @Success 200 {object} marketplacePublicAgentResponse
 // @Failure 404 {object} errorResponse
 // @Router /v1/marketplace/agents/{slug} [get]
 func (h *MarketplaceHandler) GetBySlug(w http.ResponseWriter, r *http.Request) {
@@ -164,7 +164,7 @@ func (h *MarketplaceHandler) GetBySlug(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, _ := json.Marshal(toMarketplaceAgentResponse(agent))
+	body, _ := json.Marshal(toMarketplacePublicAgentResponse(agent))
 	h.redis.Set(r.Context(), cacheKey, body, marketplaceCacheTTL)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/validate.go
+++ b/internal/proxy/validate.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"sync"
 )
 
 var (
@@ -35,7 +36,46 @@ var (
 
 	// AllowLoopback can be set to true in tests to allow loopback/private addresses.
 	AllowLoopback = false
+
+	// allowedBaseURLHosts is the process-wide allowlist of hostnames that may
+	// be used as credential base_urls. When empty, no host-level allowlist is
+	// enforced and only the SSRF/IP checks below gate the URL (this preserves
+	// local/dev behaviour where operators have not supplied an allowlist).
+	allowedBaseURLHosts   = map[string]struct{}{}
+	allowedBaseURLHostsMu sync.RWMutex
 )
+
+// SetAllowedBaseURLHosts configures the process-wide allowlist of hostnames
+// (case-insensitive) that ValidateBaseURL will accept. Passing an empty slice
+// disables host-level allowlisting and falls back to SSRF-only validation.
+func SetAllowedBaseURLHosts(hosts []string) {
+	normalised := make(map[string]struct{}, len(hosts))
+	for _, h := range hosts {
+		h = strings.TrimSpace(strings.ToLower(h))
+		if h == "" {
+			continue
+		}
+		normalised[h] = struct{}{}
+	}
+	allowedBaseURLHostsMu.Lock()
+	allowedBaseURLHosts = normalised
+	allowedBaseURLHostsMu.Unlock()
+}
+
+// baseURLHostAllowed reports whether the given host passes the allowlist.
+// When the allowlist is empty the function always returns true — callers that
+// require an explicit allowlist must check for that separately or configure
+// one at startup.
+func baseURLHostAllowed(host string) bool {
+	host = strings.ToLower(host)
+	allowedBaseURLHostsMu.RLock()
+	defer allowedBaseURLHostsMu.RUnlock()
+	if len(allowedBaseURLHosts) == 0 {
+		return true
+	}
+	_, ok := allowedBaseURLHosts[host]
+	return ok
+}
 
 func ipInNets(ip net.IP, nets ...*net.IPNet) bool {
 	for _, n := range nets {
@@ -74,6 +114,9 @@ func ValidateBaseURL(raw string) error {
 		if u.Hostname() == "" {
 			return errors.New("invalid base_url: missing host")
 		}
+		if !baseURLHostAllowed(u.Hostname()) {
+			return errors.New("invalid base_url: host not in provider allowlist")
+		}
 		return nil
 	}
 
@@ -91,6 +134,9 @@ func ValidateBaseURL(raw string) error {
 	hLower := strings.ToLower(host)
 	if _, blocked := blockedHostnames[hLower]; blocked {
 		return errors.New("invalid base_url: host not allowed")
+	}
+	if !baseURLHostAllowed(hLower) {
+		return errors.New("invalid base_url: host not in provider allowlist")
 	}
 
 	// If host is an IP literal, validate directly; otherwise resolve and validate each address


### PR DESCRIPTION
## Summary

Batched fix for four low-severity data-exposure / auth issues.

- **#67 Marketplace public endpoints expose agent system prompts** — introduced `marketplacePublicAgentResponse` for `GET /v1/marketplace/agents` and `GET /v1/marketplace/agents/{slug}`. Unauthenticated responses no longer include `system_prompt`, `tools`, `mcp_servers`, `agent_config`, `permissions`, `instructions`, or `source_agent_id`. Authenticated POST/PUT/DELETE continue to use the full shape for install/edit flows.
- **#77 Health endpoints leak infrastructure details** — `readyz` now responds with an opaque `{"status":"not ready"}` body on failure regardless of which dependency (db handle, db ping, redis ping) broke. Verbose reasons are still logged server-side via `slog.Warn`. `healthz` body unchanged but now clearly documented as intentionally opaque.
- **#78 Credential `base_url` not validated against allowlist** — added `proxy.SetAllowedBaseURLHosts` and `ALLOWED_BASE_URLS` config. Hostnames are compared case-insensitively inside `proxy.ValidateBaseURL`. Empty allowlist preserves today's dev/self-host behaviour; populated allowlist gates credentials creation (`POST /v1/credentials`) to known provider hostnames.
- **#80 API key arbitrary scopes** — `POST /v1/api-keys` now enforces a role-based allowlist on top of `model.ValidAPIKeyScopes`. Non-admin members are limited to `memberAllowedAPIKeyScopes = {connect}`; owners and admins (or API-key callers already carrying `all`) may request any scope.

## Test plan

- [ ] `go build ./cmd/server/... ./internal/...` (passes; unrelated `cmd/fetchactions-*` pre-existing failures remain on `main`)
- [ ] `go test ./internal/proxy/... ./internal/model/...` (passes)
- [ ] Manual: unauthenticated `GET /v1/marketplace/agents` no longer returns `system_prompt` or tools
- [ ] Manual: `GET /readyz` body contains no dependency name when db/redis is down
- [ ] Manual: with `ALLOWED_BASE_URLS=api.openai.com`, creating a credential with a different host returns 400
- [ ] Manual: a viewer/member JWT cannot create an API key with `credentials` / `all` scope; owner/admin can

Closes #67
Closes #77
Closes #78
Closes #80