### PR TITLE
fix: wire members page with real API calls

### DIFF
--- a/apps/web/app/w/settings/members/page.tsx
+++ b/apps/web/app/w/settings/members/page.tsx
@@ -1,6 +1,10 @@
 "use client"
 
+import { useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   Dialog,
   DialogClose,
@@ -20,97 +24,297 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Label } from "@/components/ui/label"
 import { SettingsShell } from "@/components/settings-shell"
+import { $api } from "@/lib/api/hooks"
+import { api } from "@/lib/api/client"
+import { extractErrorMessage } from "@/lib/api/error"
 import { HugeiconsIcon } from "@hugeicons/react"
 import {
   ArrowDown01Icon,
   Delete02Icon,
+  Loading03Icon,
   MoreHorizontalCircle01Icon,
   Tick02Icon,
 } from "@hugeicons/core-free-icons"
+import type { components } from "@/lib/api/schema"
+
+type Member = components["schemas"]["orgMemberResponse"]
+type Invite = components["schemas"]["orgInviteResponse"]
 
 const ASSIGNABLE_ROLES = ["Admin", "Member", "Viewer"] as const
 
-const MEMBERS = [
-  { name: "Aisha Patel", email: "aisha@acme.co", role: "Owner", initials: "AP" },
-  { name: "Marcus Chen", email: "marcus@acme.co", role: "Admin", initials: "MC" },
-  { name: "Sara Lindqvist", email: "sara@acme.co", role: "Member", initials: "SL" },
-  { name: "Diego Hernández", email: "diego@acme.co", role: "Member", initials: "DH" },
-  { name: "Yuki Tanaka", email: "yuki@acme.co", role: "Viewer", initials: "YT" },
-]
+function getInitials(name?: string): string {
+  if (!name) return ""
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2)
+}
 
-const PENDING = [
-  { email: "alex@acme.co", role: "Member", invitedAt: "2 days ago" },
-  { email: "jamie@acme.co", role: "Viewer", invitedAt: "5 days ago" },
-]
+function timeAgo(dateStr?: string): string {
+  if (!dateStr) return ""
+  const now = Date.now()
+  const then = new Date(dateStr).getTime()
+  const diffMs = now - then
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  if (diffDays === 0) return "today"
+  if (diffDays === 1) return "yesterday"
+  return `${diffDays} days ago`
+}
+
+function MembersSkeleton() {
+  return (
+    <ul className="divide-y divide-border/60 rounded-lg border border-border/60">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <li key={i} className="flex items-center gap-3 px-3.5 py-2.5">
+          <Skeleton className="size-8 rounded-full" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-40 rounded" />
+            <Skeleton className="h-3 w-28 rounded" />
+          </div>
+          <Skeleton className="h-7 w-24 rounded-md" />
+          <Skeleton className="size-7 rounded-md" />
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function InvitesSkeleton() {
+  return (
+    <ul className="divide-y divide-border/60 rounded-lg border border-border/60">
+      {Array.from({ length: 2 }).map((_, i) => (
+        <li key={i} className="flex items-center gap-3 px-3.5 py-2.5">
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-48 rounded" />
+            <Skeleton className="h-3 w-32 rounded" />
+          </div>
+          <Skeleton className="h-8 w-16 rounded-md" />
+          <Skeleton className="h-8 w-16 rounded-md" />
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-border/60 px-3.5 py-8 text-center">
+      <p className="text-[13px] text-muted-foreground">{message}</p>
+    </div>
+  )
+}
+
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string
+  onRetry: () => void
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 px-3.5 py-8 text-center">
+      <p className="mb-3 text-[13px] text-muted-foreground">{message}</p>
+      <Button variant="outline" size="sm" onClick={() => onRetry()}>
+        Retry
+      </Button>
+    </div>
+  )
+}
 
 export default function Page() {
+  const queryClient = useQueryClient()
+
+  const {
+    data: membersData,
+    isLoading: membersLoading,
+    isError: membersError,
+    refetch: refetchMembers,
+  } = $api.useQuery("get", "/v1/orgs/current/members")
+
+  const {
+    data: invitesData,
+    isLoading: invitesLoading,
+    isError: invitesError,
+    error: invitesErr,
+    refetch: refetchInvites,
+  } = $api.useQuery("get", "/v1/orgs/current/invites")
+
+  const revokeInvite = $api.useMutation("delete", "/v1/orgs/current/invites/{id}")
+  const resendInvite = $api.useMutation("post", "/v1/orgs/current/invites/{id}/resend")
+
+  const members = membersData?.data ?? []
+  const pending = invitesData?.data ?? []
+  const invitesForbidden =
+    invitesError &&
+    typeof invitesErr === "object" &&
+    invitesErr !== null &&
+    "status" in invitesErr &&
+    (invitesErr as { status: number }).status === 403
+
+  function handleRevoke(invite: Invite) {
+    if (!invite.id) return
+    revokeInvite.mutate(
+      { params: { path: { id: invite.id } } },
+      {
+        onSuccess: () => {
+          toast.success("Invite revoked")
+          queryClient.invalidateQueries({
+            queryKey: ["get", "/v1/orgs/current/invites"],
+          })
+        },
+        onError: (error) => {
+          toast.error(extractErrorMessage(error, "Failed to revoke invite"))
+        },
+      },
+    )
+  }
+
+  function handleResend(invite: Invite) {
+    if (!invite.id) return
+    resendInvite.mutate(
+      { params: { path: { id: invite.id } } },
+      {
+        onSuccess: () => {
+          toast.success("Invite resent")
+          queryClient.invalidateQueries({
+            queryKey: ["get", "/v1/orgs/current/invites"],
+          })
+        },
+        onError: (error) => {
+          toast.error(extractErrorMessage(error, "Failed to resend invite"))
+        },
+      },
+    )
+  }
+
+  const loading = membersLoading || invitesLoading
+  const description = loading
+    ? "Loading\u2026"
+    : membersError
+      ? "Could not load members"
+      : `${members.length} member${members.length !== 1 ? "s" : ""}${!invitesForbidden && pending.length > 0 ? `, ${pending.length} pending invite${pending.length !== 1 ? "s" : ""}` : ""}.`
+
   return (
     <SettingsShell
       title="Members"
-      description={`${MEMBERS.length} members, ${PENDING.length} pending invites.`}
+      description={description}
       dividers={false}
     >
       <section>
         <div className="mb-3 flex items-end justify-between gap-3">
           <h2 className="text-[13px] font-medium">All members</h2>
-          <InviteDialog />
+          {!invitesForbidden && <InviteDialog />}
         </div>
 
-        <ul className="divide-y divide-border/60 rounded-lg border border-border/60">
-          {MEMBERS.map((m) => (
-            <li
-              key={m.email}
-              className="flex items-center gap-3 px-3.5 py-2.5 transition-colors hover:bg-muted/40"
-            >
-              <div className="flex size-8 items-center justify-center rounded-full bg-muted font-mono text-[11px] font-medium text-muted-foreground">
-                {m.initials}
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-[13px] font-medium">{m.name}</p>
-                <p className="truncate text-[12px] text-muted-foreground">{m.email}</p>
-              </div>
-              <RoleSelect role={m.role} />
-              <RowMenu name={m.name} disabled={m.role === "Owner"} />
-            </li>
-          ))}
-        </ul>
+        {membersLoading ? (
+          <MembersSkeleton />
+        ) : membersError ? (
+          <ErrorState
+            message="Failed to load members"
+            onRetry={refetchMembers}
+          />
+        ) : members.length === 0 ? (
+          <EmptyState message="No members yet." />
+        ) : (
+          <ul className="divide-y divide-border/60 rounded-lg border border-border/60">
+            {members.map((m) => (
+              <li
+                key={m.user_id ?? m.email}
+                className="flex items-center gap-3 px-3.5 py-2.5 transition-colors hover:bg-muted/40"
+              >
+                <div className="flex size-8 items-center justify-center rounded-full bg-muted font-mono text-[11px] font-medium text-muted-foreground">
+                  {getInitials(m.name)}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-[13px] font-medium">{m.name}</p>
+                  <p className="truncate text-[12px] text-muted-foreground">
+                    {m.email}
+                  </p>
+                </div>
+                <RoleSelect role={m.role ?? ""} />
+                <RowMenu name={m.name ?? ""} disabled={m.role === "owner"} />
+              </li>
+            ))}
+          </ul>
+        )}
       </section>
 
-      <section>
-        <h2 className="mb-3 text-[13px] font-medium">Pending invites</h2>
-        <ul className="divide-y divide-border/60 rounded-lg border border-border/60">
-          {PENDING.map((p) => (
-            <li key={p.email} className="flex items-center gap-3 px-3.5 py-2.5">
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-[13px]">{p.email}</p>
-                <p className="text-[12px] text-muted-foreground">
-                  Invited {p.invitedAt} as {p.role}
-                </p>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 text-muted-foreground hover:text-foreground"
-              >
-                Resend
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 text-destructive hover:text-destructive"
-              >
-                Revoke
-              </Button>
-            </li>
-          ))}
-        </ul>
-      </section>
+      {!invitesForbidden && (
+        <section>
+          <h2 className="mb-3 text-[13px] font-medium">Pending invites</h2>
+          {invitesLoading ? (
+            <InvitesSkeleton />
+          ) : invitesError ? (
+            <ErrorState
+              message="Failed to load pending invites"
+              onRetry={refetchInvites}
+            />
+          ) : pending.length === 0 ? (
+            <EmptyState message="No pending invites." />
+          ) : (
+            <ul className="divide-y divide-border/60 rounded-lg border border-border/60">
+              {pending.map((p) => (
+                <li
+                  key={p.id ?? p.email}
+                  className="flex items-center gap-3 px-3.5 py-2.5"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[13px]">{p.email}</p>
+                    <p className="text-[12px] text-muted-foreground">
+                      Invited {timeAgo(p.created_at)} as{" "}
+                      {p.role
+                        ? p.role.charAt(0).toUpperCase() + p.role.slice(1)
+                        : ""}
+                    </p>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 text-muted-foreground hover:text-foreground"
+                    onClick={() => handleResend(p)}
+                    disabled={resendInvite.isPending}
+                  >
+                    {resendInvite.isPending ? (
+                      <HugeiconsIcon
+                        icon={Loading03Icon}
+                        strokeWidth={2}
+                        className="size-3.5 animate-spin"
+                      />
+                    ) : (
+                      "Resend"
+                    )}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 text-destructive hover:text-destructive"
+                    onClick={() => handleRevoke(p)}
+                    disabled={revokeInvite.isPending}
+                  >
+                    {revokeInvite.isPending ? (
+                      <HugeiconsIcon
+                        icon={Loading03Icon}
+                        strokeWidth={2}
+                        className="size-3.5 animate-spin"
+                      />
+                    ) : (
+                      "Revoke"
+                    )}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
     </SettingsShell>
   )
 }
 
 function RoleSelect({ role }: { role: string }) {
-  const isOwner = role === "Owner"
+  const isOwner = role.toLowerCase() === "owner"
 
   if (isOwner) {
     return (
@@ -130,7 +334,9 @@ function RoleSelect({ role }: { role: string }) {
           />
         }
       >
-        <span>{role}</span>
+        <span>
+          {role ? role.charAt(0).toUpperCase() + role.slice(1) : ""}
+        </span>
         <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} className="size-3" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-36">
@@ -138,7 +344,7 @@ function RoleSelect({ role }: { role: string }) {
           {ASSIGNABLE_ROLES.map((r) => (
             <DropdownMenuItem key={r}>
               <span className="flex-1">{r}</span>
-              {r === role ? (
+              {r.toLowerCase() === role.toLowerCase() ? (
                 <HugeiconsIcon
                   icon={Tick02Icon}
                   strokeWidth={2}
@@ -183,8 +389,58 @@ function RowMenu({ name, disabled }: { name: string; disabled?: boolean }) {
 }
 
 function InviteDialog() {
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [emailsText, setEmailsText] = useState("")
+  const [selectedRole, setSelectedRole] = useState("Member")
+  const [sending, setSending] = useState(false)
+
+  function reset() {
+    setEmailsText("")
+    setSelectedRole("Member")
+  }
+
+  async function handleSendInvites() {
+    const emails = emailsText
+      .split(/[\n,]+/)
+      .map((e) => e.trim())
+      .filter((e) => e.length > 0)
+
+    if (emails.length === 0) {
+      toast.error("Enter at least one email address")
+      return
+    }
+
+    setSending(true)
+
+    let successCount = 0
+    for (const email of emails) {
+      const { error } = await api.POST("/v1/orgs/current/invites", {
+        body: { email, role: selectedRole.toLowerCase() },
+      })
+      if (error) {
+        toast.error(extractErrorMessage(error, `Failed to invite ${email}`))
+      } else {
+        successCount++
+      }
+    }
+
+    setSending(false)
+
+    if (successCount > 0) {
+      toast.success(
+        `${successCount} invite${successCount > 1 ? "s" : ""} sent`,
+      )
+      reset()
+      setOpen(false)
+      queryClient.invalidateQueries({
+        queryKey: ["get", "/v1/orgs/current/invites"],
+      })
+    }
+  }
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger render={<Button size="sm" className="h-8" />}>
         Invite people
       </DialogTrigger>
@@ -206,6 +462,8 @@ function InviteDialog() {
               rows={3}
               placeholder="alex@acme.co, jamie@acme.co"
               className="resize-none rounded-md border border-input bg-transparent px-3 py-2 text-[13px] outline-none placeholder:text-muted-foreground focus:ring-2 focus:ring-ring/50"
+              value={emailsText}
+              onChange={(e) => setEmailsText(e.target.value)}
             />
             <p className="text-[12px] text-muted-foreground">
               Separate multiple emails with commas or new lines.
@@ -218,7 +476,8 @@ function InviteDialog() {
             </Label>
             <select
               id="invite-role"
-              defaultValue="Member"
+              value={selectedRole}
+              onChange={(e) => setSelectedRole(e.target.value)}
               className="h-9 rounded-md border border-input bg-transparent px-2.5 text-[13px] outline-none focus:ring-2 focus:ring-ring/50"
             >
               <option>Admin</option>
@@ -229,10 +488,20 @@ function InviteDialog() {
         </div>
 
         <DialogFooter>
-          <DialogClose render={<Button variant="ghost" size="sm" />}>
+          <DialogClose
+            render={<Button variant="ghost" size="sm" />}
+            onClick={() => reset()}
+          >
             Cancel
           </DialogClose>
-          <Button size="sm">Send invites</Button>
+          <Button
+            size="sm"
+            loading={sending}
+            disabled={sending}
+            onClick={handleSendInvites}
+          >
+            {sending ? "Sending\u2026" : "Send invites"}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

Replace the static mock data on the members invite page with real API calls using the existing openapi-react-query infrastructure. This page now fetches members and pending invites from the backend, and the action buttons actually invoke the corresponding API endpoints.

## Changes

- **`apps/web/app/w/settings/members/page.tsx`**: Complete rewrite of the data layer while preserving all existing UI components and layout.

### What changed

1. **Mock data removed** — `MEMBERS` and `PENDING` constants replaced with TanStack Query hooks:
   - `$api.useQuery("get", "/v1/orgs/current/members")` — fetches members
   - `$api.useQuery("get", "/v1/orgs/current/invites")` — fetches pending invites (admin-only)

2. **InviteDialog wired** — "Send invites" button now:
   - Parses comma/newline-separated emails from the textarea
   - Sends each email sequentially via `api.POST`
   - Shows loading spinner on the button while sending
   - Shows success/error toasts
   - Closes dialog on success and invalidates the invites query

3. **Revoke button wired** — calls `DELETE /v1/orgs/current/invites/{id}` with confirmation toast and query invalidation.

4. **Resend button wired** — calls `POST /v1/orgs/current/invites/{id}/resend` with confirmation toast and query invalidation.

5. **Edge case handling**:
   - Loading skeletons for both members and invites sections
   - Empty state messages
   - Error state with retry button
   - 403 handling — hides Invite dialog and pending invites section for non-admin users
   - Dynamic description in header showing real member/invite counts

### Verification

- `cd apps/web && pnpm typecheck` — passes
- `cd apps/web && pnpm build` — passes (compiled successfully, all 229 pages generated)
