### PR TITLE
fix(sandbox): treat upstream 404 as success in lifecycle sweeper

### DIFF
--- a/internal/sandbox/daytona/driver.go
+++ b/internal/sandbox/daytona/driver.go
@@ -144,6 +144,9 @@ func (d *Driver) DeleteSandbox(ctx context.Context, externalID string) error {
 		return fmt.Errorf("deleting sandbox: %w", err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return sandbox.ErrSandboxNotFound
+	}
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("delete sandbox failed (status %d): %s", resp.StatusCode, body)
@@ -183,6 +186,9 @@ func (d *Driver) sandboxAction(ctx context.Context, externalID, action string) e
 		return fmt.Errorf("%s sandbox: %w", action, err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return sandbox.ErrSandboxNotFound
+	}
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("%s sandbox failed (status %d): %s", action, resp.StatusCode, body)

--- a/internal/sandbox/orchestrator_delete.go
+++ b/internal/sandbox/orchestrator_delete.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -11,7 +12,11 @@ import (
 
 func (o *Orchestrator) StopSandbox(ctx context.Context, sb *model.Sandbox) error {
 	if err := o.provider.StopSandbox(ctx, sb.ExternalID); err != nil {
-		return fmt.Errorf("stopping sandbox %s: %w", sb.ID, err)
+		if !errors.Is(err, ErrSandboxNotFound) {
+			return fmt.Errorf("stopping sandbox %s: %w", sb.ID, err)
+		}
+		slog.Info("sandbox missing upstream, marking stopped locally",
+			"sandbox_id", sb.ID, "external_id", sb.ExternalID)
 	}
 	now := time.Now()
 	if err := o.db.Model(sb).Updates(map[string]any{
@@ -42,7 +47,11 @@ func (o *Orchestrator) ArchiveSandbox(ctx context.Context, sb *model.Sandbox) er
 	}
 
 	if err := o.provider.ArchiveSandbox(ctx, sb.ExternalID); err != nil {
-		return fmt.Errorf("archiving sandbox %s: %w", sb.ID, err)
+		if !errors.Is(err, ErrSandboxNotFound) {
+			return fmt.Errorf("archiving sandbox %s: %w", sb.ID, err)
+		}
+		slog.Info("sandbox missing upstream, marking archived locally",
+			"sandbox_id", sb.ID, "external_id", sb.ExternalID)
 	}
 
 	if err := o.db.Model(sb).Updates(map[string]any{

--- a/internal/sandbox/orchestrator_delete.go
+++ b/internal/sandbox/orchestrator_delete.go
@@ -12,11 +12,10 @@ import (
 
 func (o *Orchestrator) StopSandbox(ctx context.Context, sb *model.Sandbox) error {
 	if err := o.provider.StopSandbox(ctx, sb.ExternalID); err != nil {
-		if !errors.Is(err, ErrSandboxNotFound) {
-			return fmt.Errorf("stopping sandbox %s: %w", sb.ID, err)
+		if errors.Is(err, ErrSandboxNotFound) {
+			return o.purgeMissingSandbox(sb)
 		}
-		slog.Info("sandbox missing upstream, marking stopped locally",
-			"sandbox_id", sb.ID, "external_id", sb.ExternalID)
+		return fmt.Errorf("stopping sandbox %s: %w", sb.ID, err)
 	}
 	now := time.Now()
 	if err := o.db.Model(sb).Updates(map[string]any{
@@ -33,8 +32,9 @@ func (o *Orchestrator) StopSandbox(ctx context.Context, sb *model.Sandbox) error
 }
 
 func (o *Orchestrator) DeleteSandbox(ctx context.Context, sb *model.Sandbox) error {
-	if err := o.provider.DeleteSandbox(ctx, sb.ExternalID); err != nil {
-		slog.Warn("failed to delete sandbox from provider", "sandbox_id", sb.ID, "external_id", sb.ExternalID, "error", err)
+	if err := o.provider.DeleteSandbox(ctx, sb.ExternalID); err != nil && !errors.Is(err, ErrSandboxNotFound) {
+		slog.Warn("failed to delete sandbox from provider",
+			"sandbox_id", sb.ID, "external_id", sb.ExternalID, "error", err)
 	}
 	return o.db.Where("id = ?", sb.ID).Delete(&model.Sandbox{}).Error
 }
@@ -42,16 +42,18 @@ func (o *Orchestrator) DeleteSandbox(ctx context.Context, sb *model.Sandbox) err
 func (o *Orchestrator) ArchiveSandbox(ctx context.Context, sb *model.Sandbox) error {
 	if sb.Status != string(StatusStopped) {
 		if err := o.StopSandbox(ctx, sb); err != nil {
+			if errors.Is(err, ErrSandboxNotFound) {
+				return nil
+			}
 			return fmt.Errorf("stopping sandbox before archive: %w", err)
 		}
 	}
 
 	if err := o.provider.ArchiveSandbox(ctx, sb.ExternalID); err != nil {
-		if !errors.Is(err, ErrSandboxNotFound) {
-			return fmt.Errorf("archiving sandbox %s: %w", sb.ID, err)
+		if errors.Is(err, ErrSandboxNotFound) {
+			return o.purgeMissingSandbox(sb)
 		}
-		slog.Info("sandbox missing upstream, marking archived locally",
-			"sandbox_id", sb.ID, "external_id", sb.ExternalID)
+		return fmt.Errorf("archiving sandbox %s: %w", sb.ID, err)
 	}
 
 	if err := o.db.Model(sb).Updates(map[string]any{
@@ -65,6 +67,19 @@ func (o *Orchestrator) ArchiveSandbox(ctx context.Context, sb *model.Sandbox) er
 
 	slog.Info("sandbox archived", "sandbox_id", sb.ID, "external_id", sb.ExternalID)
 	return nil
+}
+
+// Sandbox is gone from the upstream provider. Drop the local row so the FK
+// CASCADE on agent_conversations / router_conversations sweeps any
+// references. Returns ErrSandboxNotFound so callers know the row no longer
+// exists and shouldn't try to update it.
+func (o *Orchestrator) purgeMissingSandbox(sb *model.Sandbox) error {
+	slog.Info("sandbox missing upstream, purging local row",
+		"sandbox_id", sb.ID, "external_id", sb.ExternalID)
+	if err := o.db.Where("id = ?", sb.ID).Delete(&model.Sandbox{}).Error; err != nil {
+		return fmt.Errorf("purging missing sandbox %s: %w", sb.ID, err)
+	}
+	return ErrSandboxNotFound
 }
 
 func (o *Orchestrator) UnarchiveSandbox(ctx context.Context, sb *model.Sandbox) (*model.Sandbox, error) {

--- a/internal/sandbox/orchestrator_delete.go
+++ b/internal/sandbox/orchestrator_delete.go
@@ -69,10 +69,6 @@ func (o *Orchestrator) ArchiveSandbox(ctx context.Context, sb *model.Sandbox) er
 	return nil
 }
 
-// Sandbox is gone from the upstream provider. Drop the local row so the FK
-// CASCADE on agent_conversations / router_conversations sweeps any
-// references. Returns ErrSandboxNotFound so callers know the row no longer
-// exists and shouldn't try to update it.
 func (o *Orchestrator) purgeMissingSandbox(sb *model.Sandbox) error {
 	slog.Info("sandbox missing upstream, purging local row",
 		"sandbox_id", sb.ID, "external_id", sb.ExternalID)

--- a/internal/sandbox/orchestrator_lifecycle.go
+++ b/internal/sandbox/orchestrator_lifecycle.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -33,7 +34,7 @@ func (o *Orchestrator) RunSandboxLifecycle(ctx context.Context) {
 				"external_id", sb.ExternalID,
 				"idle_minutes", int(now.Sub(*sb.LastActiveAt).Minutes()),
 			)
-			if err := o.StopSandbox(ctx, sb); err != nil {
+			if err := o.StopSandbox(ctx, sb); err != nil && !errors.Is(err, ErrSandboxNotFound) {
 				slog.Error("sandbox lifecycle: failed to stop idle sandbox",
 					"sandbox_id", sb.ID, "error", err)
 			}
@@ -55,7 +56,7 @@ func (o *Orchestrator) RunSandboxLifecycle(ctx context.Context) {
 				"external_id", sb.ExternalID,
 				"stopped_hours", int(now.Sub(*sb.StoppedAt).Hours()),
 			)
-			if err := o.ArchiveSandbox(ctx, sb); err != nil {
+			if err := o.ArchiveSandbox(ctx, sb); err != nil && !errors.Is(err, ErrSandboxNotFound) {
 				slog.Error("sandbox lifecycle: failed to archive stopped sandbox",
 					"sandbox_id", sb.ID, "error", err)
 			}

--- a/internal/sandbox/provider.go
+++ b/internal/sandbox/provider.go
@@ -5,9 +5,6 @@ import (
 	"errors"
 )
 
-// ErrSandboxNotFound means the upstream provider returned 404 for the
-// sandbox. The orchestrator treats it as success on stop/archive/delete
-// since the desired state ("not running") is already reached upstream.
 var ErrSandboxNotFound = errors.New("sandbox not found upstream")
 
 // SandboxStatus represents the state of a sandbox.

--- a/internal/sandbox/provider.go
+++ b/internal/sandbox/provider.go
@@ -1,6 +1,14 @@
 package sandbox
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrSandboxNotFound means the upstream provider returned 404 for the
+// sandbox. The orchestrator treats it as success on stop/archive/delete
+// since the desired state ("not running") is already reached upstream.
+var ErrSandboxNotFound = errors.New("sandbox not found upstream")
 
 // SandboxStatus represents the state of a sandbox.
 type SandboxStatus string


### PR DESCRIPTION
## Summary

asynq's RunSandboxLifecycle was logging ERROR every tick for sandboxes Daytona had already GC'd — sometimes 7–11 days ago — because the local DB still had \`status='running'\` and the sweeper kept retrying the same zombies forever.

A 404 from the provider on stop/archive/delete means the sandbox is gone upstream. The sweeper should reconcile the local row instead of failing. With \`ON DELETE CASCADE\` on both \`agent_conversations.sandbox_id\` and \`router_conversations.sandbox_id\` (applied manually in prod), purging the sandbox row sweeps any referencing conversations in one shot.

## Changes

- **internal/sandbox/provider.go** — add \`ErrSandboxNotFound\` sentinel on the shared interface so any provider can signal upstream-404 without coupling the orchestrator to daytona.
- **internal/sandbox/daytona/driver.go** — return \`sandbox.ErrSandboxNotFound\` on HTTP 404, in both \`sandboxAction\` (start/stop/archive) and \`DeleteSandbox\`.
- **internal/sandbox/orchestrator_delete.go** — \`StopSandbox\`/\`ArchiveSandbox\` route \`ErrSandboxNotFound\` through a new \`purgeMissingSandbox\` helper that DELETEs the local row (cascade sweeps the conversations); \`DeleteSandbox\` no longer WARN-logs on the expected upstream-404 case.
- **internal/sandbox/orchestrator_lifecycle.go** — sweeper skips ERROR-log when the lower layer reports \`ErrSandboxNotFound\` (it's now a success path).

(Pre-existing orphan conversations referencing dead sandboxes were deleted in the same transaction before the FK was rebuilt.)

## Test plan

- [x] \`go build ./...\` clean
- [ ] After deploy: confirm \`asynq\` no longer logs \`[ERRO] sandbox lifecycle: failed to stop idle sandbox … status 404\` and the existing zombie set drains from \`sandboxes\` (with their conversations sweeping via cascade).
