### PR TITLE
fix: use unique_key in ON CONFLICT clause for in_integrations seed

### DIFF
--- a/scripts/seed-test-data.sql
+++ b/scripts/seed-test-data.sql
@@ -67,7 +67,7 @@ VALUES
      'webhook_url','https://fake-nango.local/webhook/in_railway-test',
      'webhook_secret','whsec_fake_in_railway-test','forward_webhooks',true),
    false, NOW(), NOW())
-ON CONFLICT (provider) DO UPDATE
+ON CONFLICT (unique_key) DO UPDATE
   SET unique_key          = EXCLUDED.unique_key,
       nango_config        = EXCLUDED.nango_config,
       display_name        = EXCLUDED.display_name,


### PR DESCRIPTION
## Summary

- Fixes `ON CONFLICT (provider)` to `ON CONFLICT (unique_key)` in `scripts/seed-test-data.sql` so the `in_integrations` INSERT matches the actual unique constraint on the `unique_key` column.

## Job done

- `in_integrations` has a UNIQUE constraint on `unique_key`, not on `provider`. Using `ON CONFLICT (provider)` caused `make seed-test` to fail with a PostgreSQL error because there is no unique constraint on `provider`.
- Tracked in Linear issue ENG-56.

## Demo

```
$ make seed-test

Seeded:
       what       |                             detail
------------------+-----------------------------------------------------------------
 user (admin)     | agent-test@example.com
 user (member)    | agent-member@example.com
 user (banned)    | agent-banned@example.com
 user (cross-org) | agent-other@example.com
 org (free)       | Agent Test Workspace
 org (paid)       | Agent Test Paid Workspace
 org (cross)      | Other Workspace
 integrations     | asana, github, jira, linear, notion, railway, salesforce, slack
 api_key          | hvl_sk_aaaaaaaa…  scopes=all
 agent            | Test Agent
 revoked conn     | github · revoked 7d ago
(11 rows)
```

Ran twice to confirm idempotency — second execution produces the same result without errors.

## Requirements met

- [ ] n/a (SQL-only fix, no new tests needed; existing `make seed-test` is the verification)

## Risk & rollback

- Risk: Low. Single-word change from `provider` to `unique_key` matching the actual constraint.
- Rollback: Revert the commit.

## Linked issues

Refs: ENG-56
