### PR TITLE
[codex] Fix turn lifecycle worklog rendering

### DIFF
--- a/apps/web/app/w/(chat)/_components/new-session-view.tsx
+++ b/apps/web/app/w/(chat)/_components/new-session-view.tsx
@@ -135,6 +135,10 @@ export function SessionView({
           agentIcon: agentIcon(selectedAgent),
           agentAvatarURL: agentAvatarURL(selectedAgent),
           modelId,
+          agentTurnStatus: created.agent_turn_status,
+          agentTurnID: created.agent_turn_id,
+          agentTurnStartedAt: created.agent_turn_started_at,
+          lastTurnOutcome: created.last_turn_outcome,
         },
         { replace: true }
       )

--- a/apps/web/app/w/(chat)/_components/session-view.tsx
+++ b/apps/web/app/w/(chat)/_components/session-view.tsx
@@ -98,21 +98,28 @@ export function SessionThreadView({
     () => historyEvents.some(isPendingClientEvent),
     [historyEvents]
   )
-  const historyBlocks = useMemo(
+  const combinedEvents = useMemo(
     () =>
-      historyPages?.length
-        ? sessionEventsToConversationBlocks(historyEvents)
-        : null,
-    [historyEvents, historyPages?.length]
+      sessionHistoryPagesToEvents([
+        { data: historyEvents },
+        { data: liveEvents },
+      ]),
+    [historyEvents, liveEvents]
   )
-  const baseBlocks = historyBlocks ?? []
-  const liveBlocks = useMemo(
-    () => sessionEventsToConversationBlocks(liveEvents, { mode: "live" }),
-    [liveEvents]
+  const activeTurnID = turnActive
+    ? session.agentTurnID?.trim() || latestTurnID(liveEvents)
+    : undefined
+  const visibleBlocks = useMemo(
+    () =>
+      sessionEventsToConversationBlocks(combinedEvents, {
+        activeTurnID,
+        activeTurnStartedAt: session.agentTurnStartedAt,
+      }),
+    [activeTurnID, combinedEvents, session.agentTurnStartedAt]
   )
   const latestPlan = useMemo(
-    () => latestSessionPlan([...historyEvents, ...liveEvents]),
-    [historyEvents, liveEvents]
+    () => latestSessionPlan(combinedEvents),
+    [combinedEvents]
   )
   const fetchNextHistoryPage = sessionHistoryQuery.fetchNextPage
   const loadNextHistoryPage = useCallback(
@@ -243,7 +250,6 @@ export function SessionThreadView({
 
   const isBusy =
     turnActive || hasPendingClientEvent || sendSessionMessage.isPending
-  const visibleBlocks = [...baseBlocks, ...liveBlocks]
   const showHistorySkeleton =
     !optimisticSession && sessionHistoryQuery.isPending && !historyPages?.length
   const followButtonClassName = `!absolute ${
@@ -312,6 +318,20 @@ function isTurnActive(status: SessionRuntimeStatus) {
     status === "streaming" ||
     status === "waiting_for_user"
   )
+}
+
+function latestTurnID(events: SessionEventResponse[]) {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const payload = events[index].payload
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      continue
+    }
+    const turnID = (payload as Record<string, unknown>).turn_id
+    if (typeof turnID === "string" && turnID.trim()) {
+      return turnID.trim()
+    }
+  }
+  return ""
 }
 
 function safeAgentById(id: string) {

--- a/apps/web/app/w/(chat)/_components/session-view.tsx
+++ b/apps/web/app/w/(chat)/_components/session-view.tsx
@@ -331,7 +331,7 @@ function latestTurnID(events: SessionEventResponse[]) {
       return turnID.trim()
     }
   }
-  return ""
+  return undefined
 }
 
 function safeAgentById(id: string) {

--- a/apps/web/app/w/(chat)/_components/shell.tsx
+++ b/apps/web/app/w/(chat)/_components/shell.tsx
@@ -72,6 +72,10 @@ export interface ChatSession {
   agentAvatarURL?: string
   modelId: string
   initialMessage?: string
+  agentTurnStatus?: string
+  agentTurnID?: string
+  agentTurnStartedAt?: string
+  lastTurnOutcome?: string
 }
 
 interface WorkspaceContextValue {
@@ -735,6 +739,10 @@ function chatSessionFromResponse(
       session.model?.trim() ||
       agentModel(apiAgent) ||
       fallbackAgent.defaultModelId,
+    agentTurnStatus: session.agent_turn_status,
+    agentTurnID: session.agent_turn_id,
+    agentTurnStartedAt: session.agent_turn_started_at,
+    lastTurnOutcome: session.last_turn_outcome,
   }
 }
 

--- a/apps/web/app/w/(chat)/_components/sidebar-channel-group.tsx
+++ b/apps/web/app/w/(chat)/_components/sidebar-channel-group.tsx
@@ -231,6 +231,10 @@ function chatSessionFromResponse(
     agentIcon: apiAgent ? agentIcon(apiAgent) : fallback.icon,
     agentAvatarURL: agentAvatarURL(apiAgent),
     modelId,
+    agentTurnStatus: session.agent_turn_status,
+    agentTurnID: session.agent_turn_id,
+    agentTurnStartedAt: session.agent_turn_started_at,
+    lastTurnOutcome: session.last_turn_outcome,
   }
 }
 

--- a/apps/web/app/w/(chat)/_lib/live-session-stream.test.ts
+++ b/apps/web/app/w/(chat)/_lib/live-session-stream.test.ts
@@ -68,6 +68,12 @@ describe("live session stream", () => {
     )
   })
 
+  it("treats turn_completed frames as terminal", () => {
+    expect(
+      isTerminalStreamFrame(frame("turn_completed", { turn_id: "turn-1" }))
+    ).toBe(true)
+  })
+
   it("passes plan updates through as live session events", () => {
     const events = appendLiveSessionStreamFrame(
       [],

--- a/apps/web/app/w/(chat)/_lib/live-session-stream.ts
+++ b/apps/web/app/w/(chat)/_lib/live-session-stream.ts
@@ -32,6 +32,7 @@ export function appendLiveSessionStreamFrame(
 export function isTerminalStreamFrame(frame: DirectSessionStreamFrame) {
   return (
     frame.event === "done" ||
+    frame.event === "turn_completed" ||
     frame.event === "turn_failed" ||
     frame.event === "error"
   )

--- a/apps/web/app/w/(chat)/_lib/session-history-event-utils.ts
+++ b/apps/web/app/w/(chat)/_lib/session-history-event-utils.ts
@@ -1,0 +1,94 @@
+import type { components } from "@/lib/api/schema"
+
+export type SessionEventResponse = components["schemas"]["sessionEventResponse"]
+export type Payload = Record<string, unknown>
+
+export function compareSessionEvents(
+  left: SessionEventResponse,
+  right: SessionEventResponse
+) {
+  const byTime = eventTime(left) - eventTime(right)
+  if (byTime !== 0) return byTime
+  return (left.sequence_number ?? 0) - (right.sequence_number ?? 0)
+}
+
+export function eventTime(event: SessionEventResponse): number {
+  const time = event.event_at ? Date.parse(event.event_at) : 0
+  return Number.isNaN(time) ? 0 : time
+}
+
+export function payloadRecord(event: SessionEventResponse): Payload {
+  const payload = event.payload
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return {}
+  }
+  return payload as Payload
+}
+
+export function stringValue(payload: Payload, key: string): string {
+  const value = payload[key]
+  return typeof value === "string" ? value : ""
+}
+
+export function stringRecordValue(
+  record: Record<string, unknown>,
+  key: string
+): string {
+  const value = record[key]
+  return typeof value === "string" ? value : ""
+}
+
+export function eventText(event: SessionEventResponse): string {
+  const payload = payloadRecord(event)
+  return (
+    stringValue(payload, "text") ||
+    stringValue(payload, "message") ||
+    stringValue(payload, "content") ||
+    stringValue(payload, "markdown") ||
+    stringValue(payload, "result_summary")
+  )
+}
+
+export function eventTurnID(event: SessionEventResponse): string {
+  return stringValue(payloadRecord(event), "turn_id")
+}
+
+export function stripAttachmentTags(text: string): string {
+  return text.replace(/<attachment\b[\s\S]*?<\/attachment>/gi, "").trim()
+}
+
+export function parseTimestamp(value: string): number | undefined {
+  if (!value) return undefined
+  const time = Date.parse(value)
+  return Number.isNaN(time) ? undefined : time
+}
+
+export function durationBetween(startedAt: string, endedAt: string) {
+  if (!startedAt || !endedAt) return undefined
+  const started = Date.parse(startedAt)
+  const ended = Date.parse(endedAt)
+  if (Number.isNaN(started) || Number.isNaN(ended) || ended < started) {
+    return undefined
+  }
+  return ended - started
+}
+
+export function formatDuration(durationMs: number): string {
+  if (durationMs < 1000) {
+    return `${Math.max(0.1, Math.round(durationMs / 100) / 10)} seconds`
+  }
+  if (durationMs < 60_000) {
+    const seconds = Math.round(durationMs / 1000)
+    return seconds === 1 ? "1 second" : `${seconds} seconds`
+  }
+  if (durationMs < 3_600_000) {
+    const totalSeconds = Math.round(durationMs / 1000)
+    const minutes = Math.floor(totalSeconds / 60)
+    const seconds = totalSeconds % 60
+    return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`
+  }
+  const totalMinutes = Math.round(durationMs / 60_000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`
+}

--- a/apps/web/app/w/(chat)/_lib/session-history.test.ts
+++ b/apps/web/app/w/(chat)/_lib/session-history.test.ts
@@ -920,6 +920,52 @@ Primary category: Product UI
     ])
   })
 
+  it("keeps earlier progress tokens that match final text", () => {
+    const blocks = sessionEventsToConversationBlocks([
+      event("turn_started", { turn_id: "turn-repeated-token" }),
+      event("thinking", {
+        text: "Checking",
+        turn_id: "turn-repeated-token",
+      }),
+      event("tool_result", {
+        id: "tool-repeated-token",
+        tool: "bash",
+        result: { command: "true", output: "" },
+        turn_id: "turn-repeated-token",
+      }),
+      event("token", {
+        text: "Done.",
+        turn_id: "turn-repeated-token",
+      }),
+      event("token", {
+        text: "More context.",
+        turn_id: "turn-repeated-token",
+      }),
+      event("token", {
+        text: "Done.",
+        turn_id: "turn-repeated-token",
+      }),
+      event("final", {
+        text: "Done.",
+        turn_id: "turn-repeated-token",
+      }),
+    ])
+
+    expect(blocks).toMatchObject([
+      {
+        type: "worklog",
+        blocks: [
+          { type: "thinking", text: "Checking" },
+          { type: "tool" },
+          { type: "assistant", text: "Done." },
+          { type: "assistant", text: "More context." },
+        ],
+      },
+      { type: "assistant", text: "Done." },
+      { type: "actions" },
+    ])
+  })
+
   it("renders standalone thought, not a worklog, for completed turns without tool calls", () => {
     const blocks = sessionEventsToConversationBlocks([
       event("turn_started", { turn_id: "turn-no-tools" }),

--- a/apps/web/app/w/(chat)/_lib/session-history.test.ts
+++ b/apps/web/app/w/(chat)/_lib/session-history.test.ts
@@ -39,6 +39,28 @@ describe("sessionEventsToConversationBlocks", () => {
     expect(events).toEqual([first, duplicate, oldest])
   })
 
+  it("dedupes live and persisted copies of the same runtime event", () => {
+    const persisted = {
+      ...event("thinking", {
+        text: "shared",
+        turn_id: "turn-page",
+      }),
+      id: "db-event-id",
+      event_id: "runtime-event-id",
+    }
+    const live = {
+      ...persisted,
+      id: "runtime-event-id",
+    }
+
+    const events = sessionHistoryPagesToEvents([
+      { data: [persisted] },
+      { data: [live] },
+    ])
+
+    expect(events).toEqual([persisted])
+  })
+
   it("keeps visible block keys stable when older history is prepended", () => {
     const current = event("final", {
       text: "Visible answer",
@@ -803,6 +825,98 @@ Primary category: Product UI
         text: "Still working",
         streaming: true,
       },
+    ])
+  })
+
+  it("keeps active turn progress inside one worklog until a final signal", () => {
+    const blocks = sessionEventsToConversationBlocks(
+      [
+        event("turn_started", { turn_id: "turn-active" }),
+        event("thinking", {
+          text: "Looking around",
+          turn_id: "turn-active",
+        }),
+        event("token", {
+          text: "Let me inspect the workspace first.",
+          turn_id: "turn-active",
+        }),
+        event("tool_result", {
+          id: "tool-active",
+          tool: "bash",
+          result: { command: "ls", output: "repos" },
+          turn_id: "turn-active",
+        }),
+        event("thinking", {
+          text: "Checking the result",
+          turn_id: "turn-active",
+        }),
+      ],
+      { activeTurnID: "turn-active" }
+    )
+
+    expect(blocks).toMatchObject([
+      {
+        type: "worklog",
+        active: true,
+        defaultExpanded: true,
+        blocks: [
+          { type: "thinking", text: "Looking around" },
+          {
+            type: "assistant",
+            text: "Let me inspect the workspace first.",
+            streaming: true,
+          },
+          { type: "tool" },
+          { type: "thinking", text: "Checking the result" },
+        ],
+      },
+    ])
+    expect(blocks.some((block) => block.type === "actions")).toBe(false)
+  })
+
+  it("shows actions only after the active turn emits a final answer", () => {
+    const blocks = sessionEventsToConversationBlocks(
+      [
+        event("turn_started", { turn_id: "turn-active-final" }),
+        event("thinking", {
+          text: "Looking around",
+          turn_id: "turn-active-final",
+        }),
+        event("token", {
+          text: "Let me inspect the workspace first.",
+          turn_id: "turn-active-final",
+        }),
+        event("tool_result", {
+          id: "tool-active-final",
+          tool: "bash",
+          result: { command: "ls", output: "repos" },
+          turn_id: "turn-active-final",
+        }),
+        event("final", {
+          text: "The workspace is ready.",
+          turn_id: "turn-active-final",
+        }),
+      ],
+      { activeTurnID: "turn-active-final" }
+    )
+
+    expect(blocks).toMatchObject([
+      {
+        type: "worklog",
+        active: false,
+        defaultExpanded: false,
+        blocks: [
+          { type: "thinking", text: "Looking around" },
+          {
+            type: "assistant",
+            text: "Let me inspect the workspace first.",
+            streaming: false,
+          },
+          { type: "tool" },
+        ],
+      },
+      { type: "assistant", text: "The workspace is ready." },
+      { type: "actions" },
     ])
   })
 

--- a/apps/web/app/w/(chat)/_lib/session-history.ts
+++ b/apps/web/app/w/(chat)/_lib/session-history.ts
@@ -20,6 +20,11 @@ type SessionHistoryPage = {
 }
 type SessionBlocksMode = "history" | "live"
 type TimelineRole = "work" | "final" | "standalone"
+type SessionBlocksOptions = {
+  mode?: SessionBlocksMode
+  activeTurnID?: string
+  activeTurnStartedAt?: string
+}
 
 interface TimelineItem {
   block: ConversationBlock
@@ -50,11 +55,11 @@ export function sessionHistoryPagesToEvents(
 
   for (const page of pages) {
     for (const event of page.data ?? []) {
-      const key = event.id ?? event.event_id
-      if (key) {
-        if (seen.has(key)) continue
-        seen.add(key)
-      }
+      const keys = [event.id, event.event_id].filter((key): key is string =>
+        Boolean(key)
+      )
+      if (keys.some((key) => seen.has(key))) continue
+      for (const key of keys) seen.add(key)
       events.push(event)
     }
   }
@@ -64,12 +69,13 @@ export function sessionHistoryPagesToEvents(
 
 export function sessionEventsToConversationBlocks(
   events: SessionEventResponse[],
-  options: { mode?: SessionBlocksMode } = {}
+  options: SessionBlocksOptions = {}
 ): ConversationBlock[] {
   const mode = options.mode ?? "history"
   const ordered = [...events].sort(compareSessionEvents)
   const finalTurns = new Set<string>()
-  const lastTokenEventByTurn = new Map<string, string>()
+  const finalTextByTurn = new Map<string, string>()
+  const thinkingTurns = new Set<string>()
   const toolTurns = new Set<string>()
   const turnInfoByID = new Map<string, TurnInfo>()
 
@@ -77,17 +83,19 @@ export function sessionEventsToConversationBlocks(
     const turn = eventTurnID(event)
     if (!turn) continue
     captureTurnInfo(turnInfoByID, turn, event)
-    if (event.event_type === "final" && eventText(event)) finalTurns.add(turn)
+    if (event.event_type === "final" && eventText(event)) {
+      finalTurns.add(turn)
+      finalTextByTurn.set(turn, eventText(event))
+    }
+    if (event.event_type === "thinking") thinkingTurns.add(turn)
     if (
       event.event_type === "tool_call" ||
       event.event_type === "tool_result"
     ) {
       toolTurns.add(turn)
     }
-    if (event.event_type === "token" && eventText(event)) {
-      lastTokenEventByTurn.set(turn, event.id ?? event.event_id ?? "")
-    }
   }
+  seedActiveTurnInfo(turnInfoByID, options)
 
   const items: TimelineItem[] = []
   const toolBlockIndexByID = new Map<string, number>()
@@ -124,9 +132,10 @@ export function sessionEventsToConversationBlocks(
       const text = eventText(event).trim()
       const turn = eventTurnID(event)
       const hasTool = Boolean(turn && toolTurns.has(turn))
+      const eventMode = turnMode(turn, mode, finalTurns, options)
       items.push({
-        block: thinkingBlock(event, text, mode),
-        role: hasTool ? "work" : "standalone",
+        block: thinkingBlock(event, text, eventMode),
+        role: hasTool || eventMode === "live" ? "work" : "standalone",
         turnID: turn,
         at: eventTime(event),
       })
@@ -186,27 +195,42 @@ export function sessionEventsToConversationBlocks(
     if (type === "token") {
       const turn = eventTurnID(event)
       const hasTool = Boolean(turn && toolTurns.has(turn))
-      const tokenID = event.id ?? event.event_id ?? ""
+      const hasWork = hasTool || Boolean(turn && thinkingTurns.has(turn))
+      const eventMode = turnMode(turn, mode, finalTurns, options)
       if (turn && finalTurns.has(turn) && !hasTool) continue
       if (
         turn &&
         hasTool &&
         finalTurns.has(turn) &&
-        lastTokenEventByTurn.get(turn) === tokenID
+        finalTextByTurn.get(turn)?.trim() === eventText(event).trim()
       ) {
         continue
       }
       appendAssistantItem(
         items,
         eventText(event),
-        mode,
-        hasTool && (mode === "live" || finalTurns.has(turn)) ? "work" : "final",
+        eventMode,
+        (eventMode === "live" && hasWork) || (hasTool && finalTurns.has(turn))
+          ? "work"
+          : "final",
         event
       )
     }
   }
 
-  return buildConversationBlocks(items, turnInfoByID, mode)
+  return buildConversationBlocks(items, turnInfoByID, mode, options)
+}
+
+function turnMode(
+  turnID: string,
+  mode: SessionBlocksMode,
+  finalTurns: Set<string>,
+  options: SessionBlocksOptions
+): SessionBlocksMode {
+  if (!turnID || !options.activeTurnID || turnID !== options.activeTurnID) {
+    return mode
+  }
+  return finalTurns.has(turnID) ? "history" : "live"
 }
 
 function appendAssistantItem(
@@ -234,7 +258,8 @@ function appendAssistantItem(
 function buildConversationBlocks(
   items: TimelineItem[],
   turnInfoByID: Map<string, TurnInfo>,
-  mode: SessionBlocksMode
+  mode: SessionBlocksMode,
+  options: SessionBlocksOptions
 ): ConversationBlock[] {
   const blocks: ConversationBlock[] = []
   let workTurnID: string | undefined
@@ -245,9 +270,14 @@ function buildConversationBlocks(
     const hasPendingWork = workItems.some(
       (item) => item.block.type === "thinking" && item.block.active
     )
+    const hasActiveTurnWork = Boolean(
+      !completed && workTurnID && workTurnID === options.activeTurnID
+    )
+    const shouldShowActiveWork =
+      hasPendingWork || hasActiveTurnWork || (!completed && mode === "live")
     const workBlocks = resolveLiveThinkingState(
       workItems.map((item) => item.block),
-      hasPendingWork || (!completed && mode === "live")
+      shouldShowActiveWork
     )
     blocks.push({
       type: "worklog",
@@ -255,8 +285,8 @@ function buildConversationBlocks(
       duration: workDuration(workTurnID, workItems, turnInfoByID),
       startedAt: workStartedAt(workTurnID, workItems, turnInfoByID),
       blocks: workBlocks,
-      active: hasPendingWork || (!completed && mode === "live"),
-      defaultExpanded: hasPendingWork || (!completed && mode === "live"),
+      active: shouldShowActiveWork,
+      defaultExpanded: shouldShowActiveWork,
     })
     workItems = []
     workTurnID = undefined
@@ -277,7 +307,8 @@ function buildConversationBlocks(
     if (
       item.role === "final" &&
       mode !== "live" &&
-      item.block.type === "assistant"
+      item.block.type === "assistant" &&
+      !item.block.streaming
     )
       blocks.push({
         type: "actions",
@@ -438,8 +469,24 @@ function captureTurnInfo(
   infoByID.set(turnID, info)
 }
 
+function seedActiveTurnInfo(
+  infoByID: Map<string, TurnInfo>,
+  options: SessionBlocksOptions
+) {
+  if (!options.activeTurnID || !options.activeTurnStartedAt) return
+  const startedAt = parseTimestamp(options.activeTurnStartedAt)
+  if (startedAt === undefined) return
+  const info = infoByID.get(options.activeTurnID) ?? {}
+  if (info.startedAt === undefined) info.startedAt = startedAt
+  infoByID.set(options.activeTurnID, info)
+}
+
 function timestampValue(payload: Payload, key: string): number | undefined {
   const value = stringValue(payload, key)
+  return parseTimestamp(value)
+}
+
+function parseTimestamp(value: string): number | undefined {
   if (!value) return undefined
   const time = Date.parse(value)
   return Number.isNaN(time) ? undefined : time

--- a/apps/web/app/w/(chat)/_lib/session-history.ts
+++ b/apps/web/app/w/(chat)/_lib/session-history.ts
@@ -89,6 +89,7 @@ export function sessionEventsToConversationBlocks(
   const finalTurns = new Set<string>()
   const finalTextByTurn = new Map<string, string>()
   const thinkingTurns = new Set<string>()
+  const lastTokenEventByTurn = new Map<string, SessionEventResponse>()
   const toolTurns = new Set<string>()
   const turnInfoByID = new Map<string, TurnInfo>()
 
@@ -101,6 +102,9 @@ export function sessionEventsToConversationBlocks(
       finalTextByTurn.set(turn, eventText(event))
     }
     if (event.event_type === "thinking") thinkingTurns.add(turn)
+    if (event.event_type === "token" && eventText(event)) {
+      lastTokenEventByTurn.set(turn, event)
+    }
     if (
       event.event_type === "tool_call" ||
       event.event_type === "tool_result"
@@ -215,6 +219,7 @@ export function sessionEventsToConversationBlocks(
         turn &&
         hasTool &&
         finalTurns.has(turn) &&
+        lastTokenEventByTurn.get(turn) === event &&
         finalTextByTurn.get(turn)?.trim() === eventText(event).trim()
       ) {
         continue

--- a/apps/web/app/w/(chat)/_lib/session-history.ts
+++ b/apps/web/app/w/(chat)/_lib/session-history.ts
@@ -1,4 +1,3 @@
-import type { components } from "@/lib/api/schema"
 import {
   currentCollaborator,
   type ConversationBlock,
@@ -11,10 +10,24 @@ import {
   toolEventID,
 } from "@/app/w/(chat)/_lib/session-tools"
 import { codeLineCommentReferenceFromPayload } from "@/app/w/(chat)/_lib/code-line-comments"
+import {
+  compareSessionEvents,
+  durationBetween,
+  eventText,
+  eventTime,
+  eventTurnID,
+  formatDuration,
+  parseTimestamp,
+  payloadRecord,
+  stringRecordValue,
+  stringValue,
+  stripAttachmentTags,
+  type Payload,
+  type SessionEventResponse,
+} from "@/app/w/(chat)/_lib/session-history-event-utils"
 
-export type SessionEventResponse = components["schemas"]["sessionEventResponse"]
+export type { SessionEventResponse } from "@/app/w/(chat)/_lib/session-history-event-utils"
 
-type Payload = Record<string, unknown>
 type SessionHistoryPage = {
   data?: SessionEventResponse[]
 }
@@ -329,44 +342,6 @@ function worklogBlockKey(turnID: string | undefined, items: TimelineItem[]) {
   return `worklog:${items.map((item) => item.block.key).join("|")}`
 }
 
-function compareSessionEvents(
-  left: SessionEventResponse,
-  right: SessionEventResponse
-) {
-  const byTime = eventTime(left) - eventTime(right)
-  if (byTime !== 0) return byTime
-  return (left.sequence_number ?? 0) - (right.sequence_number ?? 0)
-}
-
-function eventTime(event: SessionEventResponse): number {
-  const time = event.event_at ? Date.parse(event.event_at) : 0
-  return Number.isNaN(time) ? 0 : time
-}
-
-function payloadRecord(event: SessionEventResponse): Payload {
-  const payload = event.payload
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-    return {}
-  }
-  return payload as Payload
-}
-
-function stringValue(payload: Payload, key: string): string {
-  const value = payload[key]
-  return typeof value === "string" ? value : ""
-}
-
-function eventText(event: SessionEventResponse): string {
-  const payload = payloadRecord(event)
-  return (
-    stringValue(payload, "text") ||
-    stringValue(payload, "message") ||
-    stringValue(payload, "content") ||
-    stringValue(payload, "markdown") ||
-    stringValue(payload, "result_summary")
-  )
-}
-
 function eventAttachments(event: SessionEventResponse): MediaAttachment[] {
   const value = payloadRecord(event).attachments
   if (!Array.isArray(value)) return []
@@ -406,22 +381,6 @@ function eventCodeLineComments(event: SessionEventResponse) {
     )
     return comment ? [comment] : []
   })
-}
-
-function stringRecordValue(
-  record: Record<string, unknown>,
-  key: string
-): string {
-  const value = record[key]
-  return typeof value === "string" ? value : ""
-}
-
-function stripAttachmentTags(text: string): string {
-  return text.replace(/<attachment\b[\s\S]*?<\/attachment>/gi, "").trim()
-}
-
-function eventTurnID(event: SessionEventResponse): string {
-  return stringValue(payloadRecord(event), "turn_id")
 }
 
 function clientStatus(
@@ -484,12 +443,6 @@ function seedActiveTurnInfo(
 function timestampValue(payload: Payload, key: string): number | undefined {
   const value = stringValue(payload, key)
   return parseTimestamp(value)
-}
-
-function parseTimestamp(value: string): number | undefined {
-  if (!value) return undefined
-  const time = Date.parse(value)
-  return Number.isNaN(time) ? undefined : time
 }
 
 function workDuration(
@@ -603,34 +556,4 @@ function thoughtDuration(event: SessionEventResponse): string | undefined {
   const durationMs = durationBetween(startedAt, endedAt)
   if (durationMs === undefined) return undefined
   return formatDuration(durationMs)
-}
-
-function durationBetween(startedAt: string, endedAt: string) {
-  if (!startedAt || !endedAt) return undefined
-  const started = Date.parse(startedAt)
-  const ended = Date.parse(endedAt)
-  if (Number.isNaN(started) || Number.isNaN(ended) || ended < started) {
-    return undefined
-  }
-  return ended - started
-}
-
-function formatDuration(durationMs: number): string {
-  if (durationMs < 1000) {
-    return `${Math.max(0.1, Math.round(durationMs / 100) / 10)} seconds`
-  }
-  if (durationMs < 60_000) {
-    const seconds = Math.round(durationMs / 1000)
-    return seconds === 1 ? "1 second" : `${seconds} seconds`
-  }
-  if (durationMs < 3_600_000) {
-    const totalSeconds = Math.round(durationMs / 1000)
-    const minutes = Math.floor(totalSeconds / 60)
-    const seconds = totalSeconds % 60
-    return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`
-  }
-  const totalMinutes = Math.round(durationMs / 60_000)
-  const hours = Math.floor(totalMinutes / 60)
-  const minutes = totalMinutes % 60
-  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`
 }

--- a/apps/web/app/w/(chat)/_stores/session-stream-manager.ts
+++ b/apps/web/app/w/(chat)/_stores/session-stream-manager.ts
@@ -331,7 +331,12 @@ async function refreshSessionQueries(queryClient: QueryClient, sessionId: string
 }
 
 function isTerminalFrame(event: string) {
-  return event === "done" || event === "turn_failed" || event === "error"
+  return (
+    event === "done" ||
+    event === "turn_completed" ||
+    event === "turn_failed" ||
+    event === "error"
+  )
 }
 
 function terminalFrameErrorMessage(data: unknown) {


### PR DESCRIPTION
## Summary

- Merge persisted session history and live stream events before rendering chat transcript blocks so one agent turn cannot split into separate completed-looking groups.
- Make the transcript reducer active-turn aware, keeping thinking/tool/progress tokens inside one worklog until final/terminal lifecycle state is received.
- Treat `turn_completed` as a terminal direct stream frame and carry runtime turn metadata through the chat session view model.
- Add regression coverage for active turn progress, final-only actions, live/persisted event dedupe, and `turn_completed` handling.

## Root Cause

The UI rendered persisted history and live events independently. Persisted partial turn tokens were processed in completed history mode, so a progress text token could be interpreted as a final assistant message. That inserted action icons and flushed the current worklog before the runtime emitted a final or terminal turn signal.

## Validation

- `pnpm test -- session-history live-session-stream`
- `pnpm typecheck`
- `pnpm lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/usehivy/codesmith/hivy/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784559342&installation_id=135752923&pr_number=194&repository=usehivy%2Fhivy&return_to=https%3A%2F%2Fgithub.com%2Fusehivy%2Fhivy%2Fpull%2F194&signature=0772292a7e746208da9aaab2b5c20cea5bf4bb9e7b029697588e2ea1f47dccc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer agent turn metadata (status/ID/start time/outcome) surfaced in chat session details.
  * Improved transcript rendering to unify live and historical updates, keeping in-progress turns grouped and showing “actions” at the correct point.

* **Improvements**
  * Enhanced stream termination handling by treating `turn_completed` as a terminal event.
  * Improved session event de-duplication and more accurate block grouping across active vs completed turns.

* **Tests**
  * Added/expanded unit coverage for terminal frame detection and active-turn transcript behavior (including deduping and action placement).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a rendering bug where a single agent turn could split into multiple completed-looking UI groups by merging persisted history and live stream events into a single deduplicated event list before converting them to conversation blocks, and by threading `activeTurnID` into the transcript reducer so per-turn mode switching (`"live"` vs `"history"`) replaces the old separate-pass approach.

- **Event deduplication** (`session-history.ts`): `sessionHistoryPagesToEvents` now matches events by both `id` and `event_id` simultaneously, so a persisted event (`id="db-id"`, `event_id="rt-id"`) correctly shadows the live copy (`id="rt-id"`) that arrives later in the same page list.
- **Active-turn mode gating** (`session-history.ts`): a new `turnMode` helper returns `"live"` only for events belonging to `activeTurnID` that haven't yet received a `final` event, ensuring thinking/token/tool blocks stay inside one worklog until a terminal signal arrives.
- **Terminal frame update** (`live-session-stream.ts`, `session-stream-manager.ts`): `turn_completed` is now treated as a terminal frame on both the stream-guard and the view-model side, and runtime turn metadata (`agentTurnID`, `agentTurnStartedAt`) is carried through the `ChatSession` view model so `session-view.tsx` can resolve the active turn ID without relying solely on live event payloads.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a pure rendering-path fix with no mutations to persistent state and good regression coverage.

The single-pass merge of persisted and live events is sound: deduplication correctly uses both `id` and `event_id` so a persisted row always wins over its live copy. The per-turn mode switching via `turnMode` is a clean replacement for the old separate-pass approach and keeps all token/thinking/tool blocks inside one worklog until a terminal signal arrives. The `turn_completed` terminal-frame addition is consistent across both `live-session-stream.ts` and `session-stream-manager.ts`. New tests cover the key regression scenarios (dedup, active-turn progress grouping, actions gating, repeated-token preservation). No data mutations, no new network calls, and no shared state is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/app/w/(chat)/_lib/session-history.ts | Core rendering logic refactored: events merged in one pass, `turnMode` helper gates per-event live/history mode, `buildConversationBlocks` updated with `hasActiveTurnWork` guard. Logic is consistent and test-covered. |
| apps/web/app/w/(chat)/_lib/session-history-event-utils.ts | New utility module extracting pure helper functions from session-history.ts; adds `parseTimestamp`, `durationBetween`, and `formatDuration` with correct edge-case handling. |
| apps/web/app/w/(chat)/_components/session-view.tsx | Replaces separate historyBlocks+liveBlocks pipeline with a single combinedEvents → visibleBlocks flow; adds latestTurnID helper and wires agentTurnID/agentTurnStartedAt into block options. |
| apps/web/app/w/(chat)/_lib/live-session-stream.ts | Adds `turn_completed` to `isTerminalStreamFrame`; one-line change, consistent with matching update in session-stream-manager.ts. |
| apps/web/app/w/(chat)/_stores/session-stream-manager.ts | isTerminalFrame updated to include turn_completed, matching the live-session-stream change. |
| apps/web/app/w/(chat)/_components/shell.tsx | Extends ChatSession interface and chatSessionFromResponse to carry agentTurnStatus, agentTurnID, agentTurnStartedAt, lastTurnOutcome from the API response. |
| apps/web/app/w/(chat)/_components/sidebar-channel-group.tsx | Mirrors the same chatSessionFromResponse field additions as shell.tsx for the sidebar channel group context. |
| apps/web/app/w/(chat)/_lib/session-history.test.ts | Adds four new regression tests: live/persisted dedup, active-turn progress grouping, final-only actions placement, and repeated-token content preservation through a final event. |
| apps/web/app/w/(chat)/_lib/live-session-stream.test.ts | Adds one-liner regression test confirming turn_completed is now a terminal stream frame. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[historyPages] -->|sessionHistoryPagesToEvents| B[historyEvents]
    C[liveEvents\nfrom stream] --> D

    B --> D["sessionHistoryPagesToEvents\n[{ data: historyEvents }, { data: liveEvents }]\n— dedupes by id + event_id"]
    D --> E[combinedEvents]

    F["session.agentTurnID\nor latestTurnID(liveEvents)"] -->|turnActive?| G{activeTurnID}
    G -->|yes| H[activeTurnID set]
    G -->|no| I[activeTurnID = undefined]

    E --> J["sessionEventsToConversationBlocks\n(combinedEvents, { activeTurnID })"]
    H --> J
    I --> J

    J --> K["per-event: turnMode()\nreturns 'live' if turn === activeTurnID\nand no final yet;\notherwise 'history'"]

    K -->|live| L["thinking/token/tool\ngrouped into active worklog\nstreaming: true"]
    K -->|history| M["completed worklog\nor standalone block\nstreaming: false"]

    L --> N["buildConversationBlocks\nhasActiveTurnWork → active: true"]
    M --> N

    N --> O[visibleBlocks\nactions block added only\nafter non-streaming final]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[historyPages] -->|sessionHistoryPagesToEvents| B[historyEvents]
    C[liveEvents\nfrom stream] --> D

    B --> D["sessionHistoryPagesToEvents\n[{ data: historyEvents }, { data: liveEvents }]\n— dedupes by id + event_id"]
    D --> E[combinedEvents]

    F["session.agentTurnID\nor latestTurnID(liveEvents)"] -->|turnActive?| G{activeTurnID}
    G -->|yes| H[activeTurnID set]
    G -->|no| I[activeTurnID = undefined]

    E --> J["sessionEventsToConversationBlocks\n(combinedEvents, { activeTurnID })"]
    H --> J
    I --> J

    J --> K["per-event: turnMode()\nreturns 'live' if turn === activeTurnID\nand no final yet;\notherwise 'history'"]

    K -->|live| L["thinking/token/tool\ngrouped into active worklog\nstreaming: true"]
    K -->|history| M["completed worklog\nor standalone block\nstreaming: false"]

    L --> N["buildConversationBlocks\nhasActiveTurnWork → active: true"]
    M --> N

    N --> O[visibleBlocks\nactions block added only\nafter non-streaming final]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address turn worklog review feedback"](https://github.com/usehivy/hivy/commit/31b2ca364b7b7d98d8781dfda102d1fa0a4bd483) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38814466)</sub>

<!-- /greptile_comment -->