### PR TITLE
fix(billing): dedicated init-upgrade endpoint

### DIFF
--- a/apps/web/app/w/settings/billing/_components/change-plan-dialog.tsx
+++ b/apps/web/app/w/settings/billing/_components/change-plan-dialog.tsx
@@ -60,7 +60,7 @@ export function ChangePlanDialog({ targetPlan, onClose, onApplied }: ChangePlanD
   const open = targetPlan !== null
   const queryClient = useQueryClient()
   const previewMutation = $api.useMutation("post", "/v1/billing/subscription/preview-change")
-  const checkoutMutation = $api.useMutation("post", "/v1/billing/checkout")
+  const initUpgradeMutation = $api.useMutation("post", "/v1/billing/subscription/init-upgrade")
   const applyMutation = $api.useMutation("post", "/v1/billing/subscription/apply-change")
   const { openPopup } = usePaystackPop()
 
@@ -110,20 +110,8 @@ export function ChangePlanDialog({ targetPlan, onClose, onApplied }: ChangePlanD
       return
     }
 
-    // Upgrade: spin up a Paystack transaction for the prorated amount, then
-    // hand the reference to apply-change once the popup completes.
-    const returnURL = typeof window !== "undefined" ? window.location.href : ""
-    checkoutMutation.mutate(
-      {
-        body: {
-          provider: "paystack",
-          plan_slug: targetPlan.slug,
-          currency: targetPlan.currency,
-          cycle: "monthly",
-          success_url: returnURL,
-          cancel_url: returnURL,
-        } as never,
-      },
+    initUpgradeMutation.mutate(
+      { body: { quote_id: preview.quote_id! } },
       {
         onSuccess: (data) => {
           if (!data.access_code) {

--- a/apps/web/lib/api/schema.d.ts
+++ b/apps/web/lib/api/schema.d.ts
@@ -5914,6 +5914,83 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/billing/subscription/init-upgrade": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Initialise a Paystack transaction for an upgrade quote */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description Upgrade quote id */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["initUpgradeRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["initUpgradeResponse"];
+                    };
+                };
+                /** @description Bad Request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["errorResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["errorResponse"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["errorResponse"];
+                    };
+                };
+                /** @description Gone */
+                410: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/billing/subscription/preview-change": {
         parameters: {
             query?: never;
@@ -13210,6 +13287,15 @@ export interface components {
             meta?: components["schemas"]["JSON"];
             nango_config?: components["schemas"]["NangoConfig"];
             provider?: string;
+        };
+        initUpgradeRequest: {
+            quote_id?: string;
+        };
+        initUpgradeResponse: {
+            access_code?: string;
+            amount_minor?: number;
+            currency?: string;
+            reference?: string;
         };
         integrationDetail: {
             actions?: components["schemas"]["actionSummary"][];

--- a/cmd/server/serve_routes_billing.go
+++ b/cmd/server/serve_routes_billing.go
@@ -17,6 +17,7 @@ func mountBillingRoutes(r chi.Router, billingHandler *handler.BillingHandler, su
 	r.Get("/billing/subscription", billingHandler.GetSubscription)
 
 	r.Post("/billing/subscription/preview-change", subscriptionHandler.PreviewChange)
+	r.Post("/billing/subscription/init-upgrade", subscriptionHandler.InitUpgrade)
 	r.Post("/billing/subscription/apply-change", subscriptionHandler.ApplyChange)
 	r.Post("/billing/subscription/cancel", subscriptionHandler.Cancel)
 	r.Post("/billing/subscription/resume", subscriptionHandler.Resume)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5230,6 +5230,68 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/billing/subscription/init-upgrade": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "billing"
+                ],
+                "summary": "Initialise a Paystack transaction for an upgrade quote",
+                "parameters": [
+                    {
+                        "description": "Upgrade quote id",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.initUpgradeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.initUpgradeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/billing/subscription/preview-change": {
             "post": {
                 "security": [
@@ -13739,6 +13801,31 @@ const docTemplate = `{
                     "$ref": "#/definitions/github_com_usehiveloop_hiveloop_internal_model.NangoConfig"
                 },
                 "provider": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.initUpgradeRequest": {
+            "type": "object",
+            "properties": {
+                "quote_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.initUpgradeResponse": {
+            "type": "object",
+            "properties": {
+                "access_code": {
+                    "type": "string"
+                },
+                "amount_minor": {
+                    "type": "integer"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "reference": {
                     "type": "string"
                 }
             }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6102,6 +6102,82 @@
         }
       }
     },
+    "/v1/billing/subscription/init-upgrade": {
+      "post": {
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "billing"
+        ],
+        "summary": "Initialise a Paystack transaction for an upgrade quote",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/initUpgradeRequest"
+              }
+            }
+          },
+          "description": "Upgrade quote id",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/initUpgradeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/billing/subscription/preview-change": {
       "post": {
         "security": [
@@ -15706,6 +15782,31 @@
             "$ref": "#/components/schemas/NangoConfig"
           },
           "provider": {
+            "type": "string"
+          }
+        }
+      },
+      "initUpgradeRequest": {
+        "type": "object",
+        "properties": {
+          "quote_id": {
+            "type": "string"
+          }
+        }
+      },
+      "initUpgradeResponse": {
+        "type": "object",
+        "properties": {
+          "access_code": {
+            "type": "string"
+          },
+          "amount_minor": {
+            "type": "integer"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "reference": {
             "type": "string"
           }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5227,6 +5227,68 @@
                 }
             }
         },
+        "/v1/billing/subscription/init-upgrade": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "billing"
+                ],
+                "summary": "Initialise a Paystack transaction for an upgrade quote",
+                "parameters": [
+                    {
+                        "description": "Upgrade quote id",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.initUpgradeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.initUpgradeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/billing/subscription/preview-change": {
             "post": {
                 "security": [
@@ -13736,6 +13798,31 @@
                     "$ref": "#/definitions/github_com_usehiveloop_hiveloop_internal_model.NangoConfig"
                 },
                 "provider": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.initUpgradeRequest": {
+            "type": "object",
+            "properties": {
+                "quote_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.initUpgradeResponse": {
+            "type": "object",
+            "properties": {
+                "access_code": {
+                    "type": "string"
+                },
+                "amount_minor": {
+                    "type": "integer"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "reference": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2164,6 +2164,22 @@ definitions:
       provider:
         type: string
     type: object
+  internal_handler.initUpgradeRequest:
+    properties:
+      quote_id:
+        type: string
+    type: object
+  internal_handler.initUpgradeResponse:
+    properties:
+      access_code:
+        type: string
+      amount_minor:
+        type: integer
+      currency:
+        type: string
+      reference:
+        type: string
+    type: object
   internal_handler.integrationDetail:
     properties:
       actions:
@@ -7262,6 +7278,45 @@ paths:
       security:
       - BearerAuth: []
       summary: Cancel a subscription
+      tags:
+      - billing
+  /v1/billing/subscription/init-upgrade:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Upgrade quote id
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.initUpgradeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_handler.initUpgradeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "410":
+          description: Gone
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Initialise a Paystack transaction for an upgrade quote
       tags:
       - billing
   /v1/billing/subscription/preview-change:

--- a/internal/billing/subscription/init_upgrade.go
+++ b/internal/billing/subscription/init_upgrade.go
@@ -1,0 +1,72 @@
+package subscription
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/usehiveloop/hiveloop/internal/billing"
+	"github.com/usehiveloop/hiveloop/internal/model"
+)
+
+type UpgradeInit struct {
+	AccessCode  string
+	Reference   string
+	AmountMinor int64
+	Currency    string
+}
+
+func (s *Service) InitUpgrade(ctx context.Context, orgID uuid.UUID, quoteID uuid.UUID) (*UpgradeInit, error) {
+	quote, err := s.loadQuote(ctx, quoteID)
+	if err != nil {
+		return nil, err
+	}
+	if quote.OrgID != orgID {
+		return nil, ErrQuoteWrongOrg
+	}
+	if quote.ConsumedAt != nil {
+		return nil, ErrQuoteConsumed
+	}
+	if s.clock().After(quote.ExpiresAt) {
+		return nil, ErrQuoteExpired
+	}
+	if quote.Kind != string(KindUpgrade) {
+		return nil, ErrNotAnUpgrade
+	}
+
+	var sub model.Subscription
+	if err := s.db.WithContext(ctx).Where("id = ?", quote.SubscriptionID).First(&sub).Error; err != nil {
+		return nil, fmt.Errorf("load subscription: %w", err)
+	}
+	provider, err := s.registry.Get(sub.Provider)
+	if err != nil {
+		return nil, err
+	}
+
+	email, err := s.lookupOrgOwnerEmail(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("lookup org owner email: %w", err)
+	}
+
+	session, err := provider.CreateCheckout(ctx, sub.ExternalCustomerID, billing.CheckoutIntent{
+		OrgID:         orgID,
+		CustomerEmail: email,
+		AmountMinor:   quote.AmountMinor,
+		Currency:      quote.Currency,
+		Metadata: map[string]string{
+			"org_id":   orgID.String(),
+			"quote_id": quote.ID.String(),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("init upgrade transaction: %w", err)
+	}
+
+	return &UpgradeInit{
+		AccessCode:  session.AccessCode,
+		Reference:   session.Reference,
+		AmountMinor: quote.AmountMinor,
+		Currency:    quote.Currency,
+	}, nil
+}

--- a/internal/billing/subscription/service.go
+++ b/internal/billing/subscription/service.go
@@ -29,6 +29,7 @@ var (
 	ErrUnsupportedChannel       = errors.New("subscription: payment channel is not eligible for recurring billing")
 	ErrCannotResume             = errors.New("subscription: cannot resume a canceled subscription")
 	ErrCannotCancel             = errors.New("subscription: subscription is already canceled")
+	ErrNotAnUpgrade             = errors.New("subscription: quote is not an upgrade")
 )
 
 type Service struct {

--- a/internal/handler/billing_subscription_init.go
+++ b/internal/handler/billing_subscription_init.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/usehiveloop/hiveloop/internal/billing/subscription"
+	"github.com/usehiveloop/hiveloop/internal/middleware"
+)
+
+type initUpgradeRequest struct {
+	QuoteID string `json:"quote_id"`
+}
+
+type initUpgradeResponse struct {
+	AccessCode  string `json:"access_code"`
+	Reference   string `json:"reference"`
+	AmountMinor int64  `json:"amount_minor"`
+	Currency    string `json:"currency"`
+}
+
+// @Summary Initialise a Paystack transaction for an upgrade quote
+// @Tags billing
+// @Accept json
+// @Produce json
+// @Param body body initUpgradeRequest true "Upgrade quote id"
+// @Success 200 {object} initUpgradeResponse
+// @Failure 400 {object} errorResponse
+// @Failure 401 {object} errorResponse
+// @Failure 403 {object} errorResponse
+// @Failure 410 {object} errorResponse
+// @Security BearerAuth
+// @Router /v1/billing/subscription/init-upgrade [post]
+func (h *SubscriptionHandler) InitUpgrade(w http.ResponseWriter, r *http.Request) {
+	org, ok := middleware.OrgFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing org context"})
+		return
+	}
+	var body initUpgradeRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.QuoteID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "quote_id is required"})
+		return
+	}
+	quoteID, err := uuid.Parse(body.QuoteID)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "quote_id is not a valid uuid"})
+		return
+	}
+
+	init, err := h.service.InitUpgrade(r.Context(), org.ID, quoteID)
+	if err != nil {
+		switch {
+		case errors.Is(err, subscription.ErrQuoteUnknown):
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown quote"})
+		case errors.Is(err, subscription.ErrQuoteWrongOrg):
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "quote belongs to another org"})
+		case errors.Is(err, subscription.ErrQuoteExpired):
+			writeJSON(w, http.StatusGone, map[string]string{"error": "quote has expired"})
+		case errors.Is(err, subscription.ErrQuoteConsumed):
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "quote already consumed"})
+		case errors.Is(err, subscription.ErrNotAnUpgrade):
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "quote is not an upgrade"})
+		default:
+			slog.Error("init-upgrade: failed", "org_id", org.ID, "quote_id", quoteID, "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to start upgrade"})
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, initUpgradeResponse{
+		AccessCode:  init.AccessCode,
+		Reference:   init.Reference,
+		AmountMinor: init.AmountMinor,
+		Currency:    init.Currency,
+	})
+}


### PR DESCRIPTION
## Summary

The upgrade flow was hitting \`/v1/billing/checkout\`, which always charges
\`plan.price_cents\` rather than the prorated amount on the quote. Customer
paid the full new plan price, then \`apply-change\` correctly refused with
\"paid amount does not match quote\" — leaving the customer out of pocket
with no plan change applied.

## Fix

New endpoint \`POST /v1/billing/subscription/init-upgrade\`:
- Takes \`{quote_id}\`
- Validates: org match, \`kind=upgrade\`, unconsumed, unexpired
- Initialises a Paystack transaction with \`quote.amount_minor\`
- Returns \`{access_code, reference, amount_minor, currency}\`

\`ChangePlanDialog\` now calls this instead of \`/v1/billing/checkout\` for
upgrades. \`/v1/billing/checkout\` is no longer hit during upgrades or
downgrades — only by fresh subscribes.

## Test plan
- [ ] Buy Pro from free
- [ ] Click Business → preview shows prorated amount
- [ ] Pay → popup charges the prorated amount (not full Business)
- [ ] Subscription flips to Business

## Note for ops

Any customer who already hit this bug paid the full new plan price and
their plan wasn't upgraded. Refund or grant credits manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)