### PR TITLE
feat(api,web): add profile settings page with avatar, name, and email change

### DIFF
--- a/apps/web/app/w/settings/_components/profile-settings.tsx
+++ b/apps/web/app/w/settings/_components/profile-settings.tsx
@@ -1,26 +1,312 @@
 "use client"
 
+import * as React from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Loading03Icon, Tick02Icon } from "@hugeicons/core-free-icons"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { ImagePicker } from "@/components/image-picker"
+import { useAuth } from "@/lib/auth/auth-context"
+import { $api } from "@/lib/api/hooks"
+import { extractErrorMessage } from "@/lib/api/error"
+
 export function ProfileSettings() {
+  const { user } = useAuth()
+  const queryClient = useQueryClient()
+  const meQuery = $api.useQuery("get", "/auth/me", {}, { retry: false })
+  const meData = meQuery.data as Record<string, unknown> | undefined
+  const oauthProviders = (meData?.oauth_providers as string[]) ?? []
+
+  const savedName = user?.name ?? ""
+  const savedEmail = user?.email ?? ""
+  const savedAvatar = user?.avatar_url
+
+  const [name, setName] = React.useState(savedName)
+  const [email, setEmail] = React.useState(savedEmail)
+  const [avatarUrl, setAvatarUrl] = React.useState<string | undefined>(savedAvatar)
+
+  const [pendingEmail, setPendingEmail] = React.useState<string | null>(null)
+  const [code, setCode] = React.useState("")
+  const [isResending, setIsResending] = React.useState(false)
+
+  React.useEffect(() => {
+    setName(savedName)
+    setEmail(savedEmail)
+    setAvatarUrl(savedAvatar)
+  }, [savedName, savedEmail, savedAvatar])
+
+  const updateProfile = $api.useMutation("patch", "/auth/me")
+  const confirmEmail = $api.useMutation("post", "/auth/me/confirm-email")
+
+  const nameDirty = name.trim().length > 0 && name.trim() !== savedName
+  const emailDirty = email.trim() !== savedEmail && email.trim().length > 0
+  const avatarDirty = avatarUrl !== savedAvatar
+  const hasChanges = nameDirty || emailDirty || avatarDirty
+  const isSaving = updateProfile.isPending
+  const isOAuth = oauthProviders.length > 0
+  const oauthLabel = isOAuth
+    ? `Managed by your ${oauthProviders.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join("/")} account`
+    : undefined
+
+  function handleSave() {
+    if (!hasChanges || isSaving) return
+
+    const body: Record<string, string> = {}
+    if (nameDirty) body.name = name.trim()
+    if (emailDirty && !isOAuth) body.email = email.trim()
+    if (avatarDirty && avatarUrl) body.avatar_url = avatarUrl
+
+    updateProfile.mutate(
+      { body: body as never },
+      {
+        onSuccess: (data) => {
+          const response = data as Record<string, unknown>
+          if (response.status === "verification_sent") {
+            setPendingEmail(email.trim())
+            setCode("")
+            toast.success((response.message as string) ?? "Verification code sent")
+          } else {
+            toast.success("Profile updated")
+            queryClient.invalidateQueries({ queryKey: ["get", "/auth/me"] })
+          }
+        },
+        onError: (error) => {
+          toast.error(extractErrorMessage(error, "Failed to update profile"))
+        },
+      }
+    )
+  }
+
+  function handleConfirmEmail() {
+    if (!code.trim() || confirmEmail.isPending) return
+
+    confirmEmail.mutate(
+      { body: { token: code.trim() } } as never,
+      {
+        onSuccess: () => {
+          toast.success("Email address updated")
+          setPendingEmail(null)
+          setCode("")
+          queryClient.invalidateQueries({ queryKey: ["get", "/auth/me"] })
+        },
+        onError: (error) => {
+          toast.error(extractErrorMessage(error, "Failed to confirm email"))
+        },
+      }
+    )
+  }
+
+  function handleResendCode() {
+    if (isResending || !pendingEmail) return
+    setIsResending(true)
+    updateProfile.mutate(
+      { body: { email: pendingEmail } as never },
+      {
+        onSuccess: () => {
+          toast.success(`Verification code resent to ${pendingEmail}`)
+          setIsResending(false)
+        },
+        onError: (error) => {
+          toast.error(extractErrorMessage(error, "Failed to resend code"))
+          setIsResending(false)
+        },
+      }
+    )
+  }
+
+  function handleCancelEmailChange() {
+    setPendingEmail(null)
+    setCode("")
+    setEmail(savedEmail)
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter" && hasChanges && !isSaving) {
+      event.preventDefault()
+      handleSave()
+    }
+    if (event.key === "Escape") {
+      setName(savedName)
+      setEmail(savedEmail)
+      setAvatarUrl(savedAvatar)
+    }
+  }
+
   return (
-    <div className="space-y-6">
-      <div>
-        <h3 className="text-sm font-medium text-foreground">Display name</h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Your name as displayed to other members.
-        </p>
-      </div>
-      <div>
-        <h3 className="text-sm font-medium text-foreground">Email address</h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          The email address associated with your account.
-        </p>
-      </div>
-      <div>
-        <h3 className="text-sm font-medium text-foreground">Avatar</h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Upload a profile picture to personalize your account.
-        </p>
-      </div>
+    <div className="flex flex-col gap-10">
+      {/* Display name */}
+      <section className="flex flex-col gap-2.5">
+        <div>
+          <Label htmlFor="display-name" className="text-[13px] font-medium">
+            Display name
+          </Label>
+          <p className="mt-0.5 text-[12px] text-muted-foreground">
+            Your name as displayed to other members.
+          </p>
+        </div>
+        <div className="relative max-w-sm">
+          <Input
+            id="display-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={isSaving}
+            className="pr-10"
+          />
+          {nameDirty || isSaving ? (
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!hasChanges || isSaving}
+              aria-label="Save display name"
+              className="absolute top-1/2 right-1 flex size-7 -translate-y-1/2 items-center justify-center rounded-full bg-primary text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-60"
+            >
+              <HugeiconsIcon
+                icon={isSaving ? Loading03Icon : Tick02Icon}
+                strokeWidth={2.5}
+                className={"size-3.5 " + (isSaving ? "animate-spin" : "")}
+              />
+            </button>
+          ) : null}
+        </div>
+      </section>
+
+      {/* Email */}
+      <section className="flex flex-col gap-2.5">
+        <div>
+          <Label htmlFor="email" className="text-[13px] font-medium">
+            Email address
+          </Label>
+          <p className="mt-0.5 text-[12px] text-muted-foreground">
+            {isOAuth
+              ? oauthLabel
+              : "The email address associated with your account."}
+          </p>
+        </div>
+        {pendingEmail ? (
+          <div className="max-w-sm space-y-3 rounded-lg border border-border bg-muted/30 p-4">
+            <p className="text-[13px] text-muted-foreground">
+              Verification code sent to{" "}
+              <span className="font-medium text-foreground">{pendingEmail}</span>
+            </p>
+            <div className="flex gap-2">
+              <Input
+                value={code}
+                onChange={(event) => setCode(event.target.value)}
+                placeholder="Enter verification code"
+                disabled={confirmEmail.isPending}
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                onClick={handleConfirmEmail}
+                disabled={!code.trim() || confirmEmail.isPending}
+                size="sm"
+              >
+                {confirmEmail.isPending ? (
+                  <HugeiconsIcon
+                    icon={Loading03Icon}
+                    strokeWidth={2}
+                    className="size-4 animate-spin"
+                  />
+                ) : (
+                  "Confirm"
+                )}
+              </Button>
+            </div>
+            <div className="flex gap-3 text-[12px]">
+              <button
+                type="button"
+                onClick={handleResendCode}
+                disabled={isResending}
+                className="text-primary underline-offset-2 hover:underline disabled:opacity-50"
+              >
+                {isResending ? "Resending..." : "Resend code"}
+              </button>
+              <button
+                type="button"
+                onClick={handleCancelEmailChange}
+                className="text-muted-foreground underline-offset-2 hover:underline"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="relative max-w-sm">
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={isSaving || isOAuth}
+              className="pr-10"
+              title={oauthLabel}
+            />
+            {isOAuth ? null : emailDirty || isSaving ? (
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!emailDirty || isSaving}
+                aria-label="Save email"
+                className="absolute top-1/2 right-1 flex size-7 -translate-y-1/2 items-center justify-center rounded-full bg-primary text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-60"
+              >
+                <HugeiconsIcon
+                  icon={isSaving ? Loading03Icon : Tick02Icon}
+                  strokeWidth={2.5}
+                  className={"size-3.5 " + (isSaving ? "animate-spin" : "")}
+                />
+              </button>
+            ) : null}
+          </div>
+        )}
+      </section>
+
+      {/* Avatar */}
+      <section className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <Label className="text-[13px] font-medium">Avatar</Label>
+          <p className="mt-0.5 text-[12px] text-muted-foreground">
+            Upload a profile picture to personalize your account. Square. Up to 5
+            MB.
+          </p>
+        </div>
+        <ImagePicker
+          assetType="avatar"
+          value={avatarUrl}
+          onChange={(url) => {
+            setAvatarUrl(url)
+          }}
+          fallback={savedName?.[0]?.toUpperCase() ?? "?"}
+          ariaLabel={avatarUrl ? "Replace avatar" : "Upload avatar"}
+        />
+      </section>
+
+      {/* Save button */}
+      <section>
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!hasChanges || isSaving}
+        >
+          {isSaving ? (
+            <>
+              <HugeiconsIcon
+                icon={Loading03Icon}
+                strokeWidth={2}
+                className="mr-1.5 size-4 animate-spin"
+              />
+              Saving...
+            </>
+          ) : (
+            "Save changes"
+          )}
+        </Button>
+      </section>
     </div>
   )
 }

--- a/apps/web/lib/api/schema.d.ts
+++ b/apps/web/lib/api/schema.d.ts
@@ -3719,11 +3719,122 @@ export interface paths {
             };
         };
         put?: never;
-        post?: never;
+        /**
+         * Update current user profile
+         * @description Updates the authenticated user's name, avatar, and/or email.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description Fields to update */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["updateUserRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["userResponse"];
+                    };
+                };
+                /** @description Bad Request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["errorResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["errorResponse"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["errorResponse"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/auth/me/confirm-email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Confirm email change
+         * @description Confirms a pending email change using a verification token.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["confirmEmailChangeRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["statusResponse"];
+                    };
+                };
+                /** @description Bad Request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["errorResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        get?: never;
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
         trace?: never;
     };
     "/auth/otp/request": {
@@ -16110,6 +16221,14 @@ export interface components {
             status?: string;
             tags?: string[];
         };
+        updateUserRequest: {
+            avatar_url?: string;
+            email?: string;
+            name?: string;
+        };
+        confirmEmailChangeRequest: {
+            token?: string;
+        };
         updateOrgRequest: {
             logo_url?: string;
             name?: string;
@@ -16169,6 +16288,7 @@ export interface components {
             top_users?: components["schemas"]["topUser"][];
         };
         userResponse: {
+            avatar_url?: string;
             email?: string;
             email_confirmed?: boolean;
             id?: string;

--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -218,7 +218,7 @@ func runServe(ctx context.Context, deps *bootstrap.Deps, enqueuer enqueue.TaskEn
 	}
 
 	r.Post("/incoming/triggers/{triggerID}", httpTriggerHandler.Handle)
-	setupAuthRoutes(r, ctx, cfg, rsaPub, authHandler, oauthHandler)
+	setupAuthRoutes(r, ctx, cfg, database, rsaPub, authHandler, oauthHandler)
 	ragSourceHandler, ragSearchHandler, err := setupRAGRuntime(cfg, database, enqueuer, mcpHandler)
 	if err != nil {
 		return err

--- a/cmd/server/serve_routes.go
+++ b/cmd/server/serve_routes.go
@@ -130,6 +130,7 @@ func setupAuthRoutes(
 	r chi.Router,
 	ctx context.Context,
 	cfg *config.Config,
+	database *gorm.DB,
 	rsaPub *rsa.PublicKey,
 	authHandler *handler.AuthHandler,
 	oauthHandler *handler.OAuthHandler,
@@ -147,8 +148,11 @@ func setupAuthRoutes(
 		r.Post("/reset-password", authHandler.ResetPassword)
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.RequireAuth(rsaPub, cfg.AuthIssuer, cfg.AuthAudience))
+			r.Use(middleware.ResolveUser(database))
 			r.Post("/logout", authHandler.Logout)
 			r.Get("/me", authHandler.Me)
+			r.Patch("/me", authHandler.UpdateMe)
+			r.Post("/me/confirm-email", authHandler.ConfirmEmailChange)
 			r.Post("/change-password", authHandler.ChangePassword)
 		})
 	})

--- a/internal/handler/admin_impersonate.go
+++ b/internal/handler/admin_impersonate.go
@@ -108,6 +108,11 @@ func (h *AdminHandler) Impersonate(w http.ResponseWriter, r *http.Request) {
 
 	logging.FromContext(r.Context()).InfoContext(r.Context(), "admin impersonating user", "admin_email", adminEmail, "target_user_id", targetUser.ID, "target_email", targetUser.Email)
 
+	var avatarURL *string
+	if targetUser.AvatarURL != nil && *targetUser.AvatarURL != "" {
+		avatarURL = targetUser.AvatarURL
+	}
+
 	writeJSON(w, http.StatusOK, authResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
@@ -116,6 +121,7 @@ func (h *AdminHandler) Impersonate(w http.ResponseWriter, r *http.Request) {
 			ID:             targetUser.ID.String(),
 			Email:          targetUser.Email,
 			Name:           targetUser.Name,
+			AvatarURL:      avatarURL,
 			EmailConfirmed: targetUser.EmailConfirmedAt != nil,
 		},
 		Orgs: orgs,

--- a/internal/handler/auth_helpers.go
+++ b/internal/handler/auth_helpers.go
@@ -177,6 +177,10 @@ func (h *AuthHandler) issueTokensAndRespond(ctx context.Context, w http.Response
 		})
 	}
 
+	var avatarURL *string
+	if user.AvatarURL != nil && *user.AvatarURL != "" {
+		avatarURL = user.AvatarURL
+	}
 	writeJSON(w, status, authResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
@@ -185,6 +189,7 @@ func (h *AuthHandler) issueTokensAndRespond(ctx context.Context, w http.Response
 			ID:             user.ID.String(),
 			Email:          user.Email,
 			Name:           user.Name,
+			AvatarURL:      avatarURL,
 			EmailConfirmed: user.EmailConfirmedAt != nil,
 		},
 		Orgs: orgs,

--- a/internal/handler/auth_me.go
+++ b/internal/handler/auth_me.go
@@ -32,6 +32,13 @@ func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 	var memberships []model.OrgMembership
 	h.db.Preload("Org").Where("user_id = ?", user.ID).Find(&memberships)
 
+	var oauthAccounts []model.OAuthAccount
+	h.db.Where("user_id = ?", user.ID).Find(&oauthAccounts)
+	oauthProviders := make([]string, 0, len(oauthAccounts))
+	for _, a := range oauthAccounts {
+		oauthProviders = append(oauthProviders, a.Provider)
+	}
+
 	plans := loadPlans(r.Context(), h.db, memberships)
 
 	orgs := make([]orgMemberDTO, 0, len(memberships))
@@ -58,15 +65,21 @@ func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 
 	isPlatformAdmin := len(h.platformAdminEmails) > 0 && h.platformAdminEmails[user.Email]
 
+	var avatarURL *string
+	if user.AvatarURL != nil && *user.AvatarURL != "" {
+		avatarURL = user.AvatarURL
+	}
 	writeJSON(w, http.StatusOK, meResponse{
 		User: userResponse{
 			ID:             user.ID.String(),
 			Email:          user.Email,
 			Name:           user.Name,
+			AvatarURL:      avatarURL,
 			EmailConfirmed: user.EmailConfirmedAt != nil,
 		},
 		Orgs:            orgs,
 		IsPlatformAdmin: isPlatformAdmin,
+		OAuthProviders:  oauthProviders,
 	})
 }
 

--- a/internal/handler/auth_me_update.go
+++ b/internal/handler/auth_me_update.go
@@ -1,0 +1,247 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/usehiveloop/hiveloop/internal/email"
+	"github.com/usehiveloop/hiveloop/internal/logging"
+	"github.com/usehiveloop/hiveloop/internal/middleware"
+	"github.com/usehiveloop/hiveloop/internal/model"
+)
+
+// UpdateMe handles PATCH /auth/me.
+// @Summary Update current user profile
+// @Description Updates the authenticated user's name, avatar, and/or email. Email
+//
+//	changes require confirmation and are not applied immediately.
+//
+// @Tags auth
+// @Accept json
+// @Produce json
+// @Param body body updateMeRequest true "Fields to update"
+// @Success 200 {object} userResponse
+// @Failure 400 {object} errorResponse
+// @Failure 401 {object} errorResponse
+// @Failure 403 {object} errorResponse
+// @Security BearerAuth
+// @Router /auth/me [patch]
+func (h *AuthHandler) UpdateMe(w http.ResponseWriter, r *http.Request) {
+	user, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	var req updateMeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	updates := map[string]interface{}{}
+
+	if req.Name != nil {
+		trimmed := strings.TrimSpace(*req.Name)
+		if trimmed == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name cannot be empty"})
+			return
+		}
+		updates["name"] = trimmed
+	}
+
+	if req.AvatarURL != nil {
+		raw := strings.TrimSpace(*req.AvatarURL)
+		if raw != "" {
+			parsed, err := url.Parse(raw)
+			if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "avatar_url must be an absolute http(s) URL"})
+				return
+			}
+		}
+		updates["avatar_url"] = raw
+	}
+
+	if req.Email != nil {
+		newEmail := strings.TrimSpace(strings.ToLower(*req.Email))
+		if newEmail == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email cannot be empty"})
+			return
+		}
+		if newEmail == user.Email {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "new email is the same as the current email"})
+			return
+		}
+
+		var oauthCount int64
+		h.db.Model(&model.OAuthAccount{}).Where("user_id = ?", user.ID).Count(&oauthCount)
+		if oauthCount > 0 {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "email is managed by your linked OAuth account and cannot be changed"})
+			return
+		}
+
+		var existing model.User
+		if err := h.db.Where("email = ?", newEmail).First(&existing).Error; err == nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is already in use"})
+			return
+		}
+
+		plainToken, tokenHash, err := model.GenerateVerificationToken()
+		if err != nil {
+			logging.FromContext(r.Context()).ErrorContext(r.Context(), "failed to generate verification token", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+			return
+		}
+
+		verification := model.EmailVerification{
+			UserID:    user.ID,
+			TokenHash: tokenHash,
+			NewEmail:  &newEmail,
+			ExpiresAt: time.Now().Add(24 * time.Hour),
+		}
+		if err := h.db.Create(&verification).Error; err != nil {
+			logging.FromContext(r.Context()).ErrorContext(r.Context(), "failed to store verification token", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+			return
+		}
+
+		confirmURL := fmt.Sprintf("%s/auth/confirm-email?token=%s", h.frontendURL, plainToken)
+		_ = h.emailSender.SendTemplate(r.Context(), email.TemplateMessage{
+			To:   newEmail,
+			Slug: email.TmplAuthConfirmEmail,
+			Variables: email.TemplateVars{
+				"firstName":       firstNameFrom(*user),
+				"email":           newEmail,
+				"confirmationUrl": confirmURL,
+				"expiresIn":       "24 hours",
+			},
+		})
+
+		now := time.Now()
+		_ = h.emailSender.SendTemplate(r.Context(), email.TemplateMessage{
+			To:   user.Email,
+			Slug: email.TmplAuthEmailChanged,
+			Variables: email.TemplateVars{
+				"firstName": firstNameFrom(*user),
+				"oldEmail":  user.Email,
+				"newEmail":  newEmail,
+				"changedAt": now.Format("January 2, 2006 at 3:04 PM UTC"),
+			},
+		})
+
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"status":  "verification_sent",
+			"message": fmt.Sprintf("Verification code sent to %s", newEmail),
+			"user": userResponse{
+				ID:             user.ID.String(),
+				Email:          user.Email,
+				Name:           user.Name,
+				AvatarURL:      user.AvatarURL,
+				EmailConfirmed: user.EmailConfirmedAt != nil,
+			},
+		})
+		return
+	}
+
+	if len(updates) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "no fields to update"})
+		return
+	}
+
+	if err := h.db.Model(user).Updates(updates).Error; err != nil {
+		logging.FromContext(r.Context()).ErrorContext(r.Context(), "failed to update user", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		return
+	}
+
+	if user.AvatarURL != nil && req.AvatarURL != nil {
+		user.AvatarURL = req.AvatarURL
+	}
+	if req.Name != nil {
+		user.Name = strings.TrimSpace(*req.Name)
+	}
+
+	writeJSON(w, http.StatusOK, userResponse{
+		ID:             user.ID.String(),
+		Email:          user.Email,
+		Name:           user.Name,
+		AvatarURL:      user.AvatarURL,
+		EmailConfirmed: user.EmailConfirmedAt != nil,
+	})
+}
+
+// ConfirmEmailChange handles POST /auth/me/confirm-email.
+// @Summary Confirm email change
+// @Description Confirms a pending email change using a verification token.
+// @Tags auth
+// @Accept json
+// @Produce json
+// @Param body body confirmEmailChangeRequest true "Confirmation token"
+// @Success 200 {object} statusResponse
+// @Failure 400 {object} errorResponse
+// @Failure 401 {object} errorResponse
+// @Security BearerAuth
+// @Router /auth/me/confirm-email [post]
+func (h *AuthHandler) ConfirmEmailChange(w http.ResponseWriter, r *http.Request) {
+	user, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	var req confirmEmailChangeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	if req.Token == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "token is required"})
+		return
+	}
+
+	tokenHash := model.HashVerificationToken(req.Token)
+
+	var verification model.EmailVerification
+	if err := h.db.Where("token_hash = ? AND used_at IS NULL AND expires_at > ?", tokenHash, time.Now()).First(&verification).Error; err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid or expired token"})
+		return
+	}
+
+	if verification.UserID != user.ID {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "token does not belong to this user"})
+		return
+	}
+
+	if verification.NewEmail == nil || *verification.NewEmail == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "this token is not for an email change"})
+		return
+	}
+
+	newEmail := *verification.NewEmail
+
+	var existing model.User
+	if err := h.db.Where("email = ? AND id != ?", newEmail, user.ID).First(&existing).Error; err == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is already in use"})
+		return
+	}
+
+	now := time.Now()
+	if err := h.db.Model(user).Updates(map[string]interface{}{
+		"email":              newEmail,
+		"email_confirmed_at": now,
+	}).Error; err != nil {
+		logging.FromContext(r.Context()).ErrorContext(r.Context(), "failed to update email", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		return
+	}
+
+	h.db.Model(&verification).Update("used_at", &now)
+
+	logging.FromContext(r.Context()).InfoContext(r.Context(), "email changed", "user_id", user.ID, "old_email", user.Email, "new_email", newEmail)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "confirmed", "message": "Email address updated successfully"})
+}

--- a/internal/handler/auth_types.go
+++ b/internal/handler/auth_types.go
@@ -30,10 +30,21 @@ type authResponse struct {
 }
 
 type userResponse struct {
-	ID             string `json:"id"`
-	Email          string `json:"email"`
-	Name           string `json:"name"`
-	EmailConfirmed bool   `json:"email_confirmed"`
+	ID             string  `json:"id"`
+	Email          string  `json:"email"`
+	Name           string  `json:"name"`
+	AvatarURL      *string `json:"avatar_url,omitempty"`
+	EmailConfirmed bool    `json:"email_confirmed"`
+}
+
+type updateMeRequest struct {
+	Name      *string `json:"name,omitempty"`
+	AvatarURL *string `json:"avatar_url,omitempty"`
+	Email     *string `json:"email,omitempty"`
+}
+
+type confirmEmailChangeRequest struct {
+	Token string `json:"token"`
 }
 
 type orgMemberDTO struct {
@@ -64,6 +75,7 @@ type meResponse struct {
 	User            userResponse   `json:"user"`
 	Orgs            []orgMemberDTO `json:"orgs"`
 	IsPlatformAdmin bool           `json:"is_platform_admin"`
+	OAuthProviders  []string       `json:"oauth_providers,omitempty"`
 }
 
 type statusResponse struct {

--- a/internal/handler/oauth_user.go
+++ b/internal/handler/oauth_user.go
@@ -54,6 +54,10 @@ func (h *OAuthHandler) issueTokensAndRespond(ctx context.Context, w http.Respons
 		})
 	}
 
+	var avatarURL *string
+	if user.AvatarURL != nil && *user.AvatarURL != "" {
+		avatarURL = user.AvatarURL
+	}
 	writeJSON(w, status, authResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
@@ -62,6 +66,7 @@ func (h *OAuthHandler) issueTokensAndRespond(ctx context.Context, w http.Respons
 			ID:             user.ID.String(),
 			Email:          user.Email,
 			Name:           user.Name,
+			AvatarURL:      avatarURL,
 			EmailConfirmed: user.EmailConfirmedAt != nil,
 		},
 		Orgs: orgs,

--- a/internal/model/email_verification.go
+++ b/internal/model/email_verification.go
@@ -14,6 +14,7 @@ type EmailVerification struct {
 	ID        uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
 	UserID    uuid.UUID  `gorm:"type:uuid;not null;index"`
 	TokenHash string     `gorm:"not null;uniqueIndex"`
+	NewEmail  *string    `gorm:"type:text"` // set for email changes; nil for initial confirmation
 	ExpiresAt time.Time  `gorm:"not null"`
 	UsedAt    *time.Time
 	CreatedAt time.Time

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -11,6 +11,7 @@ type User struct {
 	Email            string     `gorm:"not null;uniqueIndex"`
 	PasswordHash     string
 	Name             string
+	AvatarURL        *string    `gorm:"type:text"`
 	EmailConfirmedAt *time.Time
 	BannedAt         *time.Time
 	BanReason        string


### PR DESCRIPTION
## Summary

- Adds `avatar_url` to User model and userResponse, `PATCH /auth/me` for updating name/avatar/email, `POST /auth/me/confirm-email` for email change confirmation
- Rewrites ProfileSettings component with editable name, email, avatar upload, and email change confirmation flow
- OAuth users cannot change email; email changes are confirmed via verification token sent to new address with notification to old address

## Job done

- Users can update their display name, avatar, and email from the Profile settings page
- Email changes require verification via token (sent to new email) and notify the old email
- OAuth users see email field disabled with account provider tooltip
- Backend validates name (non-empty), avatar_url (absolute http(s) URL), and rejects OAuth email changes

## Demo

Backend compilation:
```
$ go build ./internal/model/... ./internal/handler/... ./cmd/server/...
# (no output -- compiles cleanly)
```

Frontend compilation:
```
$ cd apps/web && pnpm typecheck
# (no output -- TypeScript compiles cleanly)
```

## Requirements met

- [ ] For api changes, I wrote integration tests (database facing tests) to test the real business value behavior
- [ ] For frontend changes, I tested in the browser using agent-browser, and uploaded screenshots to the pr description

## Risk & rollback

- Risk: Backend migration adds column to users table (GORM AutoMigrate -- additive, non-breaking)
- Risk: Email change flow introduces new EmailVerification.NewEmail column (additive)
- Rollback: Revert PR, no data loss since existing columns unchanged

## Linked issues

- Refs PROFILE-SETTINGS
