### PR TITLE
fix(rag): bump rag-engine Dockerfile to rustc 1.91

### DIFF
--- a/services/rag-engine/Dockerfile
+++ b/services/rag-engine/Dockerfile
@@ -8,7 +8,7 @@
 # the `proto/` directory (the `.proto` file is the build input to
 # `rag-engine-proto`'s build.rs) and the `services/rag-engine/` tree.
 
-ARG RUST_VERSION=1.89
+ARG RUST_VERSION=1.91
 
 # --- stage 1: chef -----------------------------------------------------
 FROM rust:${RUST_VERSION}-slim AS chef


### PR DESCRIPTION
## Summary

One-line fix. The rag-engine Cargo workspace has `rust-version = "1.91"` (`services/rag-engine/Cargo.toml:15`) but the Dockerfile was still on `RUST_VERSION=1.89`. Railway's first deploy failed during `cargo chef cook --release` with rustc-version errors from `aws-sdk-*` and `lance-*` crates, which all require `1.91.0+`.

CI (the existing `test-rag-e2e` workflow) pulls a separate `dtolnay/rust-toolchain@stable` so it builds fine; the Dockerfile is the only place that pinned an outdated version.

## Test plan

- [ ] `test-rag-e2e` workflow stays green (CI uses stable toolchain, untouched).
- [ ] Once merged, Railway's auto-deploy of `rag-engine.usehiveloop.com` succeeds (cold cargo-chef build, ~6-10 min).
- [ ] No other workflow regressions.