### PR TITLE
fix(bugsink-proxy): skip sandbox auth for system agents

### DIFF
--- a/internal/handler/bugsink_proxy.go
+++ b/internal/handler/bugsink_proxy.go
@@ -82,7 +82,7 @@ func (h *BugsinkProxyHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 	eventCtx.OrgID = *agent.OrgID
 
-	if !h.authenticatedSandbox(ctx, agentID, bearerToken) {
+	if !agent.IsSystem && !h.authenticatedSandbox(ctx, agentID, bearerToken) {
 		h.captureProxyFailure(ctx, eventCtx, http.StatusUnauthorized, "invalid credentials")
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
 		return

--- a/internal/handler/bugsink_proxy_harness_test.go
+++ b/internal/handler/bugsink_proxy_harness_test.go
@@ -24,14 +24,15 @@ import (
 const bugsinkProxyTestDBURL = "postgres://hiveloop:localdev@localhost:5433/hiveloop_test?sslmode=disable" // #nosec G101 -- test fixture, not a real secret
 
 type bugsinkProxyHarness struct {
-	db           *gorm.DB
-	router       *chi.Mux
-	orgID        uuid.UUID
-	employeeID   uuid.UUID
-	subagentID   uuid.UUID
-	standaloneID uuid.UUID
-	connectionID uuid.UUID
-	bridgeKey    string
+	db            *gorm.DB
+	router        *chi.Mux
+	orgID         uuid.UUID
+	employeeID    uuid.UUID
+	subagentID    uuid.UUID
+	systemAgentID uuid.UUID
+	standaloneID  uuid.UUID
+	connectionID  uuid.UUID
+	bridgeKey     string
 }
 
 func newBugsinkProxyHarness(t *testing.T, nangoHandler http.Handler) *bugsinkProxyHarness {
@@ -57,6 +58,7 @@ func newBugsinkProxyHarness(t *testing.T, nangoHandler http.Handler) *bugsinkPro
 	userID := uuid.New()
 	employeeID := uuid.New()
 	subagentID := uuid.New()
+	systemAgentID := uuid.New()
 	standaloneID := uuid.New()
 	connectionID := uuid.New()
 	unattachedConnectionID := uuid.New()
@@ -98,6 +100,13 @@ func newBugsinkProxyHarness(t *testing.T, nangoHandler http.Handler) *bugsinkPro
 	if err := database.Create(&model.AgentSubagent{AgentID: employeeID, SubagentID: subagentID}).Error; err != nil {
 		t.Fatalf("link subagent: %v", err)
 	}
+	systemAgent := model.Agent{ID: systemAgentID, OrgID: &orgID, Name: "Bugsink System " + uuid.NewString()[:8], Status: "active", IsSystem: true}
+	if err := database.Create(&systemAgent).Error; err != nil {
+		t.Fatalf("create system agent: %v", err)
+	}
+	if err := database.Create(&model.AgentSubagent{AgentID: employeeID, SubagentID: systemAgentID}).Error; err != nil {
+		t.Fatalf("link system agent: %v", err)
+	}
 	standalone := model.Agent{ID: standaloneID, OrgID: &orgID, Name: "Bugsink Standalone " + uuid.NewString()[:8], Status: "active"}
 	if err := database.Create(&standalone).Error; err != nil {
 		t.Fatalf("create standalone: %v", err)
@@ -129,14 +138,15 @@ func newBugsinkProxyHarness(t *testing.T, nangoHandler http.Handler) *bugsinkPro
 	router.Handle("/internal/bugsink-proxy/{agentID}/*", http.HandlerFunc(bugsinkProxyHandler.Handle))
 
 	return &bugsinkProxyHarness{
-		db:           database,
-		router:       router,
-		orgID:        orgID,
-		employeeID:   employeeID,
-		subagentID:   subagentID,
-		standaloneID: standaloneID,
-		connectionID: connectionID,
-		bridgeKey:    bridgeKey,
+		db:            database,
+		router:        router,
+		orgID:         orgID,
+		employeeID:    employeeID,
+		subagentID:    subagentID,
+		systemAgentID: systemAgentID,
+		standaloneID:  standaloneID,
+		connectionID:  connectionID,
+		bridgeKey:     bridgeKey,
 	}
 }
 

--- a/internal/handler/bugsink_proxy_test.go
+++ b/internal/handler/bugsink_proxy_test.go
@@ -90,6 +90,42 @@ func TestBugsinkProxy_SubagentUsesOwningEmployeeConnection(t *testing.T) {
 	}
 }
 
+func TestBugsinkProxy_SystemAgentWithoutSandboxSucceeds(t *testing.T) {
+	var captured struct {
+		method       string
+		path         string
+		auth         string
+		providerKey  string
+		connectionID string
+	}
+	var mu sync.Mutex
+	harness := newBugsinkProxyHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.auth = r.Header.Get("Authorization")
+		captured.providerKey = r.Header.Get("Provider-Config-Key")
+		captured.connectionID = r.Header.Get("Connection-Id")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"projects":[]}`))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/bugsink-proxy/"+harness.systemAgentID.String()+"/api/canonical/0/projects/", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+	rec := httptest.NewRecorder()
+	harness.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if captured.connectionID != "bugsink-nango-1" {
+		t.Fatalf("connection id = %q", captured.connectionID)
+	}
+}
+
 func TestBugsinkProxy_RejectsInvalidAndUnattachedRequests(t *testing.T) {
 	var nangoCalls atomic.Int64
 	harness := newBugsinkProxyHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Bypass the `authenticatedSandbox` check in `BugsinkProxyHandler.Handle` when the calling agent is a system agent (`IsSystem = true`)
- System agents (e.g. the trigger agent) have no sandbox and therefore no `EncryptedBridgeAPIKey`, so the existing sandbox-key comparison always rejects them with 401
- Add a harness test that proves a system agent subagent without a sandbox can successfully proxy requests through to the Bugsink connection

## Job done
- System/trigger agents can now use the Bugsink proxy without owning a sandbox
- Non-system agents continue to require sandbox bridge-key auth as before
- The test database will exercise the full path: auth bypass → employee resolution via subagent → connection resolution → Nango proxy

## Demo

```
go test ./internal/handler -run 'TestBugsinkProxy_SystemAgentWithoutSandboxSucceeds' -count=1 -v
```

(Test requires a running postgres on :5433 with `hiveloop_test` database — skips gracefully when unavailable.)

## Requirements met
- [x] For api changes, I wrote integration tests (database facing tests) to test the real business value behavior

## Risk & rollback
- Risk: Low. Only system agents are affected; the `IsSystem` gate is a one-line check that does not change the path for non-system agents.
- Rollback: `git revert` the commit.

## Linked issues
- Closes ENG-25
