### PR TITLE
fix(embed): forward dimensions parameter for Matryoshka truncation

### DIFF
--- a/internal/rag/embedclient/embedder.go
+++ b/internal/rag/embedclient/embedder.go
@@ -51,10 +51,14 @@ func (e *Embedder) Embed(ctx context.Context, inputs []string) ([][]float32, err
 	if len(inputs) == 0 {
 		return nil, nil
 	}
-	body, err := json.Marshal(map[string]any{
+	payload := map[string]any{
 		"model": e.cfg.Model,
 		"input": inputs,
-	})
+	}
+	if e.cfg.Dim > 0 {
+		payload["dimensions"] = e.cfg.Dim
+	}
+	body, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("embed: marshal: %w", err)
 	}


### PR DESCRIPTION
## Why

\`text-embedding-3-*\` defaults to its native dimensionality (1536 for 3-small, 3072 for 3-large). The OpenAI API only truncates the vector if the request body sets the \`dimensions\` field — Matryoshka. We were silently dropping it, so any \`LLM_EMBEDDING_DIM\` smaller than the model's native dim returned full-length vectors and qdrant rejected the upsert (\`Vector dimension error\`).

## Change

Single-file edit. When \`EmbedderConfig.Dim > 0\`, include \`\"dimensions\": <dim>\` in the request payload.

## Why now

Prepping the prod cutover from \`text-embedding-3-large @ 3072\` → \`text-embedding-3-small @ 1024\`. Without this fix, the env flip + worker restart produces a broken embed pipeline.

## Test plan

- [x] \`go build ./internal/rag/embedclient/...\` clean
- [x] file-length / comment-density gates pass (0% density)
- [ ] After merge: deploy, set \`LLM_MODEL=text-embedding-3-small\`, \`LLM_EMBEDDING_DIM=1024\`, \`QDRANT_COLLECTION=rag_chunks_1024\`, recreate the qdrant collection, confirm an ingest run produces 1024-dim points

🤖 Generated with [Claude Code](https://claude.com/claude-code)