### PR TITLE
[codex] fix Railway runtime command timeout

### DIFF
--- a/internal/employeeruntime/client.go
+++ b/internal/employeeruntime/client.go
@@ -21,6 +21,8 @@ type Client struct {
 	http    *http.Client
 }
 
+const defaultHTTPTimeout = 2 * time.Minute
+
 type SyncResponse struct {
 	Applied          int      `json:"applied"`
 	Deleted          int      `json:"deleted"`
@@ -53,10 +55,17 @@ type HTTPMessageResponse struct {
 }
 
 func NewClient(baseURL, apiKey string) *Client {
+	return NewClientWithTimeout(baseURL, apiKey, defaultHTTPTimeout)
+}
+
+func NewClientWithTimeout(baseURL, apiKey string, timeout time.Duration) *Client {
+	if timeout <= 0 {
+		timeout = defaultHTTPTimeout
+	}
 	return &Client{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		apiKey:  apiKey,
-		http:    &http.Client{Timeout: 2 * time.Minute},
+		http:    &http.Client{Timeout: timeout},
 	}
 }
 

--- a/internal/employeeruntime/client_test.go
+++ b/internal/employeeruntime/client_test.go
@@ -1,0 +1,24 @@
+package employeeruntime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewClientWithTimeoutAppliesHTTPTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClientWithTimeout(srv.URL, "runtime-secret", time.Millisecond)
+
+	err := client.Healthz(context.Background())
+	if err == nil {
+		t.Fatal("expected healthz to fail when response headers exceed configured timeout")
+	}
+}

--- a/internal/sandbox/railway/driver.go
+++ b/internal/sandbox/railway/driver.go
@@ -12,6 +12,7 @@ import (
 )
 
 const defaultRuntimePort = 7080
+const runtimeCommandHTTPTimeoutPadding = 30 * time.Second
 
 type Config struct {
 	APIToken      string
@@ -201,7 +202,7 @@ func (d *Driver) ExecuteCommandViaRuntime(ctx context.Context, cmdCtx sandbox.Ru
 	if seconds <= 0 {
 		seconds = 120
 	}
-	client := employeeruntime.NewClient(cmdCtx.RuntimeURL, cmdCtx.RuntimeSecret)
+	client := employeeruntime.NewClientWithTimeout(cmdCtx.RuntimeURL, cmdCtx.RuntimeSecret, runtimeCommandHTTPTimeout(time.Duration(seconds)*time.Second))
 	resp, err := client.RunCommands(ctx, employeeruntime.ControlCommandsRequest{
 		Commands:       []string{command},
 		TimeoutSeconds: seconds,
@@ -218,4 +219,11 @@ func (d *Driver) ExecuteCommandViaRuntime(ctx context.Context, cmdCtx sandbox.Ru
 		return result.Output, fmt.Errorf("command failed in runtime: exit_code=%v timed_out=%v", result.ExitCode, result.TimedOut)
 	}
 	return result.Output, nil
+}
+
+func runtimeCommandHTTPTimeout(commandTimeout time.Duration) time.Duration {
+	if commandTimeout <= 0 {
+		commandTimeout = 120 * time.Second
+	}
+	return commandTimeout + runtimeCommandHTTPTimeoutPadding
 }

--- a/internal/sandbox/railway/driver_test.go
+++ b/internal/sandbox/railway/driver_test.go
@@ -1,0 +1,26 @@
+package railway
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRuntimeCommandHTTPTimeoutExceedsCommandTimeout(t *testing.T) {
+	commandTimeout := 60 * time.Minute
+
+	got := runtimeCommandHTTPTimeout(commandTimeout)
+	want := commandTimeout + runtimeCommandHTTPTimeoutPadding
+
+	if got != want {
+		t.Fatalf("runtime command HTTP timeout = %s, want %s", got, want)
+	}
+}
+
+func TestRuntimeCommandHTTPTimeoutUsesRuntimeDefault(t *testing.T) {
+	got := runtimeCommandHTTPTimeout(0)
+	want := 120*time.Second + runtimeCommandHTTPTimeoutPadding
+
+	if got != want {
+		t.Fatalf("runtime command HTTP timeout = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Increase the Railway runtime command HTTP timeout so long-running `/control/commands` calls can outlive the previous 2-minute client limit.
- Keep the default employee runtime client timeout unchanged for normal health/config/message requests.
- Add focused regression coverage for configurable runtime HTTP timeouts and the Railway command timeout calculation.

## Root cause

Sandbox upgrade backup commands pass a 60-minute runtime command timeout, but the Go HTTP client used for `/control/commands` had a fixed 2-minute timeout. Because the runtime command endpoint returns only after command completion, backups that take longer than 2 minutes failed while awaiting response headers.

## Tests

- PASS: `/opt/homebrew/bin/go test ./internal/employeeruntime -count=1`
- PASS: `/opt/homebrew/bin/go test ./internal/sandbox/railway -count=1`
- PASS: `/opt/homebrew/bin/go test ./internal/sandbox/... -count=1`
- PASS: `/opt/homebrew/bin/go test ./internal/tasks -count=1 -run 'TestEmployeeSandboxUpgrade'`
- PASS: `./scripts/check-go-file-length.sh`
- PASS: `/opt/homebrew/bin/go test ./internal/... -count=1`

## Manual verification

- Production investigation showed failed upgrade `dbac60fd-63e5-4627-8154-663d2dcdf666` failed in `backup` after roughly 2 minutes with `Client.Timeout exceeded while awaiting headers` against Railway sandbox `hivy-employee-warm-c2bb2bbf`.
- No manual upgrade retry has been run yet; this PR should deploy first, then retry the upgrade.

## Untested risk

- This is an interim fix. It still relies on one long synchronous HTTP request through Railway. A permanent solution should make runtime control commands asynchronous with command IDs and polling.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/usehivy/codesmith/hivy/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782880377&installation_id=135752923&pr_number=178&repository=usehivy%2Fhivy&return_to=https%3A%2F%2Fgithub.com%2Fusehivy%2Fhivy%2Fpull%2F178&signature=6e7b3da7db30c50b4e618b0d398d40530e7f9e15a95981d957adb8a5b3b149e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->