### PR TITLE
fix(daytona): route ExecuteCommand through API gateway, not preview proxy

### DIFF
--- a/internal/sandbox/daytona/driver.go
+++ b/internal/sandbox/daytona/driver.go
@@ -39,6 +39,7 @@ type Config struct {
 type Driver struct {
 	sdk                 *daytonasdk.Client
 	apiClient           *apiclient.APIClient
+	apiURL              string
 	apiKey              string
 	bridgeBinaryVersion string
 }
@@ -72,6 +73,7 @@ func NewDriver(cfg Config) (*Driver, error) {
 	return &Driver{
 		sdk:                 sdkClient,
 		apiClient:           apiClient,
+		apiURL:              apiURL,
 		apiKey:              apiKey,
 		bridgeBinaryVersion: cfg.BridgeBinaryVersion,
 	}, nil

--- a/internal/sandbox/daytona/driver_lifecycle.go
+++ b/internal/sandbox/daytona/driver_lifecycle.go
@@ -3,7 +3,11 @@ package daytona
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
+
+	toolbox "github.com/daytonaio/daytona/libs/toolbox-api-client-go"
 
 	"github.com/usehiveloop/hiveloop/internal/sandbox"
 )
@@ -39,25 +43,45 @@ func (d *Driver) SetAutoArchive(ctx context.Context, externalID string, interval
 }
 
 func (d *Driver) ExecuteCommand(ctx context.Context, externalID string, command string) (string, error) {
-	sb, err := d.sdk.Get(ctx, externalID)
+	client, err := d.toolboxClient(externalID)
 	if err != nil {
-		if isSDKNotFound(err) {
-			return "", sandbox.ErrSandboxNotFound
-		}
-		return "", fmt.Errorf("getting sandbox %s: %w", externalID, err)
+		return "", fmt.Errorf("building toolbox client for sandbox %s: %w", externalID, err)
 	}
 
 	execCtx, cancel := context.WithTimeout(ctx, executeCommandTimeout)
 	defer cancel()
 
-	resp, err := sb.Process.ExecuteCommand(execCtx, command)
+	req := toolbox.NewExecuteRequest(command)
+	resp, httpResp, err := client.ProcessAPI.ExecuteCommand(execCtx).Request(*req).Execute()
 	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == 404 {
+			return "", sandbox.ErrSandboxNotFound
+		}
 		return "", fmt.Errorf("executing command on sandbox %s: %w", externalID, err)
 	}
-	if resp.ExitCode != 0 {
-		return resp.Result, fmt.Errorf("command exited with code %d on sandbox %s: %s", resp.ExitCode, externalID, resp.Result)
+	exitCode := int(resp.GetExitCode())
+	result := resp.GetResult()
+	if exitCode != 0 {
+		return result, fmt.Errorf("command exited with code %d on sandbox %s: %s", exitCode, externalID, result)
 	}
-	return resp.Result, nil
+	return result, nil
+}
+
+// SDK default reads sandbox.toolboxProxyUrl (preview.<host>, not in our DNS).
+func (d *Driver) toolboxClient(externalID string) (*toolbox.APIClient, error) {
+	parsed, err := url.Parse(d.apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing API URL %q: %w", d.apiURL, err)
+	}
+	basePath := strings.TrimRight(parsed.Path, "/") + "/toolbox/" + externalID + "/toolbox"
+	cfg := toolbox.NewConfiguration()
+	cfg.Host = parsed.Host
+	cfg.Scheme = parsed.Scheme
+	cfg.Servers = toolbox.ServerConfigurations{
+		{URL: fmt.Sprintf("%s://%s%s", parsed.Scheme, parsed.Host, basePath)},
+	}
+	cfg.AddDefaultHeader("Authorization", "Bearer "+d.apiKey)
+	return toolbox.NewAPIClient(cfg), nil
 }
 
 // mapState normalizes Daytona's API state strings into our SandboxStatus enum.


### PR DESCRIPTION
## Summary

Cold-start sandbox setup is broken in prod:

\`\`\`
asynq task failed: creating dedicated sandbox: cloning repositories:
  creating repos directory: executing command on sandbox …:
    Daytona error: Post \"https://preview.usehiveloop.com/toolbox/…/process/execute\":
      dial tcp: lookup preview.usehiveloop.com on [fd12::10]:53: no such host
\`\`\`

The SDK's \`Sandbox.Process.ExecuteCommand\` uses the \`sandbox.toolboxProxyUrl\` returned by Daytona — which points at \`preview.usehiveloop.com\` and isn't in our DNS. The pre-migration driver routed through the API gateway at \`{apiURL}/toolbox/{id}/toolbox/process/execute\`.

This builds the official \`toolbox-api-client-go\` config manually so it routes through the gateway path the prior driver used. Same official client, just configured with our gateway URL instead of the SDK's auto-derived preview URL.

The 120s context timeout and 404 → \`ErrSandboxNotFound\` mapping carry over.

## Why the prior PR missed this

The five-agent audit confirmed: the OLD driver always called the gateway path; the SDK assumes the per-sandbox preview-URL topology Daytona's hosted offering uses. Our self-hosted Daytona sets \`toolboxProxyUrl\` to a hostname our DNS doesn't serve.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/sandbox/...\` pass
- [ ] Once merged + deployed, trigger a fresh agent conversation; confirm the dedicated sandbox completes \`mkdir -p /home/daytona/repos\` and \`git clone …\` without DNS errors.

## Other findings from the audit (not in this PR)

- \`Sandbox.Start/Stop/Archive\` now auto-wait for state transitions via the SDK (old code returned immediately). Total wait is the SDK wait + the existing \`waitForBridgeHealthy\`. Could matter on slow sandboxes — flag it if you see hangs.
- SDK default per-call timeout is 60s vs the old hand-rolled 30s. Generally safer.
- \`GetSnapshotBuildLogs\` is a deprecated SDK method but still functional.

None of these are reported broken yet — leaving them for a future PR.