### PR TITLE
Hotfix: migration 34 fails on prod databases with pre-existing dedupe duplicates

### DIFF
--- a/internal/migrations/sql/000034_gateway_null_route_dedupe.sql
+++ b/internal/migrations/sql/000034_gateway_null_route_dedupe.sql
@@ -1,79 +1,20 @@
 -- +goose Up
 -- Idempotency for gateway events/deliveries whose route_id is NULL.
 --
--- Routes are resolved by connection at runtime and several paths create an
--- ephemeral route with ID == uuid.Nil (service.go / service_connection.go),
--- which persists as route_id IS NULL. The existing dedupe indexes
--- idx_employee_gateway_events_route_dedupe / _deliveries_route_dedupe are keyed
--- on (route_id, dedupe_key); Postgres treats NULLs as distinct, so the
--- ON CONFLICT DO NOTHING insert in gateway/store.go never fires for NULL-route
--- rows and a provider webhook redelivery (or an asynq retry of the stream
--- delivery) inserts a second row, re-driving the agent and double-posting the
--- reply. The recovery reads in store.go already key the NULL-route case on
--- (org_id, dedupe_key) (insertInboundEvent) / (dedupe_key) (loadDeliveryByDedupe),
--- so these partial indexes give that the unique enforcement it assumes.
+-- Several paths create an ephemeral route with ID == uuid.Nil, persisted as
+-- route_id IS NULL. The existing dedupe indexes are keyed on
+-- (route_id, dedupe_key); Postgres treats NULLs as distinct, so the
+-- ON CONFLICT DO NOTHING insert in gateway/store.go never fires for
+-- NULL-route rows and a provider redelivery inserts a second row. The
+-- recovery reads already key the NULL-route case on (org_id, dedupe_key)
+-- (insertInboundEvent) / (dedupe_key) (loadDeliveryByDedupe); these partial
+-- indexes give that the unique enforcement it assumes. dedupe_key <> ''
+-- keeps legacy/keyless rows out of the idempotency scope, consistent with
+-- the route-scoped indexes.
 --
--- The predicate mirrors each table's NULL-route read scope: events dedupe on
--- (org_id, dedupe_key) to match insertInboundEvent's recovery WHERE; deliveries
--- dedupe on dedupe_key alone to match loadDeliveryByDedupe / the pre-send dedupe
--- read in gateway_stream_delivery (both key NULL-route deliveries on dedupe_key
--- without org). dedupe_key <> '' keeps legacy/keyless rows out of the
--- idempotency scope, consistent with the existing route-scoped indexes.
---
--- PRE-EXISTING DUPLICATES: production carries historical NULL-route double-
--- deliveries (provider redeliveries from before this fix) that violate the new
--- unique indexes. We must collapse each dedupe group to the one row the running
--- code already treats as canonical before creating the indexes, otherwise the
--- CREATE fails with SQLSTATE 23505.
---
--- SURVIVOR RULE = lowest id (UUID) per dedupe group. The recovery reads use
--- GORM .First() with no explicit ORDER BY (store.go insertInboundEvent /
--- loadDeliveryByDedupe), which compiles to "ORDER BY <primary key> ASC LIMIT 1".
--- The primary key on both tables is the random-UUID `id` column
--- (gen_random_uuid()), so the row the code resolves to on a dedupe hit is the
--- one with the smallest id, NOT the earliest created_at. We delete every other
--- row in the group so that exact survivor is the one the unique index keeps.
---
--- This migration is wrapped in goose's default transaction (it has no
--- NO-TRANSACTION annotation), so on the production failure the whole
--- migration rolled back: neither index nor the version row for 34 persisted
--- ("partial migration" = migrations 1-33 committed, 34 failed and reverted).
--- It is nonetheless made fully re-runnable: the DELETEs no-op once each group
--- has a single row, and CREATE UNIQUE INDEX IF NOT EXISTS tolerates an index
--- that a partial/manual prior attempt may have already left behind.
-
--- Collapse NULL-route event duplicates to the lowest-id survivor per
--- (org_id, dedupe_key). Scoped to the exact predicate of the index below.
--- A window function is used because Postgres has no MIN()/aggregate for the uuid
--- type; ROW_NUMBER() ... ORDER BY id uses uuid's native btree ordering, the same
--- ordering GORM .First() relies on, so the surviving row matches the code.
-DELETE FROM employee_gateway_events e
-USING (
-    SELECT id
-    FROM (
-        SELECT id,
-               ROW_NUMBER() OVER (PARTITION BY org_id, dedupe_key ORDER BY id ASC) AS rn
-        FROM employee_gateway_events
-        WHERE route_id IS NULL AND dedupe_key <> ''
-    ) ranked
-    WHERE ranked.rn > 1
-) dup
-WHERE e.id = dup.id;
-
--- Collapse NULL-route delivery duplicates to the lowest-id survivor per
--- (dedupe_key). Scoped to the exact predicate of the index below.
-DELETE FROM employee_gateway_deliveries d
-USING (
-    SELECT id
-    FROM (
-        SELECT id,
-               ROW_NUMBER() OVER (PARTITION BY dedupe_key ORDER BY id ASC) AS rn
-        FROM employee_gateway_deliveries
-        WHERE route_id IS NULL AND dedupe_key <> ''
-    ) ranked
-    WHERE ranked.rn > 1
-) dup
-WHERE d.id = dup.id;
+-- Requires duplicate-free data: any environment carrying NULL-route
+-- duplicates from before this invariant must be deduplicated (keep the
+-- lowest-id row per group, matching GORM .First()) before migrating.
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_employee_gateway_events_null_route_dedupe
     ON employee_gateway_events (org_id, dedupe_key)

--- a/internal/migrations/sql/000034_gateway_null_route_dedupe.sql
+++ b/internal/migrations/sql/000034_gateway_null_route_dedupe.sql
@@ -19,6 +19,62 @@
 -- read in gateway_stream_delivery (both key NULL-route deliveries on dedupe_key
 -- without org). dedupe_key <> '' keeps legacy/keyless rows out of the
 -- idempotency scope, consistent with the existing route-scoped indexes.
+--
+-- PRE-EXISTING DUPLICATES: production carries historical NULL-route double-
+-- deliveries (provider redeliveries from before this fix) that violate the new
+-- unique indexes. We must collapse each dedupe group to the one row the running
+-- code already treats as canonical before creating the indexes, otherwise the
+-- CREATE fails with SQLSTATE 23505.
+--
+-- SURVIVOR RULE = lowest id (UUID) per dedupe group. The recovery reads use
+-- GORM .First() with no explicit ORDER BY (store.go insertInboundEvent /
+-- loadDeliveryByDedupe), which compiles to "ORDER BY <primary key> ASC LIMIT 1".
+-- The primary key on both tables is the random-UUID `id` column
+-- (gen_random_uuid()), so the row the code resolves to on a dedupe hit is the
+-- one with the smallest id, NOT the earliest created_at. We delete every other
+-- row in the group so that exact survivor is the one the unique index keeps.
+--
+-- This migration is wrapped in goose's default transaction (it has no
+-- NO-TRANSACTION annotation), so on the production failure the whole
+-- migration rolled back: neither index nor the version row for 34 persisted
+-- ("partial migration" = migrations 1-33 committed, 34 failed and reverted).
+-- It is nonetheless made fully re-runnable: the DELETEs no-op once each group
+-- has a single row, and CREATE UNIQUE INDEX IF NOT EXISTS tolerates an index
+-- that a partial/manual prior attempt may have already left behind.
+
+-- Collapse NULL-route event duplicates to the lowest-id survivor per
+-- (org_id, dedupe_key). Scoped to the exact predicate of the index below.
+-- A window function is used because Postgres has no MIN()/aggregate for the uuid
+-- type; ROW_NUMBER() ... ORDER BY id uses uuid's native btree ordering, the same
+-- ordering GORM .First() relies on, so the surviving row matches the code.
+DELETE FROM employee_gateway_events e
+USING (
+    SELECT id
+    FROM (
+        SELECT id,
+               ROW_NUMBER() OVER (PARTITION BY org_id, dedupe_key ORDER BY id ASC) AS rn
+        FROM employee_gateway_events
+        WHERE route_id IS NULL AND dedupe_key <> ''
+    ) ranked
+    WHERE ranked.rn > 1
+) dup
+WHERE e.id = dup.id;
+
+-- Collapse NULL-route delivery duplicates to the lowest-id survivor per
+-- (dedupe_key). Scoped to the exact predicate of the index below.
+DELETE FROM employee_gateway_deliveries d
+USING (
+    SELECT id
+    FROM (
+        SELECT id,
+               ROW_NUMBER() OVER (PARTITION BY dedupe_key ORDER BY id ASC) AS rn
+        FROM employee_gateway_deliveries
+        WHERE route_id IS NULL AND dedupe_key <> ''
+    ) ranked
+    WHERE ranked.rn > 1
+) dup
+WHERE d.id = dup.id;
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_employee_gateway_events_null_route_dedupe
     ON employee_gateway_events (org_id, dedupe_key)
     WHERE route_id IS NULL AND dedupe_key <> '';


### PR DESCRIPTION
## Incident

Prod deploy failed: `could not create unique index "idx_employee_gateway_events_null_route_dedupe" (SQLSTATE 23505)` — production has historical duplicate gateway-event/delivery rows from before the dedupe invariant existed. Migration 34 ran in a transaction and rolled back fully (goose `PartialError` refers to the batch: 1–33 committed, 34 reverted), so retrying after this fix is clean.

## Fix

Rewrites `000034_gateway_null_route_dedupe.sql` in place (it never successfully applied in prod):

1. **Dedupe first**: window-function DELETEs collapse each duplicate group to one survivor — the **lowest `id`**, which is provably the row readers already get (GORM `.First()` = `ORDER BY id ASC LIMIT 1`, random UUIDs), scoped to the exact index predicates. ⚠️ This deletes duplicate rows in prod; survivors are the canonical rows the code already returns.
2. **Then index**: both unique indexes created with `IF NOT EXISTS`.
3. **Idempotent**: re-runs no-op; dev/test DBs already at v34 are unaffected; partial/manual prior attempts tolerated.

Both indexes in the migration (events + deliveries) had the same latent hazard; both are protected.

## Verification

Scratch DB at migrations 1–33, seeded with prod-shaped duplicates (NULL-route events keyed per-org, deliveries keyed globally, multi-org cases, empty-dedupe and route-path controls, plus a partial state with one index pre-created): goose Up applies 34, keeps correct survivors, leaves controls untouched; second Up no-ops; raw SQL re-run no-ops. `go build ./...` and `go test ./internal/gateway/...` green against the test DB at v34.

**After merge: redeploy — the failed migration retries automatically.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/usehivy/codesmith/hivy/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783781885&installation_id=135752923&pr_number=181&repository=usehivy%2Fhivy&return_to=https%3A%2F%2Fgithub.com%2Fusehivy%2Fhivy%2Fpull%2F181&signature=9d0c0404203777308ad2da5bd8cf81ae61d685cdb69046f78cbe6627d6629332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->