### PR TITLE
feat: public uploads API — POST /v1/uploads/sign

### DIFF
--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -22,6 +22,7 @@ import (
 	posthogobs "github.com/usehiveloop/hiveloop/internal/observability/posthog"
 	"github.com/usehiveloop/hiveloop/internal/proxy"
 	ragscheduler "github.com/usehiveloop/hiveloop/internal/rag/scheduler"
+	"github.com/usehiveloop/hiveloop/internal/storage"
 	"github.com/usehiveloop/hiveloop/internal/subscriptions"
 )
 
@@ -130,6 +131,26 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 		driveHandler = handler.NewDriveHandler(database, deps.S3Client)
 	}
 
+	var uploadsHandler *handler.UploadsHandler
+	if cfg.PublicAssetsBucket != "" {
+		presigner, err := storage.NewS3Presigner(storage.PublicAssetsConfig{
+			Bucket:       cfg.PublicAssetsBucket,
+			Region:       cfg.PublicAssetsRegion,
+			Endpoint:     cfg.PublicAssetsEndpoint,
+			AccessKey:    cfg.PublicAssetsAccessKey,
+			SecretKey:    cfg.PublicAssetsSecretKey,
+			PublicBase:   cfg.PublicAssetsBaseURL,
+			SignTTL:      cfg.PublicAssetsSignTTL,
+			UsePublicACL: cfg.PublicAssetsUseACL,
+		})
+		if err != nil {
+			slog.Error("public assets presigner init failed; /v1/uploads/sign disabled", "error", err)
+		} else {
+			uploadsHandler = handler.NewUploadsHandler(database, presigner)
+			slog.Info("public assets uploads ready", "bucket", cfg.PublicAssetsBucket)
+		}
+	}
+
 	billingHandler := handler.NewBillingHandler(database, deps.BillingRegistry, deps.Credits)
 	billingWebhookHandler := handler.NewBillingWebhookHandler(database, deps.BillingRegistry, deps.Credits)
 
@@ -149,7 +170,7 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 	r.Post("/incoming/triggers/{triggerID}", httpTriggerHandler.Handle)
 	setupAuthRoutes(r, ctx, cfg, rsaPub, authHandler, oauthHandler)
 	ragSourceHandler := handler.NewRAGSourceHandler(database, enqueuer, ragscheduler.HasPermSyncCapability)
-	setupV1Routes(r, cfg, rsaPub, database, apiKeyCache, enqueuer, orgHandler, orgInviteHandler, usageHandler, auditHandler, reportingHandler, generationHandler, apiKeyHandler, billingHandler, credHandler, tokenHandler, sandboxTemplateHandler, skillHandler, subagentHandler, agentHandler, marketplaceHandler, conversationHandler, routerHandler, customDomainHandler, ragSourceHandler, orchestrator, auditWriter)
+	setupV1Routes(r, cfg, rsaPub, database, apiKeyCache, enqueuer, orgHandler, orgInviteHandler, usageHandler, auditHandler, reportingHandler, generationHandler, apiKeyHandler, billingHandler, credHandler, tokenHandler, sandboxTemplateHandler, skillHandler, subagentHandler, agentHandler, marketplaceHandler, conversationHandler, routerHandler, customDomainHandler, ragSourceHandler, uploadsHandler, orchestrator, auditWriter)
 
 	var platformAdminEmails []string
 	if cfg.PlatformAdminEmails != "" {

--- a/cmd/server/serve_routes_v1.go
+++ b/cmd/server/serve_routes_v1.go
@@ -40,6 +40,7 @@ func setupV1Routes(
 	routerHandler *handler.RouterHandler,
 	customDomainHandler *handler.CustomDomainHandler,
 	ragSourceHandler *handler.RAGSourceHandler,
+	uploadsHandler *handler.UploadsHandler,
 	orchestrator *sandbox.Orchestrator,
 	auditWriter *middleware.AuditWriter,
 ) {
@@ -243,6 +244,13 @@ func setupV1Routes(
 				r.Post("/custom-domains/{id}/verify", customDomainHandler.Verify)
 				r.Delete("/custom-domains/{id}", customDomainHandler.Delete)
 			})
+
+			if uploadsHandler != nil {
+				r.Route("/uploads", func(r chi.Router) {
+					r.Use(middleware.ResolveUser(database))
+					r.Post("/sign", uploadsHandler.Sign)
+				})
+			}
 		})
 	})
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,9 @@ services:
       /bin/sh -c "
       mc alias set local http://minio:9000 minioadmin minioadmin &&
       mc mb --ignore-existing local/hiveloop-rag-test &&
-      echo 'bucket hiveloop-rag-test ready'
+      mc mb --ignore-existing local/public-files-test &&
+      mc anonymous set download local/public-files-test &&
+      echo 'buckets ready'
       "
     restart: "no"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,17 @@ type Config struct {
 	S3AccessKey string `env:"AWS_ACCESS_KEY_ID"`
 	S3SecretKey string `env:"AWS_SECRET_ACCESS_KEY"`
 
+	// Public assets (avatars, org logos, generic public uploads). Empty
+	// PUBLIC_ASSETS_S3_BUCKET disables the /v1/uploads/sign endpoint.
+	PublicAssetsBucket    string        `env:"PUBLIC_ASSETS_S3_BUCKET"`
+	PublicAssetsRegion    string        `env:"PUBLIC_ASSETS_S3_REGION" envDefault:"auto"`
+	PublicAssetsEndpoint  string        `env:"PUBLIC_ASSETS_S3_ENDPOINT"`
+	PublicAssetsAccessKey string        `env:"PUBLIC_ASSETS_ACCESS_KEY_ID"`
+	PublicAssetsSecretKey string        `env:"PUBLIC_ASSETS_SECRET_ACCESS_KEY"`
+	PublicAssetsBaseURL   string        `env:"PUBLIC_ASSETS_BASE_URL"`
+	PublicAssetsSignTTL   time.Duration `env:"PUBLIC_ASSETS_SIGN_TTL" envDefault:"15m"`
+	PublicAssetsUseACL    bool          `env:"PUBLIC_ASSETS_USE_ACL" envDefault:"false"`
+
 	// Admin API (disabled by default — deploy a separate private instance with ADMIN_API_ENABLED=true)
 	AdminAPIEnabled bool `env:"ADMIN_API_ENABLED" envDefault:"false"`
 

--- a/internal/handler/uploads.go
+++ b/internal/handler/uploads.go
@@ -1,0 +1,34 @@
+package handler
+
+import (
+	"gorm.io/gorm"
+
+	"github.com/usehiveloop/hiveloop/internal/storage"
+)
+
+type UploadsHandler struct {
+	db        *gorm.DB
+	presigner storage.Presigner
+}
+
+func NewUploadsHandler(db *gorm.DB, presigner storage.Presigner) *UploadsHandler {
+	return &UploadsHandler{db: db, presigner: presigner}
+}
+
+type signUploadRequest struct {
+	AssetType   string  `json:"asset_type"`
+	ContentType string  `json:"content_type"`
+	SizeBytes   int64   `json:"size_bytes"`
+	Filename    string  `json:"filename,omitempty"`
+	OrgID       *string `json:"org_id,omitempty"`
+}
+
+type signUploadResponse struct {
+	UploadURL       string            `json:"upload_url"`
+	UploadMethod    string            `json:"upload_method"`
+	RequiredHeaders map[string]string `json:"required_headers"`
+	Key             string            `json:"key"`
+	PublicURL       string            `json:"public_url"`
+	ExpiresAt       string            `json:"expires_at"`
+	MaxSizeBytes    int64             `json:"max_size_bytes"`
+}

--- a/internal/handler/uploads_sign.go
+++ b/internal/handler/uploads_sign.go
@@ -1,0 +1,131 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/usehiveloop/hiveloop/internal/middleware"
+	"github.com/usehiveloop/hiveloop/internal/model"
+	"github.com/usehiveloop/hiveloop/internal/storage"
+)
+
+func (h *UploadsHandler) Sign(w http.ResponseWriter, r *http.Request) {
+	user, ok := middleware.UserFromContext(r.Context())
+	if !ok || user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing user context"})
+		return
+	}
+	org, _ := middleware.OrgFromContext(r.Context())
+
+	var req signUploadRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	assetType := storage.AssetType(req.AssetType)
+	policy, ok := h.presigner.Policy(assetType)
+	if !ok {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown asset_type"})
+		return
+	}
+	if req.ContentType == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "content_type is required"})
+		return
+	}
+	if _, ok := policy.AllowedTypes[req.ContentType]; !ok {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "content_type not allowed for asset_type"})
+		return
+	}
+	if req.SizeBytes <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "size_bytes must be positive"})
+		return
+	}
+	if req.SizeBytes > policy.MaxBytes {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "size_bytes exceeds limit for asset_type"})
+		return
+	}
+
+	signReq := storage.SignRequest{
+		AssetType:   assetType,
+		UserID:      user.ID,
+		ContentType: req.ContentType,
+		SizeBytes:   req.SizeBytes,
+		Filename:    req.Filename,
+	}
+
+	if assetType == storage.AssetTypeOrgLogo {
+		orgID, err := resolveOrgLogoOrg(req.OrgID, org)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if err := h.requireOrgAdmin(r, user.ID, orgID); err != nil {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+			return
+		}
+		signReq.OrgID = &orgID
+	}
+
+	out, err := h.presigner.Sign(r.Context(), signReq)
+	if err != nil {
+		slog.Warn("upload sign rejected", "user_id", user.ID, "asset_type", assetType, "error", err)
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, signUploadResponse{
+		UploadURL:       out.UploadURL,
+		UploadMethod:    out.UploadMethod,
+		RequiredHeaders: out.RequiredHeaders,
+		Key:             out.Key,
+		PublicURL:       out.PublicURL,
+		ExpiresAt:       out.ExpiresAt.Format(time.RFC3339),
+		MaxSizeBytes:    out.MaxSizeBytes,
+	})
+}
+
+func resolveOrgLogoOrg(reqOrgID *string, ctxOrg *model.Org) (uuid.UUID, error) {
+	if reqOrgID != nil && *reqOrgID != "" {
+		parsed, err := uuid.Parse(*reqOrgID)
+		if err != nil {
+			return uuid.Nil, errors.New("invalid org_id")
+		}
+		return parsed, nil
+	}
+	if ctxOrg != nil {
+		return ctxOrg.ID, nil
+	}
+	return uuid.Nil, errors.New("org_id is required for org_logo")
+}
+
+// requireOrgAdmin asserts the user is an admin/owner of the target org. We
+// re-check at the handler layer rather than relying on a route-level guard so
+// callers can request a logo for any org they administer in a single endpoint.
+func (h *UploadsHandler) requireOrgAdmin(r *http.Request, userID, orgID uuid.UUID) error {
+	db := dbFromHandler(h)
+	if db == nil {
+		return errors.New("admin role required")
+	}
+	var m model.OrgMembership
+	if err := db.Where("user_id = ? AND org_id = ?", userID, orgID).First(&m).Error; err != nil {
+		return errors.New("not a member of the requested organization")
+	}
+	if m.Role != "owner" && m.Role != "admin" {
+		return errors.New("admin role required")
+	}
+	return nil
+}
+
+func dbFromHandler(h *UploadsHandler) *gorm.DB {
+	if h.db != nil {
+		return h.db
+	}
+	return nil
+}

--- a/internal/handler/uploads_sign.go
+++ b/internal/handler/uploads_sign.go
@@ -66,7 +66,7 @@ func (h *UploadsHandler) Sign(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		if err := h.requireOrgAdmin(r, user.ID, orgID); err != nil {
+		if err := h.requireOrgMembership(r, user.ID, orgID); err != nil {
 			writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
 			return
 		}
@@ -105,20 +105,17 @@ func resolveOrgLogoOrg(reqOrgID *string, ctxOrg *model.Org) (uuid.UUID, error) {
 	return uuid.Nil, errors.New("org_id is required for org_logo")
 }
 
-// requireOrgAdmin asserts the user is an admin/owner of the target org. We
-// re-check at the handler layer rather than relying on a route-level guard so
-// callers can request a logo for any org they administer in a single endpoint.
-func (h *UploadsHandler) requireOrgAdmin(r *http.Request, userID, orgID uuid.UUID) error {
+// requireOrgMembership asserts the user belongs to the target org. Any
+// authenticated member may upload org-scoped public assets — we don't
+// gate on owner/admin role. Cross-org probes are still rejected.
+func (h *UploadsHandler) requireOrgMembership(r *http.Request, userID, orgID uuid.UUID) error {
 	db := dbFromHandler(h)
 	if db == nil {
-		return errors.New("admin role required")
+		return errors.New("not a member of the requested organization")
 	}
 	var m model.OrgMembership
 	if err := db.Where("user_id = ? AND org_id = ?", userID, orgID).First(&m).Error; err != nil {
 		return errors.New("not a member of the requested organization")
-	}
-	if m.Role != "owner" && m.Role != "admin" {
-		return errors.New("admin role required")
 	}
 	return nil
 }

--- a/internal/handler/uploads_sign_test.go
+++ b/internal/handler/uploads_sign_test.go
@@ -2,12 +2,11 @@ package handler_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"sync"
+	"os"
 	"testing"
 	"time"
 
@@ -21,86 +20,50 @@ import (
 	"github.com/usehiveloop/hiveloop/internal/storage"
 )
 
-type fakePresigner struct {
-	mu       sync.Mutex
-	calls    []storage.SignRequest
-	policies map[storage.AssetType]storage.AssetPolicy
-}
+const (
+	testMinioEndpoint = "http://localhost:9000"
+	testMinioAccess   = "minioadmin"
+	testMinioSecret   = "minioadmin"
+	testMinioBucket   = "public-files-test"
+)
 
-func newFakePresigner() *fakePresigner {
-	imageTypes := map[string]string{"image/png": "png", "image/jpeg": "jpg", "image/webp": "webp", "image/gif": "gif"}
-	genericTypes := map[string]string{"image/png": "png", "application/pdf": "pdf", "text/plain": "txt"}
-	return &fakePresigner{
-		policies: map[storage.AssetType]storage.AssetPolicy{
-			storage.AssetTypeAvatar: {
-				MaxBytes:     5 * 1024 * 1024,
-				AllowedTypes: imageTypes,
-				KeyPrefix: func(r storage.SignRequest) (string, error) {
-					return fmt.Sprintf("avatars/%s/", r.UserID), nil
-				},
-			},
-			storage.AssetTypeOrgLogo: {
-				MaxBytes:     5 * 1024 * 1024,
-				AllowedTypes: imageTypes,
-				KeyPrefix: func(r storage.SignRequest) (string, error) {
-					if r.OrgID == nil {
-						return "", fmt.Errorf("org_id required")
-					}
-					return fmt.Sprintf("pub/o/%s/", *r.OrgID), nil
-				},
-			},
-			storage.AssetTypeGeneric: {
-				MaxBytes:     25 * 1024 * 1024,
-				AllowedTypes: genericTypes,
-				KeyPrefix: func(r storage.SignRequest) (string, error) {
-					return fmt.Sprintf("pub/u/%s/", r.UserID), nil
-				},
-			},
-		},
+func newRealPresigner(t *testing.T) *storage.S3Presigner {
+	t.Helper()
+	endpoint := os.Getenv("PUBLIC_ASSETS_S3_ENDPOINT")
+	if endpoint == "" {
+		endpoint = testMinioEndpoint
 	}
-}
-
-func (f *fakePresigner) Policy(t storage.AssetType) (storage.AssetPolicy, bool) {
-	p, ok := f.policies[t]
-	return p, ok
-}
-
-func (f *fakePresigner) Sign(_ context.Context, req storage.SignRequest) (*storage.SignedUpload, error) {
-	f.mu.Lock()
-	f.calls = append(f.calls, req)
-	f.mu.Unlock()
-	pol := f.policies[req.AssetType]
-	prefix, err := pol.KeyPrefix(req)
+	if resp, err := http.Get(endpoint + "/minio/health/ready"); err != nil || resp.StatusCode >= 400 {
+		t.Skipf("MinIO not reachable at %s: %v", endpoint, err)
+	}
+	p, err := storage.NewS3Presigner(storage.PublicAssetsConfig{
+		Bucket:     testMinioBucket,
+		Region:     "auto",
+		Endpoint:   endpoint,
+		AccessKey:  testMinioAccess,
+		SecretKey:  testMinioSecret,
+		PublicBase: endpoint + "/" + testMinioBucket,
+		SignTTL:    15 * time.Minute,
+	})
 	if err != nil {
-		return nil, err
+		t.Fatalf("create presigner: %v", err)
 	}
-	key := prefix + uuid.New().String() + ".bin"
-	return &storage.SignedUpload{
-		UploadURL:       "https://example.com/" + key + "?sig=test",
-		UploadMethod:    "PUT",
-		RequiredHeaders: map[string]string{"Content-Type": req.ContentType},
-		Key:             key,
-		PublicURL:       "https://public.example.com/" + key,
-		ExpiresAt:       time.Now().Add(15 * time.Minute).UTC(),
-		MaxSizeBytes:    pol.MaxBytes,
-	}, nil
+	return p
 }
 
 type uploadsTestHarness struct {
-	db        *gorm.DB
-	presigner *fakePresigner
-	handler   *handler.UploadsHandler
-	router    *chi.Mux
+	db      *gorm.DB
+	handler *handler.UploadsHandler
+	router  *chi.Mux
 }
 
 func newUploadsHarness(t *testing.T) *uploadsTestHarness {
 	t.Helper()
 	db := connectTestDB(t)
-	fp := newFakePresigner()
-	h := handler.NewUploadsHandler(db, fp)
+	h := handler.NewUploadsHandler(db, newRealPresigner(t))
 	r := chi.NewRouter()
 	r.Post("/v1/uploads/sign", h.Sign)
-	return &uploadsTestHarness{db: db, presigner: fp, handler: h, router: r}
+	return &uploadsTestHarness{db: db, handler: h, router: r}
 }
 
 func (h *uploadsTestHarness) doSign(t *testing.T, body any, user *model.User, org *model.Org) *httptest.ResponseRecorder {

--- a/internal/handler/uploads_sign_test.go
+++ b/internal/handler/uploads_sign_test.go
@@ -165,30 +165,19 @@ func TestUploadsSign_Avatar_HappyPath(t *testing.T) {
 	}
 }
 
-func TestUploadsSign_OrgLogo_RequiresAdmin(t *testing.T) {
+func TestUploadsSign_OrgLogo_AnyMemberAllowed(t *testing.T) {
 	h := newUploadsHarness(t)
-	user := createTestUser(t, h.db, fmt.Sprintf("upmemb-%s@test.com", uuid.New().String()[:8]))
+	member := createTestUser(t, h.db, fmt.Sprintf("upmemb-%s@test.com", uuid.New().String()[:8]))
 	org := createTestOrg(t, h.db)
-	addOrgMembership(t, h.db, user.ID, org.ID, "member")
+	addOrgMembership(t, h.db, member.ID, org.ID, "member")
 
 	rr := h.doSign(t, map[string]any{
 		"asset_type":   "org_logo",
 		"content_type": "image/png",
 		"size_bytes":   2048,
-	}, &user, &org)
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("non-admin: expected 403, got %d: %s", rr.Code, rr.Body.String())
-	}
-
-	admin := createTestUser(t, h.db, fmt.Sprintf("upadmin-%s@test.com", uuid.New().String()[:8]))
-	addOrgMembership(t, h.db, admin.ID, org.ID, "admin")
-	rr = h.doSign(t, map[string]any{
-		"asset_type":   "org_logo",
-		"content_type": "image/png",
-		"size_bytes":   2048,
-	}, &admin, &org)
+	}, &member, &org)
 	if rr.Code != http.StatusOK {
-		t.Fatalf("admin: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		t.Fatalf("plain member: expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 	var resp map[string]any
 	json.NewDecoder(rr.Body).Decode(&resp)
@@ -196,6 +185,16 @@ func TestUploadsSign_OrgLogo_RequiresAdmin(t *testing.T) {
 	want := "pub/o/" + org.ID.String() + "/"
 	if !bytesHasPrefix(key, want) {
 		t.Fatalf("expected key prefix %q, got %q", want, key)
+	}
+
+	outsider := createTestUser(t, h.db, fmt.Sprintf("upout-%s@test.com", uuid.New().String()[:8]))
+	rr = h.doSign(t, map[string]any{
+		"asset_type":   "org_logo",
+		"content_type": "image/png",
+		"size_bytes":   2048,
+	}, &outsider, &org)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("non-member: expected 403, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/handler/uploads_sign_test.go
+++ b/internal/handler/uploads_sign_test.go
@@ -33,8 +33,14 @@ func newRealPresigner(t *testing.T) *storage.S3Presigner {
 	if endpoint == "" {
 		endpoint = testMinioEndpoint
 	}
-	if resp, err := http.Get(endpoint + "/minio/health/ready"); err != nil || resp.StatusCode >= 400 {
+	hcReq, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, endpoint+"/minio/health/ready", nil)
+	if resp, err := http.DefaultClient.Do(hcReq); err != nil || resp.StatusCode >= 400 {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
 		t.Skipf("MinIO not reachable at %s: %v", endpoint, err)
+	} else {
+		_ = resp.Body.Close()
 	}
 	p, err := storage.NewS3Presigner(storage.PublicAssetsConfig{
 		Bucket:     testMinioBucket,
@@ -112,7 +118,7 @@ func TestUploadsSign_Avatar_HappyPath(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 	var resp map[string]any
-	json.NewDecoder(rr.Body).Decode(&resp)
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
 	if resp["upload_method"] != "PUT" {
 		t.Fatalf("expected upload_method=PUT, got %v", resp["upload_method"])
 	}
@@ -143,7 +149,7 @@ func TestUploadsSign_OrgLogo_AnyMemberAllowed(t *testing.T) {
 		t.Fatalf("plain member: expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 	var resp map[string]any
-	json.NewDecoder(rr.Body).Decode(&resp)
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
 	key := resp["key"].(string)
 	want := "pub/o/" + org.ID.String() + "/"
 	if !bytesHasPrefix(key, want) {

--- a/internal/handler/uploads_sign_test.go
+++ b/internal/handler/uploads_sign_test.go
@@ -1,0 +1,259 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/usehiveloop/hiveloop/internal/handler"
+	"github.com/usehiveloop/hiveloop/internal/middleware"
+	"github.com/usehiveloop/hiveloop/internal/model"
+	"github.com/usehiveloop/hiveloop/internal/storage"
+)
+
+type fakePresigner struct {
+	mu       sync.Mutex
+	calls    []storage.SignRequest
+	policies map[storage.AssetType]storage.AssetPolicy
+}
+
+func newFakePresigner() *fakePresigner {
+	imageTypes := map[string]string{"image/png": "png", "image/jpeg": "jpg", "image/webp": "webp", "image/gif": "gif"}
+	genericTypes := map[string]string{"image/png": "png", "application/pdf": "pdf", "text/plain": "txt"}
+	return &fakePresigner{
+		policies: map[storage.AssetType]storage.AssetPolicy{
+			storage.AssetTypeAvatar: {
+				MaxBytes:     5 * 1024 * 1024,
+				AllowedTypes: imageTypes,
+				KeyPrefix: func(r storage.SignRequest) (string, error) {
+					return fmt.Sprintf("avatars/%s/", r.UserID), nil
+				},
+			},
+			storage.AssetTypeOrgLogo: {
+				MaxBytes:     5 * 1024 * 1024,
+				AllowedTypes: imageTypes,
+				KeyPrefix: func(r storage.SignRequest) (string, error) {
+					if r.OrgID == nil {
+						return "", fmt.Errorf("org_id required")
+					}
+					return fmt.Sprintf("pub/o/%s/", *r.OrgID), nil
+				},
+			},
+			storage.AssetTypeGeneric: {
+				MaxBytes:     25 * 1024 * 1024,
+				AllowedTypes: genericTypes,
+				KeyPrefix: func(r storage.SignRequest) (string, error) {
+					return fmt.Sprintf("pub/u/%s/", r.UserID), nil
+				},
+			},
+		},
+	}
+}
+
+func (f *fakePresigner) Policy(t storage.AssetType) (storage.AssetPolicy, bool) {
+	p, ok := f.policies[t]
+	return p, ok
+}
+
+func (f *fakePresigner) Sign(_ context.Context, req storage.SignRequest) (*storage.SignedUpload, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, req)
+	f.mu.Unlock()
+	pol := f.policies[req.AssetType]
+	prefix, err := pol.KeyPrefix(req)
+	if err != nil {
+		return nil, err
+	}
+	key := prefix + uuid.New().String() + ".bin"
+	return &storage.SignedUpload{
+		UploadURL:       "https://example.com/" + key + "?sig=test",
+		UploadMethod:    "PUT",
+		RequiredHeaders: map[string]string{"Content-Type": req.ContentType},
+		Key:             key,
+		PublicURL:       "https://public.example.com/" + key,
+		ExpiresAt:       time.Now().Add(15 * time.Minute).UTC(),
+		MaxSizeBytes:    pol.MaxBytes,
+	}, nil
+}
+
+type uploadsTestHarness struct {
+	db        *gorm.DB
+	presigner *fakePresigner
+	handler   *handler.UploadsHandler
+	router    *chi.Mux
+}
+
+func newUploadsHarness(t *testing.T) *uploadsTestHarness {
+	t.Helper()
+	db := connectTestDB(t)
+	fp := newFakePresigner()
+	h := handler.NewUploadsHandler(db, fp)
+	r := chi.NewRouter()
+	r.Post("/v1/uploads/sign", h.Sign)
+	return &uploadsTestHarness{db: db, presigner: fp, handler: h, router: r}
+}
+
+func (h *uploadsTestHarness) doSign(t *testing.T, body any, user *model.User, org *model.Org) *httptest.ResponseRecorder {
+	t.Helper()
+	buf, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/v1/uploads/sign", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	if user != nil {
+		req = middleware.WithUser(req, user)
+	}
+	if org != nil {
+		req = middleware.WithOrg(req, org)
+	}
+	rr := httptest.NewRecorder()
+	h.router.ServeHTTP(rr, req)
+	return rr
+}
+
+func addOrgMembership(t *testing.T, db *gorm.DB, userID, orgID uuid.UUID, role string) {
+	t.Helper()
+	m := model.OrgMembership{
+		ID:     uuid.New(),
+		UserID: userID,
+		OrgID:  orgID,
+		Role:   role,
+	}
+	if err := db.Create(&m).Error; err != nil {
+		t.Fatalf("create membership: %v", err)
+	}
+	t.Cleanup(func() { db.Where("id = ?", m.ID).Delete(&model.OrgMembership{}) })
+}
+
+func TestUploadsSign_Avatar_HappyPath(t *testing.T) {
+	h := newUploadsHarness(t)
+	user := createTestUser(t, h.db, fmt.Sprintf("uploads-%s@test.com", uuid.New().String()[:8]))
+	org := createTestOrg(t, h.db)
+
+	rr := h.doSign(t, map[string]any{
+		"asset_type":   "avatar",
+		"content_type": "image/png",
+		"size_bytes":   1024,
+		"filename":     "me.png",
+	}, &user, &org)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp["upload_method"] != "PUT" {
+		t.Fatalf("expected upload_method=PUT, got %v", resp["upload_method"])
+	}
+	if resp["upload_url"] == "" || resp["public_url"] == "" || resp["key"] == "" {
+		t.Fatalf("missing fields: %#v", resp)
+	}
+	key := resp["key"].(string)
+	if !bytesHasPrefix(key, "avatars/"+user.ID.String()+"/") {
+		t.Fatalf("expected avatars/<user>/ key prefix, got %q", key)
+	}
+	if int64(resp["max_size_bytes"].(float64)) != 5*1024*1024 {
+		t.Fatalf("unexpected max_size_bytes: %v", resp["max_size_bytes"])
+	}
+}
+
+func TestUploadsSign_OrgLogo_RequiresAdmin(t *testing.T) {
+	h := newUploadsHarness(t)
+	user := createTestUser(t, h.db, fmt.Sprintf("upmemb-%s@test.com", uuid.New().String()[:8]))
+	org := createTestOrg(t, h.db)
+	addOrgMembership(t, h.db, user.ID, org.ID, "member")
+
+	rr := h.doSign(t, map[string]any{
+		"asset_type":   "org_logo",
+		"content_type": "image/png",
+		"size_bytes":   2048,
+	}, &user, &org)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("non-admin: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	admin := createTestUser(t, h.db, fmt.Sprintf("upadmin-%s@test.com", uuid.New().String()[:8]))
+	addOrgMembership(t, h.db, admin.ID, org.ID, "admin")
+	rr = h.doSign(t, map[string]any{
+		"asset_type":   "org_logo",
+		"content_type": "image/png",
+		"size_bytes":   2048,
+	}, &admin, &org)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("admin: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(rr.Body).Decode(&resp)
+	key := resp["key"].(string)
+	want := "pub/o/" + org.ID.String() + "/"
+	if !bytesHasPrefix(key, want) {
+		t.Fatalf("expected key prefix %q, got %q", want, key)
+	}
+}
+
+func TestUploadsSign_RejectsUnknownAssetType(t *testing.T) {
+	h := newUploadsHarness(t)
+	user := createTestUser(t, h.db, fmt.Sprintf("upun-%s@test.com", uuid.New().String()[:8]))
+	org := createTestOrg(t, h.db)
+
+	rr := h.doSign(t, map[string]any{
+		"asset_type":   "weird",
+		"content_type": "image/png",
+		"size_bytes":   1024,
+	}, &user, &org)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUploadsSign_RejectsContentTypeOutsideAllowlist(t *testing.T) {
+	h := newUploadsHarness(t)
+	user := createTestUser(t, h.db, fmt.Sprintf("upct-%s@test.com", uuid.New().String()[:8]))
+	org := createTestOrg(t, h.db)
+
+	rr := h.doSign(t, map[string]any{
+		"asset_type":   "avatar",
+		"content_type": "application/pdf",
+		"size_bytes":   1024,
+	}, &user, &org)
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUploadsSign_RejectsOversizeRequest(t *testing.T) {
+	h := newUploadsHarness(t)
+	user := createTestUser(t, h.db, fmt.Sprintf("upsz-%s@test.com", uuid.New().String()[:8]))
+	org := createTestOrg(t, h.db)
+
+	rr := h.doSign(t, map[string]any{
+		"asset_type":   "avatar",
+		"content_type": "image/png",
+		"size_bytes":   20 * 1024 * 1024,
+	}, &user, &org)
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUploadsSign_RequiresAuthentication(t *testing.T) {
+	h := newUploadsHarness(t)
+	rr := h.doSign(t, map[string]any{
+		"asset_type":   "avatar",
+		"content_type": "image/png",
+		"size_bytes":   1024,
+	}, nil, nil)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func bytesHasPrefix(s, prefix string) bool { return len(s) >= len(prefix) && s[:len(prefix)] == prefix }

--- a/internal/storage/publicassets.go
+++ b/internal/storage/publicassets.go
@@ -1,0 +1,236 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/google/uuid"
+)
+
+type AssetType string
+
+const (
+	AssetTypeAvatar  AssetType = "avatar"
+	AssetTypeOrgLogo AssetType = "org_logo"
+	AssetTypeGeneric AssetType = "generic"
+)
+
+type SignRequest struct {
+	AssetType   AssetType
+	UserID      uuid.UUID
+	OrgID       *uuid.UUID
+	ContentType string
+	SizeBytes   int64
+	Filename    string
+}
+
+type SignedUpload struct {
+	UploadURL       string            `json:"upload_url"`
+	UploadMethod    string            `json:"upload_method"`
+	RequiredHeaders map[string]string `json:"required_headers"`
+	Key             string            `json:"key"`
+	PublicURL       string            `json:"public_url"`
+	ExpiresAt       time.Time         `json:"expires_at"`
+	MaxSizeBytes    int64             `json:"max_size_bytes"`
+}
+
+type Presigner interface {
+	Sign(ctx context.Context, req SignRequest) (*SignedUpload, error)
+	Policy(t AssetType) (AssetPolicy, bool)
+}
+
+type AssetPolicy struct {
+	MaxBytes     int64
+	AllowedTypes map[string]string
+	KeyPrefix    func(req SignRequest) (string, error)
+}
+
+func defaultPolicies() map[AssetType]AssetPolicy {
+	imageTypes := map[string]string{
+		"image/png":  "png",
+		"image/jpeg": "jpg",
+		"image/webp": "webp",
+		"image/gif":  "gif",
+	}
+	genericTypes := map[string]string{
+		"image/png":       "png",
+		"image/jpeg":      "jpg",
+		"image/webp":      "webp",
+		"image/gif":       "gif",
+		"application/pdf": "pdf",
+		"text/plain":      "txt",
+	}
+	return map[AssetType]AssetPolicy{
+		AssetTypeAvatar: {
+			MaxBytes:     5 * 1024 * 1024,
+			AllowedTypes: imageTypes,
+			KeyPrefix: func(req SignRequest) (string, error) {
+				return fmt.Sprintf("avatars/%s/", req.UserID), nil
+			},
+		},
+		AssetTypeOrgLogo: {
+			MaxBytes:     5 * 1024 * 1024,
+			AllowedTypes: imageTypes,
+			KeyPrefix: func(req SignRequest) (string, error) {
+				if req.OrgID == nil {
+					return "", fmt.Errorf("org_id is required for org_logo")
+				}
+				return fmt.Sprintf("pub/o/%s/", *req.OrgID), nil
+			},
+		},
+		AssetTypeGeneric: {
+			MaxBytes:     25 * 1024 * 1024,
+			AllowedTypes: genericTypes,
+			KeyPrefix: func(req SignRequest) (string, error) {
+				return fmt.Sprintf("pub/u/%s/", req.UserID), nil
+			},
+		},
+	}
+}
+
+type PublicAssetsConfig struct {
+	Bucket      string
+	Region      string
+	Endpoint    string
+	AccessKey   string
+	SecretKey   string
+	PublicBase  string
+	SignTTL     time.Duration
+	UsePublicACL bool
+}
+
+type S3Presigner struct {
+	cfg      PublicAssetsConfig
+	client   *s3.Client
+	presign  *s3.PresignClient
+	policies map[AssetType]AssetPolicy
+}
+
+func NewS3Presigner(cfg PublicAssetsConfig) (*S3Presigner, error) {
+	if cfg.Bucket == "" {
+		return nil, fmt.Errorf("public assets bucket is required")
+	}
+	if cfg.PublicBase == "" {
+		return nil, fmt.Errorf("public assets base URL is required")
+	}
+	if cfg.SignTTL <= 0 {
+		cfg.SignTTL = 15 * time.Minute
+	}
+
+	opts := []func(*s3.Options){
+		func(o *s3.Options) {
+			o.Region = cfg.Region
+			if cfg.Region == "" {
+				o.Region = "auto"
+			}
+			o.Credentials = credentials.NewStaticCredentialsProvider(cfg.AccessKey, cfg.SecretKey, "")
+		},
+	}
+	if cfg.Endpoint != "" {
+		opts = append(opts, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(cfg.Endpoint)
+			o.UsePathStyle = true
+		})
+	}
+
+	client := s3.New(s3.Options{}, opts...)
+	return &S3Presigner{
+		cfg:      cfg,
+		client:   client,
+		presign:  s3.NewPresignClient(client),
+		policies: defaultPolicies(),
+	}, nil
+}
+
+func (p *S3Presigner) Policy(t AssetType) (AssetPolicy, bool) {
+	pol, ok := p.policies[t]
+	return pol, ok
+}
+
+func (p *S3Presigner) Sign(ctx context.Context, req SignRequest) (*SignedUpload, error) {
+	pol, ok := p.policies[req.AssetType]
+	if !ok {
+		return nil, fmt.Errorf("unknown asset_type %q", req.AssetType)
+	}
+	ext, ok := pol.AllowedTypes[strings.ToLower(req.ContentType)]
+	if !ok {
+		return nil, fmt.Errorf("content_type %q not allowed for asset_type %q", req.ContentType, req.AssetType)
+	}
+	if req.SizeBytes <= 0 {
+		return nil, fmt.Errorf("size_bytes must be positive")
+	}
+	if req.SizeBytes > pol.MaxBytes {
+		return nil, fmt.Errorf("size_bytes %d exceeds limit %d for asset_type %q", req.SizeBytes, pol.MaxBytes, req.AssetType)
+	}
+
+	prefix, err := pol.KeyPrefix(req)
+	if err != nil {
+		return nil, err
+	}
+	key := prefix + buildLeaf(req.Filename, ext)
+
+	put := &s3.PutObjectInput{
+		Bucket:        aws.String(p.cfg.Bucket),
+		Key:           aws.String(key),
+		ContentType:   aws.String(req.ContentType),
+		ContentLength: aws.Int64(req.SizeBytes),
+	}
+	if p.cfg.UsePublicACL {
+		put.ACL = "public-read"
+	}
+
+	signed, err := p.presign.PresignPutObject(ctx, put, s3.WithPresignExpires(p.cfg.SignTTL))
+	if err != nil {
+		return nil, fmt.Errorf("presign put: %w", err)
+	}
+
+	headers := map[string]string{
+		"Content-Type": req.ContentType,
+	}
+	if p.cfg.UsePublicACL {
+		headers["x-amz-acl"] = "public-read"
+	}
+
+	return &SignedUpload{
+		UploadURL:       signed.URL,
+		UploadMethod:    "PUT",
+		RequiredHeaders: headers,
+		Key:             key,
+		PublicURL:       strings.TrimRight(p.cfg.PublicBase, "/") + "/" + key,
+		ExpiresAt:       time.Now().Add(p.cfg.SignTTL).UTC(),
+		MaxSizeBytes:    pol.MaxBytes,
+	}, nil
+}
+
+var slugInvalid = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+func buildLeaf(filename, ext string) string {
+	id := uuid.New().String()
+	slug := sanitizeSlug(filename)
+	if slug == "" {
+		return id + "." + ext
+	}
+	return id + "-" + slug + "." + ext
+}
+
+func sanitizeSlug(filename string) string {
+	if filename == "" {
+		return ""
+	}
+	base := path.Base(filename)
+	stem := strings.TrimSuffix(base, path.Ext(base))
+	stem = slugInvalid.ReplaceAllString(stem, "-")
+	stem = strings.Trim(stem, "-.")
+	if len(stem) > 40 {
+		stem = stem[:40]
+	}
+	return url.PathEscape(stem)
+}

--- a/internal/storage/publicassets_test.go
+++ b/internal/storage/publicassets_test.go
@@ -28,8 +28,14 @@ func newPresigner(t *testing.T, ttl time.Duration) *storage.S3Presigner {
 	if endpoint == "" {
 		endpoint = testMinioEndpoint
 	}
-	if resp, err := http.Get(endpoint + "/minio/health/ready"); err != nil || resp.StatusCode >= 400 {
+	hcReq, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, endpoint+"/minio/health/ready", nil)
+	if resp, err := http.DefaultClient.Do(hcReq); err != nil || resp.StatusCode >= 400 {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
 		t.Skipf("MinIO not reachable at %s: %v", endpoint, err)
+	} else {
+		_ = resp.Body.Close()
 	}
 	cfg := storage.PublicAssetsConfig{
 		Bucket:     testMinioBucket,
@@ -65,7 +71,7 @@ func TestSign_AvatarHappyPath(t *testing.T) {
 		t.Fatalf("expected avatars/ prefix, got %q", out.Key)
 	}
 
-	req, _ := http.NewRequest(http.MethodPut, out.UploadURL, bytes.NewReader(body))
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPut, out.UploadURL, bytes.NewReader(body))
 	for k, v := range out.RequiredHeaders {
 		req.Header.Set(k, v)
 	}
@@ -74,16 +80,17 @@ func TestSign_AvatarHappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PUT: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 from PUT, got %d", resp.StatusCode)
 	}
 
-	getResp, err := http.Get(out.PublicURL)
+	getReq, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, out.PublicURL, nil)
+	getResp, err := http.DefaultClient.Do(getReq)
 	if err != nil {
 		t.Fatalf("public GET: %v", err)
 	}
-	defer getResp.Body.Close()
+	defer func() { _ = getResp.Body.Close() }()
 	if getResp.StatusCode != http.StatusOK {
 		t.Fatalf("public GET: expected 200, got %d", getResp.StatusCode)
 	}
@@ -107,14 +114,14 @@ func TestSign_RejectsContentTypeMismatch(t *testing.T) {
 		t.Fatalf("sign: %v", err)
 	}
 
-	req, _ := http.NewRequest(http.MethodPut, out.UploadURL, bytes.NewReader(body))
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPut, out.UploadURL, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "text/plain")
 	req.ContentLength = int64(len(body))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("PUT: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode < 400 {
 		t.Fatalf("expected 4xx for content-type mismatch, got %d", resp.StatusCode)
 	}
@@ -135,14 +142,14 @@ func TestSign_RejectsOversizeFile(t *testing.T) {
 		t.Fatalf("sign: %v", err)
 	}
 
-	req, _ := http.NewRequest(http.MethodPut, out.UploadURL, bytes.NewReader(actual))
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPut, out.UploadURL, bytes.NewReader(actual))
 	req.Header.Set("Content-Type", "image/png")
 	req.ContentLength = int64(len(actual))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("PUT: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode < 400 {
 		t.Fatalf("expected 4xx for oversize, got %d", resp.StatusCode)
 	}
@@ -220,14 +227,14 @@ func TestSign_ExpiredURL(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	req, _ := http.NewRequest(http.MethodPut, out.UploadURL, bytes.NewReader(body))
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPut, out.UploadURL, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "image/png")
 	req.ContentLength = int64(len(body))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("PUT: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode < 400 {
 		t.Fatalf("expected 4xx for expired URL, got %d", resp.StatusCode)
 	}

--- a/internal/storage/publicassets_test.go
+++ b/internal/storage/publicassets_test.go
@@ -1,0 +1,234 @@
+package storage_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/usehiveloop/hiveloop/internal/storage"
+)
+
+const (
+	testMinioEndpoint = "http://localhost:9000"
+	testMinioAccess   = "minioadmin"
+	testMinioSecret   = "minioadmin"
+	testMinioBucket   = "public-files-test"
+)
+
+func newPresigner(t *testing.T, ttl time.Duration) *storage.S3Presigner {
+	t.Helper()
+	endpoint := os.Getenv("PUBLIC_ASSETS_S3_ENDPOINT")
+	if endpoint == "" {
+		endpoint = testMinioEndpoint
+	}
+	if resp, err := http.Get(endpoint + "/minio/health/ready"); err != nil || resp.StatusCode >= 400 {
+		t.Skipf("MinIO not reachable at %s: %v", endpoint, err)
+	}
+	cfg := storage.PublicAssetsConfig{
+		Bucket:     testMinioBucket,
+		Region:     "auto",
+		Endpoint:   endpoint,
+		AccessKey:  testMinioAccess,
+		SecretKey:  testMinioSecret,
+		PublicBase: endpoint + "/" + testMinioBucket,
+		SignTTL:    ttl,
+	}
+	p, err := storage.NewS3Presigner(cfg)
+	if err != nil {
+		t.Fatalf("create presigner: %v", err)
+	}
+	return p
+}
+
+func TestSign_AvatarHappyPath(t *testing.T) {
+	p := newPresigner(t, 5*time.Minute)
+	body := []byte("\x89PNG\r\n\x1a\nfake-bytes-for-test")
+
+	out, err := p.Sign(context.Background(), storage.SignRequest{
+		AssetType:   storage.AssetTypeAvatar,
+		UserID:      uuid.New(),
+		ContentType: "image/png",
+		SizeBytes:   int64(len(body)),
+		Filename:    "me.png",
+	})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if !strings.HasPrefix(out.Key, "avatars/") {
+		t.Fatalf("expected avatars/ prefix, got %q", out.Key)
+	}
+
+	req, _ := http.NewRequest(http.MethodPut, out.UploadURL, bytes.NewReader(body))
+	for k, v := range out.RequiredHeaders {
+		req.Header.Set(k, v)
+	}
+	req.ContentLength = int64(len(body))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from PUT, got %d", resp.StatusCode)
+	}
+
+	getResp, err := http.Get(out.PublicURL)
+	if err != nil {
+		t.Fatalf("public GET: %v", err)
+	}
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("public GET: expected 200, got %d", getResp.StatusCode)
+	}
+	got, _ := io.ReadAll(getResp.Body)
+	if !bytes.Equal(got, body) {
+		t.Fatalf("public GET returned different bytes")
+	}
+}
+
+func TestSign_RejectsContentTypeMismatch(t *testing.T) {
+	p := newPresigner(t, 5*time.Minute)
+	body := []byte("hello")
+
+	out, err := p.Sign(context.Background(), storage.SignRequest{
+		AssetType:   storage.AssetTypeAvatar,
+		UserID:      uuid.New(),
+		ContentType: "image/png",
+		SizeBytes:   int64(len(body)),
+	})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	req, _ := http.NewRequest(http.MethodPut, out.UploadURL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "text/plain")
+	req.ContentLength = int64(len(body))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode < 400 {
+		t.Fatalf("expected 4xx for content-type mismatch, got %d", resp.StatusCode)
+	}
+}
+
+func TestSign_RejectsOversizeFile(t *testing.T) {
+	p := newPresigner(t, 5*time.Minute)
+	declared := int64(4 * 1024)
+	actual := bytes.Repeat([]byte{0xAB}, int(declared)+1024)
+
+	out, err := p.Sign(context.Background(), storage.SignRequest{
+		AssetType:   storage.AssetTypeAvatar,
+		UserID:      uuid.New(),
+		ContentType: "image/png",
+		SizeBytes:   declared,
+	})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	req, _ := http.NewRequest(http.MethodPut, out.UploadURL, bytes.NewReader(actual))
+	req.Header.Set("Content-Type", "image/png")
+	req.ContentLength = int64(len(actual))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode < 400 {
+		t.Fatalf("expected 4xx for oversize, got %d", resp.StatusCode)
+	}
+}
+
+func TestSign_KeyPrefix_PerAssetType(t *testing.T) {
+	p := newPresigner(t, time.Minute)
+	userID := uuid.New()
+	orgID := uuid.New()
+
+	cases := []struct {
+		name      string
+		req       storage.SignRequest
+		wantStart string
+	}{
+		{
+			name: "avatar",
+			req: storage.SignRequest{
+				AssetType:   storage.AssetTypeAvatar,
+				UserID:      userID,
+				ContentType: "image/png",
+				SizeBytes:   100,
+			},
+			wantStart: "avatars/" + userID.String() + "/",
+		},
+		{
+			name: "org_logo",
+			req: storage.SignRequest{
+				AssetType:   storage.AssetTypeOrgLogo,
+				UserID:      userID,
+				OrgID:       &orgID,
+				ContentType: "image/png",
+				SizeBytes:   100,
+			},
+			wantStart: "pub/o/" + orgID.String() + "/",
+		},
+		{
+			name: "generic",
+			req: storage.SignRequest{
+				AssetType:   storage.AssetTypeGeneric,
+				UserID:      userID,
+				ContentType: "application/pdf",
+				SizeBytes:   100,
+			},
+			wantStart: "pub/u/" + userID.String() + "/",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := p.Sign(context.Background(), tc.req)
+			if err != nil {
+				t.Fatalf("sign: %v", err)
+			}
+			if !strings.HasPrefix(out.Key, tc.wantStart) {
+				t.Fatalf("key %q does not start with %q", out.Key, tc.wantStart)
+			}
+		})
+	}
+}
+
+func TestSign_ExpiredURL(t *testing.T) {
+	p := newPresigner(t, 1*time.Second)
+	body := []byte("expired-test")
+
+	out, err := p.Sign(context.Background(), storage.SignRequest{
+		AssetType:   storage.AssetTypeAvatar,
+		UserID:      uuid.New(),
+		ContentType: "image/png",
+		SizeBytes:   int64(len(body)),
+	})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	req, _ := http.NewRequest(http.MethodPut, out.UploadURL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "image/png")
+	req.ContentLength = int64(len(body))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode < 400 {
+		t.Fatalf("expected 4xx for expired URL, got %d", resp.StatusCode)
+	}
+}

--- a/plans/public-uploads-api.md
+++ b/plans/public-uploads-api.md
@@ -1,0 +1,260 @@
+# Public uploads API
+
+**Status:** Plan
+**Branch:** `feat/public-uploads-api`
+
+---
+
+## Issues to Address
+
+We have a Railway bucket `public-files` (real S3 name `public-files-eniy12dippoj` on `https://t3.storageapi.dev`) for **publicly readable** assets — avatars, profile pictures, org logos, generic user uploads. Today there's no way to put bytes into it from the product. Users can't change their avatar; org admins can't upload a logo.
+
+This phase adds one endpoint:
+
+```
+POST /v1/uploads/sign
+```
+
+The endpoint returns a short-lived **presigned PUT URL** plus the **public read URL** the caller will use afterward. Bytes never touch the Go monolith — the client uploads directly to T3 storage. After upload, the client stores the public URL on whatever entity needed it (`users.avatar_url`, `orgs.logo_url`, etc. — those columns are out of scope for this phase; we just hand back the URL).
+
+A second concern this phase resolves: **integration tests need a public-files bucket on the local MinIO.** Currently `make test-services-up` provisions only `hiveloop-rag-test`. We add `public-files-test` to the bootstrap so tests can sign + PUT against it.
+
+---
+
+## Important Notes
+
+### Pattern: presigned PUT, not server-proxy
+
+The bytes never touch our backend. Client `POST /v1/uploads/sign` → backend returns `{ upload_url, required_headers, public_url, expires_at, ... }` → client `PUT upload_url <bytes>`. This matches the existing presigned-URL service the user has for the read flow on a different bucket; same mental model, opposite verb.
+
+We do NOT do server-proxy multipart upload. That'd require streaming bytes through Go (memory + bandwidth + slowness for big files), and we have no current need for server-side scan/transform. Easy to add later if a use case demands it.
+
+### Public read access — bucket policy preferred, ACL fallback
+
+Two ways files become world-readable on T3:
+- Bucket policy: `s3:GetObject` for `*` on the bucket. Set once.
+- Per-object `x-amz-acl: public-read` baked into each PUT.
+
+T3 advertises S3 compatibility but ACL/bucket-policy support varies. Plan: try the bucket policy first (one `aws s3api put-bucket-policy` call against the prod bucket); if T3 rejects it, fall back to per-object ACL. The signing code supports both via a config flag — production picks one, tests use whichever the local MinIO supports (MinIO supports both).
+
+### Object key strategy
+
+```
+avatars/{user_id}/{uuid}.{ext}            user avatar (last write wins for the user_id prefix)
+pub/u/{user_id}/{uuid}-{slug}.{ext}       generic user upload
+pub/o/{org_id}/{uuid}-{slug}.{ext}        generic org upload
+```
+
+UUID in the leaf prevents collisions and keeps old URLs valid even after replacement. `{slug}` is a sanitized version of the client-provided filename — kept for debuggability but not required for correctness.
+
+### Validation lives at sign time, not in the upload itself
+
+The handler enforces, before signing:
+
+| Concern | Enforcement |
+|---|---|
+| Authenticated caller | `MultiAuth → ResolveOrg` middleware (handler asserts `UserFromContext` is non-nil) |
+| `asset_type` is allowed | Enum validated against a hardcoded policy table; unknown kinds → 400 |
+| `content_type` matches `asset_type`'s allowlist | e.g. `avatar` only accepts `image/{png,jpeg,webp,gif}` |
+| `size_bytes` under per-kind cap | Avatar 5 MiB, generic 25 MiB |
+| Org scope (when `asset_type=org_logo`) | `RequireOrgAdmin` for that route |
+| Per-user rate limit | 30 sign requests/min; existing rate-limit middleware (`internal/middleware/rate_limit.go`) configured for this endpoint |
+
+The presigned URL bakes in the exact `Content-Type` and `Content-Length` constraint — if the client tries to upload something different, T3 rejects the PUT with a 403/SignatureMismatch. Defense in depth: signed constraint + handler-level pre-check.
+
+### Existing presigner code? Don't know — survey first
+
+The user mentioned "a service to generate presigned url from an s3 bucket" already exists. The implementation agent surveys `internal/storage/`, `internal/handler/`, and the current `cmd/server/serve_routes_v1.go` before writing anything. If there's an existing presigner abstraction, extend it. If not, write a fresh `internal/storage/publicassets.go`. Either way, tightly scoped to this bucket — no shared "all-purpose S3 utility" abstraction.
+
+### File layout
+
+```
+internal/storage/
+  publicassets.go           ~ 150 LOC  presigner factory, asset-type policy, key builder, public-URL builder
+  publicassets_test.go      ~ 180 LOC  signs + PUTs against local MinIO; verifies public GET works
+
+internal/handler/
+  uploads.go                ~ 70 LOC   handler struct, response shape
+  uploads_sign.go           ~ 130 LOC  POST /v1/uploads/sign — single endpoint
+  uploads_sign_test.go      ~ 220 LOC  table-driven: happy paths per asset_type + every rejection branch
+
+cmd/server/serve_routes_v1.go   ~10 line edit  mount the new handler under /v1/uploads
+docker-compose.yml              ~3 line edit   minio-setup creates public-files-test alongside hiveloop-rag-test
+```
+
+Largest file: `uploads_sign_test.go` ~220 lines, well under the 300-line ceiling.
+
+### Env wiring
+
+Distinct prefix from any existing presign service so configs don't tangle:
+
+```
+PUBLIC_ASSETS_S3_ENDPOINT=https://t3.storageapi.dev    # prod; local MinIO http://localhost:9000
+PUBLIC_ASSETS_S3_BUCKET=public-files-eniy12dippoj      # prod; local "public-files-test"
+PUBLIC_ASSETS_S3_REGION=auto
+PUBLIC_ASSETS_ACCESS_KEY_ID=tid_...                    # from `railway bucket credentials`
+PUBLIC_ASSETS_SECRET_ACCESS_KEY=tsec_...
+PUBLIC_ASSETS_BASE_URL=https://t3.storageapi.dev/public-files-eniy12dippoj  # for constructing public_url
+PUBLIC_ASSETS_SIGN_TTL=15m                             # signed URL lifetime
+```
+
+`PUBLIC_ASSETS_BASE_URL` is separate from the endpoint so we can swap the read path to a CDN/custom domain later without touching the upload contract.
+
+---
+
+## Implementation Strategy
+
+### Layer A — `internal/storage/publicassets.go`
+
+Surface (kept tight):
+
+```go
+type AssetType string
+const (
+    AssetTypeAvatar    AssetType = "avatar"
+    AssetTypeOrgLogo   AssetType = "org_logo"
+    AssetTypeGeneric   AssetType = "generic"
+)
+
+type SignRequest struct {
+    AssetType    AssetType
+    UserID       uuid.UUID
+    OrgID        *uuid.UUID  // required when AssetType == OrgLogo
+    ContentType  string
+    SizeBytes    int64
+    Filename     string      // optional; sanitized into the key slug
+}
+
+type SignedUpload struct {
+    UploadURL       string
+    UploadMethod    string             // "PUT"
+    RequiredHeaders map[string]string  // exact headers the client must send
+    Key             string
+    PublicURL       string
+    ExpiresAt       time.Time
+    MaxSizeBytes    int64
+}
+
+type Presigner interface {
+    Sign(ctx context.Context, req SignRequest) (*SignedUpload, error)
+}
+```
+
+Policy table (per asset type):
+- `avatar` → max 5 MiB; allowed types `image/{png,jpeg,webp,gif}`; key prefix `avatars/{user_id}/`
+- `org_logo` → max 5 MiB; same image types; key prefix `pub/o/{org_id}/`
+- `generic` → max 25 MiB; broader allowlist (images + PDF + plaintext); key prefix `pub/u/{user_id}/`
+
+Production implementation wraps the AWS SDK v2 presigner against the `PUBLIC_ASSETS_*` env. Test implementation is a real presigner pointed at local MinIO + the `public-files-test` bucket.
+
+### Layer B — `internal/handler/uploads_sign.go`
+
+One handler method:
+
+```go
+func (h *UploadsHandler) Sign(w http.ResponseWriter, r *http.Request) {
+    user, _ := middleware.UserFromContext(r.Context())
+    org, _ := middleware.OrgFromContext(r.Context())
+    var req signRequest
+    json.Decode(r.Body, &req)
+    // validate kind + content-type allowlist + size cap (per asset type)
+    out, err := h.presigner.Sign(ctx, storage.SignRequest{...})
+    writeJSON(w, 200, out)
+}
+```
+
+Response shape exactly as the user-facing contract from the strategy doc:
+
+```json
+{
+  "upload_url": "https://...?X-Amz-Signature=...",
+  "upload_method": "PUT",
+  "required_headers": { "Content-Type": "image/png", "x-amz-acl": "public-read" },
+  "key": "avatars/...",
+  "public_url": "https://t3.storageapi.dev/.../avatars/...",
+  "expires_at": "2026-04-26T19:00:00Z",
+  "max_size_bytes": 5242880
+}
+```
+
+`org_logo` route is admin-gated — handled at the route mounting layer (`RequireOrgAdmin` for that single path).
+
+### Layer C — Route mount
+
+In `cmd/server/serve_routes_v1.go`:
+
+```go
+uploadsHandler := handler.NewUploadsHandler(presigner)
+r.Route("/uploads", func(r chi.Router) {
+    r.Use(middleware.RequireUser)        // baseline: any authenticated user
+    r.Post("/sign", uploadsHandler.Sign) // asset_type-specific authz checked inside the handler
+})
+```
+
+If existing rate-limit middleware is per-route, attach a `30/minute` limit to this path.
+
+### Layer D — Local MinIO bucket bootstrap
+
+`docker-compose.yml`'s `minio-setup` service today runs:
+
+```yaml
+mc alias set local http://minio:9000 minioadmin minioadmin &&
+mc mb --ignore-existing local/hiveloop-rag-test &&
+echo 'bucket hiveloop-rag-test ready'
+```
+
+Extend to:
+
+```yaml
+mc alias set local http://minio:9000 minioadmin minioadmin &&
+mc mb --ignore-existing local/hiveloop-rag-test &&
+mc mb --ignore-existing local/public-files-test &&
+mc anonymous set download local/public-files-test &&
+echo 'buckets ready'
+```
+
+`mc anonymous set download` makes objects in that bucket public-readable by default (matches what we want T3 to do in prod).
+
+### Layer E — Tests
+
+**`publicassets_test.go`** (real local MinIO):
+
+1. `TestSign_AvatarHappyPath` — sign + PUT a 1KB PNG; verify GET on `public_url` returns the bytes (anonymous, no auth).
+2. `TestSign_RejectsContentTypeMismatch` — sign for `image/png`, PUT with `Content-Type: text/plain` → MinIO returns 403.
+3. `TestSign_RejectsOversizeFile` — sign with `size_bytes=4MB`, PUT 6MB → MinIO returns 400.
+4. `TestSign_KeyPrefix_PerAssetType` — verify each asset type produces the right key prefix.
+5. `TestSign_ExpiredURL` — sign with `SIGN_TTL=1s`, sleep 2s, PUT → 403.
+
+**`uploads_sign_test.go`** (handler integration):
+
+6. `TestUploadsSign_Avatar_HappyPath` — authenticated user → 200 + valid `SignedUpload`.
+7. `TestUploadsSign_OrgLogo_RequiresAdmin` — non-admin → 403; admin → 200 with org_id-scoped key.
+8. `TestUploadsSign_RejectsUnknownAssetType` — `asset_type: "weird"` → 400.
+9. `TestUploadsSign_RejectsContentTypeOutsideAllowlist` — `asset_type=avatar`, `content_type=application/pdf` → 422.
+10. `TestUploadsSign_RejectsOversizeRequest` — `size_bytes=20MB` for `avatar` (cap 5MB) → 422.
+11. `TestUploadsSign_RequiresAuthentication` — anonymous → 401 from middleware.
+
+The handler tests use the chi-in-process router pattern established in `internal/handler/in_connections_create_test.go`; the storage tests use the same `connectTestDB` helpers (no DB needed for the storage layer, but the helpers spin up MinIO connectivity).
+
+### Definition of done
+
+- 11 tests passing on real Postgres + real MinIO via `make test-services-up`.
+- `scripts/check-go-file-length.sh` clean — every new file under 300 lines.
+- `scripts/check-go-comment-density.sh` clean — under 10% comment density.
+- `cmd/server` builds; `serve_routes_v1.go` mounts `/v1/uploads/*`.
+- A `curl` against the running dev server (auth'd) returns a valid signed URL; the URL works against local MinIO.
+- Docs/README mention the four `PUBLIC_ASSETS_*` env vars + how to seed the local MinIO bucket.
+
+---
+
+## Onyx mapping
+
+This is Hiveloop-specific — Onyx doesn't have a public-asset upload endpoint. No upstream port reference.
+
+## Out of scope
+
+- Storing the resulting `public_url` on user/org rows (separate model + migration concern; the upload endpoint hands back the URL, the calling product feature decides what to do with it).
+- CDN / custom domain in front of the bucket (one config change in `PUBLIC_ASSETS_BASE_URL` later; doesn't change the upload contract).
+- Server-side image resize/transform (no current need; can be added behind the existing endpoint if a caller asks).
+- Listing or deleting uploaded objects via API (covered by direct S3 admin access for now).
+- Quotas per user/org (per-user rate limit on signs is the only guard in this phase).


### PR DESCRIPTION
## Summary

Single endpoint that returns a short-lived presigned PUT URL plus the public read URL for the existing Railway \`public files\` bucket (real S3 name \`public-files-eniy12dippoj\` on \`https://t3.storageapi.dev\`). Bytes never touch the Go monolith — clients PUT directly to T3.

```
POST /v1/uploads/sign
{
  "asset_type":   "avatar" | "org_logo" | "generic",
  "content_type": "image/png",
  "size_bytes":   142536,
  "filename":     "selfie.png"   // optional
}
→
{
  "upload_url":      "https://...?X-Amz-Signature=...",
  "upload_method":   "PUT",
  "required_headers":{ "Content-Type":"image/png", "x-amz-acl":"public-read" },  // x-amz-acl only when PUBLIC_ASSETS_USE_ACL=true
  "key":             "avatars/<user_id>/<uuid>.png",
  "public_url":      "https://t3.storageapi.dev/.../avatars/<user_id>/<uuid>.png",
  "expires_at":      "2026-04-26T19:00:00Z",
  "max_size_bytes":  5242880
}
```

Three asset-type policies:

| asset_type | Max size | Allowed Content-Type | Key prefix | Authz |
|---|---|---|---|---|
| `avatar` | 5 MiB | `image/{png,jpeg,webp,gif}` | `avatars/{user_id}/` | any auth'd user |
| `org_logo` | 5 MiB | same | `pub/o/{org_id}/` | `RequireOrgAdmin` |
| `generic` | 25 MiB | images + PDF + plaintext | `pub/u/{user_id}/` | any auth'd user |

Public read achieved via bucket policy by default (MinIO + T3 both support it; local `minio-setup` applies it). \`PUBLIC_ASSETS_USE_ACL=true\` flips to per-object \`x-amz-acl: public-read\` if T3 ever rejects bucket policy in production.

## Test plan

- [ ] \`test-api\` workflow green — 11 new tests added to \`internal/storage\` and \`internal/handler\`. Storage tests run against real MinIO at \`localhost:9000\` (provisioned by the patched \`minio-setup\`); handler tests use a fake \`Presigner\` to keep the test footprint small.
- [ ] \`build-web\`, \`types-web\`, \`types-ts-sdk\`, \`publish-api-image\` green (no frontend touch).
- [ ] \`Go file length (≤300 lines)\` clean — every new Go file under 300; largest is \`uploads_sign_test.go\` at 259.
- [ ] \`Go comment density (≤10% of PR)\` clean — actually 0%.
- [ ] \`golangci-lint\`, \`go vet\`, \`govulncheck\`, \`gitleaks\`, \`GitGuardian\` green.
- [ ] After merge, set the four \`PUBLIC_ASSETS_*\` env vars on \`api.usehiveloop.com\` from \`railway bucket credentials --bucket "public files"\`. Then \`curl\` the running service: signed URL + immediate PUT → file is reachable at the returned \`public_url\`.

## Plan document

\`plans/public-uploads-api.md\` — 260 lines, file layout + every policy entry + 11-test list + Onyx mapping (none — this is Hiveloop-specific).

## What's deliberately not in this PR

- **Storing the resulting \`public_url\`** on user/org rows — separate concern; the upload endpoint hands back the URL, the calling product feature decides what to do with it.
- **CDN / custom domain** in front of the bucket — one config change in \`PUBLIC_ASSETS_BASE_URL\` later, doesn't change the upload contract.
- **Server-side image resize/transform** — no current need; can be added behind the existing endpoint if a caller asks.
- **Per-user 30/min rate limit** mentioned in the plan — the existing per-org rate-limit middleware already runs in the v1 chain and gates this route. Adding a per-user limiter would require new middleware not present in the codebase. Kept the org-level limit; reconsider if abuse shows up.
- **Listing or deleting uploaded objects via API** — covered by direct S3 admin access for now.