### PR TITLE
[codex] fix new session stream handoff

### DIFF
--- a/apps/web/app/w/(chat)/_components/new-session-view.test.ts
+++ b/apps/web/app/w/(chat)/_components/new-session-view.test.ts
@@ -1,0 +1,115 @@
+import React from "react"
+import { renderToString } from "react-dom/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  composerProps: null as null | {
+    onSend: (text: string, effort: string) => boolean | Promise<boolean>
+  },
+  mutateAsync: vi.fn(),
+  useMutation: vi.fn(),
+  useQuery: vi.fn(),
+}))
+
+vi.mock("@/app/w/(chat)/_components/chat-composer", () => ({
+  ChatComposer: (props: {
+    onSend: (text: string, effort: string) => boolean | Promise<boolean>
+  }) => {
+    mocks.composerProps = props
+    return null
+  },
+}))
+
+vi.mock("@/lib/api/hooks", () => ({
+  $api: {
+    useMutation: mocks.useMutation,
+    useQuery: mocks.useQuery,
+  },
+}))
+
+import { SessionView } from "@/app/w/(chat)/_components/new-session-view"
+
+describe("SessionView", () => {
+  beforeEach(() => {
+    mocks.composerProps = null
+    mocks.mutateAsync.mockReset()
+    mocks.useMutation.mockReset()
+    mocks.useQuery.mockReset()
+
+    mocks.useQuery.mockImplementation((_method: string, path: string) => {
+      if (path === "/v1/channels") {
+        return {
+          data: {
+            data: [{ id: "channel-1", name: "General", is_default: true }],
+          },
+          isError: false,
+          isLoading: false,
+        }
+      }
+      if (path === "/v1/agents") {
+        return {
+          data: {
+            data: [
+              {
+                id: "agent-1",
+                name: "Hivy",
+                is_default: true,
+                model: "test-model",
+              },
+            ],
+          },
+          isError: false,
+          isLoading: false,
+        }
+      }
+      return { data: undefined, isError: false, isLoading: false }
+    })
+    mocks.useMutation.mockReturnValue({
+      isPending: false,
+      mutateAsync: mocks.mutateAsync,
+    })
+    mocks.mutateAsync.mockResolvedValue({
+      event: {
+        event_id: "event-1",
+        event_type: "user.message",
+        session_id: "session-1",
+      },
+      session: {
+        agent_id: "agent-1",
+        channel_id: "channel-1",
+        id: "session-1",
+        name: "Created from response",
+      },
+    })
+  })
+
+  it("redirects after create without passing create-response placeholders", async () => {
+    const onSessionCreated = vi.fn()
+
+    renderToString(React.createElement(SessionView, { onSessionCreated }))
+
+    expect(mocks.composerProps).toBeTruthy()
+    if (!mocks.composerProps) {
+      throw new Error("ChatComposer props were not captured")
+    }
+    const sent = await mocks.composerProps.onSend("Investigate this", "High")
+
+    expect(sent).toBe(true)
+    expect(mocks.mutateAsync).toHaveBeenCalledWith({
+      body: {
+        access_mode: "full",
+        agent_id: "agent-1",
+        channel_id: "channel-1",
+        model: "test-model",
+        reasoning_effort: "high",
+        text: "Investigate this",
+      },
+    })
+    expect(onSessionCreated).toHaveBeenCalledWith(
+      "general",
+      "session-1",
+      undefined,
+      { replace: true }
+    )
+  })
+})

--- a/apps/web/app/w/(chat)/_components/new-session-view.tsx
+++ b/apps/web/app/w/(chat)/_components/new-session-view.tsx
@@ -1,26 +1,17 @@
 "use client"
 
 import { useMemo, useState } from "react"
-import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "@heroui/react"
 import { $api } from "@/lib/api/hooks"
 import { extractErrorMessage } from "@/lib/api/error"
 import { ChatComposer } from "@/app/w/(chat)/_components/chat-composer"
 import type { ChatSession } from "@/app/w/(chat)/_components/shell"
 import { AGENTS } from "@/app/w/(chat)/_lib/agents"
+import { CHAT_QUERY_STALE_TIME_MS } from "@/app/w/(chat)/_lib/chat-cache"
 import {
-  CHAT_QUERY_STALE_TIME_MS,
-  insertSessionIntoChannelCache,
-  seedSessionDetail,
-  seedSessionEvents,
-} from "@/app/w/(chat)/_lib/chat-cache"
-import {
-  agentAvatarURL,
   agentDisplayName,
-  agentIcon,
   agentModel,
   channelRouteSlug,
-  sessionDisplayName,
 } from "@/app/w/(chat)/_lib/sidebar-data"
 
 interface SessionViewProps {
@@ -37,7 +28,6 @@ export function SessionView({
   channelSlug,
   onSessionCreated,
 }: SessionViewProps) {
-  const queryClient = useQueryClient()
   const channelsQuery = $api.useQuery(
     "get",
     "/v1/channels",
@@ -118,24 +108,10 @@ export function SessionView({
         return false
       }
 
-      seedSessionDetail(queryClient, created)
-      insertSessionIntoChannelCache(queryClient, created)
-      if (response.event) {
-        seedSessionEvents(queryClient, created.id, [response.event])
-      }
       onSessionCreated(
         channelRouteSlug(activeChannel),
         created.id,
-        {
-          title: sessionDisplayName(created),
-          agentId: selectedAgent?.id ?? fallbackAgent.id,
-          agentName: selectedAgent
-            ? agentDisplayName(selectedAgent)
-            : undefined,
-          agentIcon: agentIcon(selectedAgent),
-          agentAvatarURL: agentAvatarURL(selectedAgent),
-          modelId,
-        },
+        undefined,
         { replace: true }
       )
       return true


### PR DESCRIPTION
## Summary

Fixes the new-chat handoff so the create response no longer seeds placeholder session detail or event data into React Query before redirecting.

After `POST /v1/sessions` succeeds, the UI now redirects with only the channel slug and session id. The destination session route then loads session detail and events from the API and uses the existing runtime hydration/stream subscription path, matching normal session navigation.

## Root Cause

The new-chat create path seeded the freshly-created session and first event into React Query. That response could contain an idle-looking session snapshot, and the chat cache treats it as fresh for five minutes. The redirected session page then hydrated from stale client-side data, did not start the live stream, and showed no thinking/activity until refresh.

## Changes

- Removed create-response seeding from the new-session view.
- Stopped passing a preview `ChatSession` object from the create response during redirect.
- Added a regression test that verifies the create flow redirects without passing create-response placeholders.

## Validation

- `pnpm test -- 'app/w/(chat)/_components/new-session-view.test.ts' 'app/w/(chat)/_lib/chat-cache.test.ts' 'app/w/(chat)/_stores/session-runtime-store.test.ts'` (ran 21 files / 137 tests)
- `pnpm typecheck`
- `pnpm lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/usehivy/codesmith/hivy/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784558569&installation_id=135752923&pr_number=193&repository=usehivy%2Fhivy&return_to=https%3A%2F%2Fgithub.com%2Fusehivy%2Fhivy%2Fpull%2F193&signature=1718843c05d203264b09cdb70fc624c62dfd103bde6159e04b4e61d5a743188d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the React Query cache pre-seeding that occurred immediately after `POST /v1/sessions` succeeded, fixing a bug where the redirected session page hydrated from an idle-looking cache snapshot and never started the live stream.

- **`new-session-view.tsx`**: Drops `useQueryClient`, `seedSessionDetail`, `insertSessionIntoChannelCache`, `seedSessionEvents`, and the `ChatSession` payload from the `onSessionCreated` call; the redirect now passes only the channel slug and session id so the destination route performs a fresh API load.
- **`new-session-view.test.ts`** (new): Verifies that after a successful create, `onSessionCreated` is invoked with `undefined` for the session preview and `{ replace: true }`, confirming no create-response placeholders are passed through.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change narrows a single create-redirect path and the destination route already handles fresh API loading correctly.

The diff is small and targeted: it removes three cache-seeding calls and one ChatSession payload from a single code path, with no side effects on other flows. The destination session route was already designed to load from the API and start the live stream independently, so passing undefined is the correct contract. The new test directly exercises the changed path and all assertions match the implementation.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/app/w/(chat)/_components/new-session-view.tsx | Removes cache pre-seeding and ChatSession payload from the redirect; unused imports are correctly cleaned up. CHAT_QUERY_STALE_TIME_MS import is retained and still used in query options. |
| apps/web/app/w/(chat)/_components/new-session-view.test.ts | New regression test that renders SessionView via renderToString, captures ChatComposer's onSend prop, exercises the create path, and asserts onSessionCreated is called with undefined session and { replace: true }. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix new session stream handoff"](https://github.com/usehivy/hivy/commit/93ef2127f5d09022e405898d381f013d93f00b3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38813745)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suite for the new session view functionality.

* **Refactor**
  * Simplified session-creation flow by streamlining internal data handling during session initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->