### PR TITLE
fix(rag): authoritative source counter from qdrant

### DIFF
--- a/internal/rag/qdrant/points.go
+++ b/internal/rag/qdrant/points.go
@@ -89,6 +89,12 @@ func (c *Client) Count(ctx context.Context, collection string, filter *qc.Filter
 	return n, nil
 }
 
+func (c *Client) CountBySourceID(ctx context.Context, collection, sourceID string) (uint64, error) {
+	return c.Count(ctx, collection, &qc.Filter{
+		Must: []*qc.Condition{qc.NewMatchKeyword("rag_source_id", sourceID)},
+	})
+}
+
 // Stable UUID-shaped string from (org_id, source_id, doc_id). Re-ingesting the
 // same doc under the same source upserts in place; a doc shared by two sources
 // gets two points.

--- a/internal/rag/tasks/ingest.go
+++ b/internal/rag/tasks/ingest.go
@@ -74,7 +74,7 @@ func (d *Deps) HandleIngest(ctx context.Context, t *asynq.Task) error {
 
 	stats, runErr := runIngest(ctx, deps, src, runnable, attempt, hb)
 
-	finalErr := finalizeAttempt(ctx, deps.DB, src, attempt, stats, runErr, runnable)
+	finalErr := finalizeAttempt(ctx, deps, src, attempt, stats, runErr, runnable)
 	// Stop heartbeat BEFORE returning so no further writes race the
 	// finalisation UPDATE. The defer is a backstop.
 	hb.stop()

--- a/internal/rag/tasks/ingest_attempt.go
+++ b/internal/rag/tasks/ingest_attempt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"time"
 
 	"github.com/google/uuid"
@@ -59,13 +60,14 @@ func lastCheckpointPointer(ctx context.Context, db *gorm.DB, sourceID uuid.UUID)
 
 func finalizeAttempt(
 	ctx context.Context,
-	db *gorm.DB,
+	deps *Deps,
 	src *ragmodel.RAGSource,
 	a *ragmodel.RAGIndexAttempt,
 	stats ingestStats,
 	runErr error,
 	runnable RunnableCheckpointed,
 ) error {
+	db := deps.DB
 	now := time.Now()
 	updates := map[string]any{
 		"time_updated":       now,
@@ -116,8 +118,14 @@ func finalizeAttempt(
 	if stats.docsBatched > 0 || src.Status != ragmodel.RAGSourceStatusInitialIndexing {
 		srcUpd["last_successful_index_time"] = now
 	}
-	if stats.docsBatched > 0 {
-		srcUpd["total_docs_indexed"] = gorm.Expr("total_docs_indexed + ?", stats.docsBatched)
+	if n, err := deps.Qdrant.CountBySourceID(ctx, deps.Collection, src.ID.String()); err == nil {
+		if n > uint64(math.MaxInt32) {
+			n = uint64(math.MaxInt32)
+		}
+		srcUpd["total_docs_indexed"] = int(n) //nolint:gosec // bounded above
+	} else {
+		slog.Warn("rag finalize: count by source failed; leaving total_docs_indexed unchanged",
+			"source_id", src.ID, "err", err)
 	}
 	if src.Status == ragmodel.RAGSourceStatusInitialIndexing && stats.docsBatched > 0 {
 		srcUpd["status"] = ragmodel.RAGSourceStatusActive


### PR DESCRIPTION
## Bug

\`rag_sources.total_docs_indexed\` was a running sum of \`stats.docsBatched\` across all attempts:

\`\`\`go
srcUpd[\"total_docs_indexed\"] = gorm.Expr(\"total_docs_indexed + ?\", stats.docsBatched)
\`\`\`

Re-runs (or any window that re-emits an existing doc) inflated the column even though qdrant deduped the storage via the deterministic \`PointID(orgID, sourceID, docID)\`. Symptom: kibamail/kibamail had 8 PRs in qdrant but the column read 16 after a second run.

## Fix

Replace the running sum with an authoritative recount from qdrant at finalize time. \`Qdrant.CountBySourceID(collection, sourceID)\` filters on \`rag_source_id\` and returns the exact point count.

If the count call fails, leave the column unchanged (logged warn) — the next finalize self-corrects.

## Test plan

- [x] \`go build ./internal/rag/...\` clean
- [x] file-length + comment-density gates green
- [ ] After merge, trigger a re-run on a github source that previously had inflated \`total_docs_indexed\` and confirm the column settles to the actual qdrant point count

🤖 Generated with [Claude Code](https://claude.com/claude-code)