### PR TITLE
[codex] direct deliver idle session messages

### DIFF
--- a/internal/agentruntime/session_model.go
+++ b/internal/agentruntime/session_model.go
@@ -1,75 +1,24 @@
 package agentruntime
 
 import (
-	"context"
 	"fmt"
 	"strings"
-
-	"github.com/google/uuid"
 
 	"github.com/usehivy/hivy/internal/model"
 )
 
-func SessionProxyAPIKeyEnv(sessionID uuid.UUID) string {
-	if sessionID == uuid.Nil {
-		return ProxyAPIKeyEnv
-	}
-	return "HIVY_SESSION_" + strings.ReplaceAll(sessionID.String(), "-", "_") + "_PROXY_API_KEY"
-}
-
-func PushAgentRuntimeConfigForSessionModel(
-	ctx context.Context,
+// SessionModelDefinition builds the per-message model override sent with a
+// session message. It must stay side-effect free: hot message delivery should
+// not push runtime config or mint session-scoped runtime env.
+func SessionModelDefinition(
 	deps CompileDeps,
 	agent *model.Agent,
-	sb *model.Sandbox,
-	sessionID uuid.UUID,
 	modelID string,
 	reasoningEffort string,
 ) (*ModelConfig, error) {
-	if deps.EncKey == nil {
-		return nil, fmt.Errorf("agent runtime config push: encryption key is required")
+	if agent == nil {
+		return nil, fmt.Errorf("session model definition: agent is required")
 	}
-	if agent == nil || agent.OrgID == nil {
-		return nil, fmt.Errorf("agent runtime config push: agent must have org_id")
-	}
-	if sb == nil {
-		return nil, fmt.Errorf("agent runtime config push: sandbox is required")
-	}
-	runtimeSecret, err := deps.EncKey.DecryptString(sb.EncryptedRuntimeSecret)
-	if err != nil {
-		return nil, fmt.Errorf("decrypt runtime secret: %w", err)
-	}
-	configUpdate, _, err := BuildAgentRuntimeConfigUpdate(ctx, deps, agent, sb, runtimeSecret)
-	if err != nil {
-		return nil, fmt.Errorf("build agent runtime config: %w", err)
-	}
-	sessionModel, err := addSessionModelProxyToken(ctx, deps, agent, sb, sessionID, modelID, reasoningEffort, configUpdate.RuntimeEnv)
-	if err != nil {
-		return nil, err
-	}
-	client := NewClient(sb.RuntimeURL, runtimeSecret)
-	if err := client.Healthz(ctx); err != nil {
-		return nil, fmt.Errorf("agent runtime healthz: %w", err)
-	}
-	if _, err := client.PutRuntimeConfig(ctx, configUpdate); err != nil {
-		return nil, fmt.Errorf("agent runtime put config: %w", err)
-	}
-	if err := client.Readyz(ctx); err != nil {
-		return nil, fmt.Errorf("agent runtime readyz: %w", err)
-	}
-	return &sessionModel, nil
-}
-
-func addSessionModelProxyToken(
-	ctx context.Context,
-	deps CompileDeps,
-	agent *model.Agent,
-	sb *model.Sandbox,
-	sessionID uuid.UUID,
-	modelID string,
-	reasoningEffort string,
-	env map[string]string,
-) (ModelConfig, error) {
 	modelID = strings.TrimSpace(modelID)
 	if modelID == "" {
 		modelID = strings.TrimSpace(agent.Model)
@@ -78,28 +27,6 @@ func addSessionModelProxyToken(
 		modelID = DefaultAgentModel
 	}
 	sessionModel := ProxyModelConfig(deps.Cfg, modelID, reasoningEffort)
-	baseModel := strings.TrimSpace(agent.Model)
-	if baseModel == "" {
-		baseModel = DefaultAgentModel
-	}
-	if modelID == baseModel {
-		return sessionModel, nil
-	}
-	tokenAgent := *agent
-	tokenAgent.Model = modelID
-	sandboxID := uuid.Nil
-	if sb != nil {
-		sandboxID = sb.ID
-	}
-	token, err := MintProxyToken(ctx, deps, &tokenAgent, sandboxID)
-	if err != nil {
-		return ModelConfig{}, err
-	}
-	envKey := SessionProxyAPIKeyEnv(sessionID)
-	if envKey == ProxyAPIKeyEnv {
-		return ModelConfig{}, fmt.Errorf("session proxy api key env requires a session id")
-	}
-	env[envKey] = token.Token
-	sessionModel.APIKeyEnv = envKey
-	return sessionModel, nil
+	sessionModel.APIKeyEnv = ProxyAPIKeyEnv
+	return &sessionModel, nil
 }

--- a/internal/handler/sessions.go
+++ b/internal/handler/sessions.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"context"
-	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -19,7 +17,6 @@ import (
 	"github.com/usehivy/hivy/internal/registry"
 	"github.com/usehivy/hivy/internal/sandbox"
 	"github.com/usehivy/hivy/internal/storage"
-	"github.com/usehivy/hivy/internal/tasks"
 	"github.com/usehivy/hivy/internal/transcription"
 )
 
@@ -100,20 +97,6 @@ func (h *SessionHandler) WithTranscription(kms *crypto.KeyWrapper, reader storag
 	}
 	h.transcriptionRegistry = reg
 	return h
-}
-
-func (h *SessionHandler) dispatchOrQueueSessionDelivery(ctx context.Context, sessionID uuid.UUID) (bool, error) {
-	if h.orchestrator != nil && h.compileDeps.EncKey != nil {
-		dispatcher := tasks.NewSessionMessageDeliverHandler(h.db, h.orchestrator, h.compileDeps, h.enqueuer).WithoutProvisioning()
-		if _, err := dispatcher.DispatchNext(ctx, sessionID); err == nil {
-			return false, nil
-		} else if errors.Is(err, tasks.ErrSessionTurnActive) {
-			return true, nil
-		} else if !errors.Is(err, tasks.ErrSessionRuntimeNotReady) && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return true, h.enqueueSessionDelivery(ctx, sessionID)
-		}
-	}
-	return true, h.enqueueSessionDelivery(ctx, sessionID)
 }
 
 type createSessionRequest struct {

--- a/internal/handler/sessions_create.go
+++ b/internal/handler/sessions_create.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -81,26 +80,7 @@ func (h *SessionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		perSessionSandbox = sb
 		session.SandboxID = &sb.ID
 	}
-	var event model.SessionEvent
-	err := h.db.WithContext(r.Context()).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Create(&session).Error; err != nil {
-			return err
-		}
-		if userID != nil {
-			now := time.Now()
-			if err := tx.Create(&model.SessionParticipant{
-				SessionID: session.ID,
-				UserID:    *userID,
-				Role:      "owner",
-				JoinedAt:  &now,
-			}).Error; err != nil {
-				return err
-			}
-		}
-		var err error
-		event, err = h.createUserMessageEvent(tx, &session, userID, text, raw)
-		return err
-	})
+	intent, err := h.createInitialSessionMessageIntent(r.Context(), &session, userID, text, raw)
 	if err != nil {
 		if perSessionSandbox != nil {
 			h.cleanupFailedPerSessionCreate(r.Context(), session.ID, perSessionSandbox)
@@ -108,24 +88,23 @@ func (h *SessionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to create session"})
 		return
 	}
-	queued := false
-	if agent.SandboxStrategy == agentStrategyPerSession {
-		if err := h.dispatchInitialPerSessionDelivery(r.Context(), session.ID); err != nil {
+	queued, err := h.dispatchSessionMessageIntent(r.Context(), intent)
+	if err != nil {
+		if agent.SandboxStrategy == agentStrategyPerSession {
 			h.cleanupFailedPerSessionCreate(r.Context(), session.ID, perSessionSandbox)
 			logging.FromContext(r.Context()).ErrorContext(r.Context(), "send initial per-session message failed", "session_id", session.ID, "agent_id", agent.ID, "error", err)
 			logging.Capture(r.Context(), err)
 			writeJSON(w, http.StatusBadGateway, errorResponse{Error: "failed to send initial session message"})
 			return
 		}
+		logging.FromContext(r.Context()).ErrorContext(r.Context(), "send initial session message failed", "session_id", session.ID, "agent_id", agent.ID, "error", err)
+		logging.Capture(r.Context(), err)
+		writeJSON(w, http.StatusBadGateway, errorResponse{Error: "failed to send initial session message"})
+		return
+	}
+	if !queued {
 		if err := h.db.WithContext(r.Context()).First(&session, "id = ?", session.ID).Error; err != nil {
-			logging.FromContext(r.Context()).WarnContext(r.Context(), "reload per-session session after initial delivery failed", "session_id", session.ID, "error", err)
-		}
-	} else {
-		var err error
-		queued, err = h.dispatchOrQueueSessionDelivery(r.Context(), session.ID)
-		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to queue session delivery"})
-			return
+			logging.FromContext(r.Context()).WarnContext(r.Context(), "reload session after initial delivery failed", "session_id", session.ID, "error", err)
 		}
 	}
 	if strings.TrimSpace(req.Name) == "" {
@@ -136,7 +115,7 @@ func (h *SessionHandler) Create(w http.ResponseWriter, r *http.Request) {
 	stats := h.statsForSessions(r.Context(), []uuid.UUID{session.ID})[session.ID]
 	writeJSON(w, http.StatusCreated, sessionMutationResponse{
 		Session: sessionToResponse(session, stats.ParticipantCount, stats.EventCount, stats.LastEvent),
-		Event:   ptrSessionEventResponse(eventToResponse(event)),
+		Event:   ptrSessionEventResponse(eventToResponse(intent.Event)),
 		Queued:  queued,
 	})
 }

--- a/internal/handler/sessions_data.go
+++ b/internal/handler/sessions_data.go
@@ -116,17 +116,27 @@ func (h *SessionHandler) createUserMessageEvent(tx *gorm.DB, session *model.Sess
 	if err := tx.Create(&event).Error; err != nil {
 		return model.SessionEvent{}, err
 	}
+	return event, nil
+}
+
+func (h *SessionHandler) enqueueSessionMessageEvent(tx *gorm.DB, session *model.Session, event model.SessionEvent) error {
+	if session == nil || session.ID == uuid.Nil {
+		return fmt.Errorf("session message queue: session is required")
+	}
+	if event.ID == uuid.Nil {
+		return fmt.Errorf("session message queue: event is required")
+	}
 	queue := model.SessionMessageQueue{
 		OrgID:          session.OrgID,
 		SessionID:      session.ID,
 		SessionEventID: event.ID,
-		SequenceNumber: seq,
+		SequenceNumber: event.SequenceNumber,
 		Status:         "pending",
 	}
 	if err := tx.Create(&queue).Error; err != nil {
-		return model.SessionEvent{}, err
+		return fmt.Errorf("create session message queue row: %w", err)
 	}
-	return event, nil
+	return nil
 }
 
 func (h *SessionHandler) nextSessionSequence(tx *gorm.DB, sessionID uuid.UUID) (int64, error) {

--- a/internal/handler/sessions_delivery.go
+++ b/internal/handler/sessions_delivery.go
@@ -1,0 +1,193 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/usehivy/hivy/internal/agentruntime"
+	"github.com/usehivy/hivy/internal/model"
+	"github.com/usehivy/hivy/internal/tasks"
+)
+
+type sessionMessageDeliveryIntent struct {
+	Session       model.Session
+	Event         model.SessionEvent
+	Queued        bool
+	DispatchQueue bool
+}
+
+type sessionMessageDeliveryOptions struct {
+	Model             string
+	ReasoningEffort   string
+	ClearLastOutcome  bool
+	BeforeUserMessage func(*gorm.DB, *model.Session) error
+}
+
+func (h *SessionHandler) runtimeDeliveryConfigured() bool {
+	return h != nil && h.orchestrator != nil && h.compileDeps.EncKey != nil
+}
+
+func (h *SessionHandler) createInitialSessionMessageIntent(ctx context.Context, session *model.Session, userID *uuid.UUID, text string, payload model.JSON) (sessionMessageDeliveryIntent, error) {
+	if session == nil || session.ID == uuid.Nil {
+		return sessionMessageDeliveryIntent{}, fmt.Errorf("session is required")
+	}
+	direct := h.runtimeDeliveryConfigured()
+	if direct {
+		markSessionTurnStarting(session, time.Now())
+	}
+	var event model.SessionEvent
+	err := h.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(session).Error; err != nil {
+			return err
+		}
+		if userID != nil {
+			now := time.Now()
+			if err := tx.Create(&model.SessionParticipant{
+				SessionID: session.ID,
+				UserID:    *userID,
+				Role:      "owner",
+				JoinedAt:  &now,
+			}).Error; err != nil {
+				return err
+			}
+		}
+		var err error
+		event, err = h.createUserMessageEvent(tx, session, userID, text, payload)
+		if err != nil {
+			return err
+		}
+		if !direct {
+			return h.enqueueSessionMessageEvent(tx, session, event)
+		}
+		return nil
+	})
+	if err != nil {
+		return sessionMessageDeliveryIntent{}, err
+	}
+	return sessionMessageDeliveryIntent{
+		Session:       *session,
+		Event:         event,
+		Queued:        !direct,
+		DispatchQueue: !direct,
+	}, nil
+}
+
+func (h *SessionHandler) createSessionMessageIntent(ctx context.Context, base model.Session, actor *uuid.UUID, text string, payload model.JSON, opts sessionMessageDeliveryOptions) (sessionMessageDeliveryIntent, error) {
+	var intent sessionMessageDeliveryIntent
+	err := h.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var session model.Session
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", base.ID).
+			First(&session).Error; err != nil {
+			return fmt.Errorf("lock session for message delivery: %w", err)
+		}
+		if opts.BeforeUserMessage != nil {
+			if err := opts.BeforeUserMessage(tx, &session); err != nil {
+				return err
+			}
+		}
+		event, err := h.createUserMessageEvent(tx, &session, actor, text, payload)
+		if err != nil {
+			return err
+		}
+
+		updates := map[string]any{"updated_at": event.EventAt}
+		session.UpdatedAt = event.EventAt
+		if strings.TrimSpace(opts.Model) != "" {
+			updates["model"] = strings.TrimSpace(opts.Model)
+			updates["reasoning_effort"] = strings.TrimSpace(opts.ReasoningEffort)
+			session.Model = strings.TrimSpace(opts.Model)
+			session.ReasoningEffort = strings.TrimSpace(opts.ReasoningEffort)
+		}
+		if opts.ClearLastOutcome {
+			updates["agent_turn_last_outcome"] = ""
+			session.AgentTurnLastOutcome = ""
+		}
+
+		queued := session.AgentTurnStatus == model.SessionAgentTurnActive || !h.runtimeDeliveryConfigured()
+		if queued {
+			if err := h.enqueueSessionMessageEvent(tx, &session, event); err != nil {
+				return err
+			}
+		} else {
+			startedAt := time.Now()
+			updates["agent_turn_status"] = model.SessionAgentTurnActive
+			updates["agent_turn_id"] = ""
+			updates["agent_stream_id"] = ""
+			updates["agent_turn_started_at"] = startedAt
+			updates["agent_turn_last_outcome"] = ""
+			markSessionTurnStarting(&session, startedAt)
+		}
+
+		if err := tx.Model(&model.Session{}).Where("id = ?", session.ID).Updates(updates).Error; err != nil {
+			return fmt.Errorf("update session message state: %w", err)
+		}
+		intent = sessionMessageDeliveryIntent{
+			Session:       session,
+			Event:         event,
+			Queued:        queued,
+			DispatchQueue: queued && session.AgentTurnStatus != model.SessionAgentTurnActive,
+		}
+		return nil
+	})
+	return intent, err
+}
+
+func markSessionTurnStarting(session *model.Session, startedAt time.Time) {
+	session.AgentTurnStatus = model.SessionAgentTurnActive
+	session.AgentTurnID = ""
+	session.AgentStreamID = ""
+	session.AgentTurnStartedAt = &startedAt
+	session.AgentTurnLastOutcome = ""
+}
+
+func (h *SessionHandler) dispatchSessionMessageIntent(ctx context.Context, intent sessionMessageDeliveryIntent) (bool, error) {
+	if intent.Queued {
+		if intent.DispatchQueue {
+			return true, h.enqueueSessionDelivery(ctx, intent.Session.ID)
+		}
+		return true, nil
+	}
+	dispatcher := tasks.NewSessionMessageDeliverHandler(h.db, h.orchestrator, h.compileDeps, h.enqueuer).WithoutProvisioning()
+	delivery, err := dispatcher.DeliverEvent(ctx, intent.Session, intent.Event)
+	if err != nil {
+		_ = h.releaseDirectSessionTurn(context.WithoutCancel(ctx), intent.Session.ID)
+		return false, err
+	}
+	if err := h.recordDirectSessionDelivery(ctx, intent.Session.ID, delivery); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func (h *SessionHandler) recordDirectSessionDelivery(ctx context.Context, sessionID uuid.UUID, delivery *agentruntime.HTTPMessageResponse) error {
+	updates := map[string]any{
+		"agent_turn_status":       model.SessionAgentTurnActive,
+		"agent_turn_last_outcome": "",
+	}
+	if delivery != nil {
+		updates["agent_turn_id"] = strings.TrimSpace(delivery.TurnID)
+		updates["agent_stream_id"] = strings.TrimSpace(delivery.StreamID)
+	}
+	return h.db.WithContext(ctx).Model(&model.Session{}).
+		Where("id = ?", sessionID).
+		Updates(updates).Error
+}
+
+func (h *SessionHandler) releaseDirectSessionTurn(ctx context.Context, sessionID uuid.UUID) error {
+	return h.db.WithContext(ctx).Model(&model.Session{}).
+		Where("id = ?", sessionID).
+		Updates(map[string]any{
+			"agent_turn_status":       model.SessionAgentTurnIdle,
+			"agent_turn_id":           "",
+			"agent_stream_id":         "",
+			"agent_turn_started_at":   nil,
+			"agent_turn_last_outcome": model.SessionAgentTurnOutcomeFailed,
+		}).Error
+}

--- a/internal/handler/sessions_direct_delivery_test.go
+++ b/internal/handler/sessions_direct_delivery_test.go
@@ -1,0 +1,188 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/usehivy/hivy/internal/agentruntime"
+	"github.com/usehivy/hivy/internal/model"
+	"github.com/usehivy/hivy/internal/tasks"
+)
+
+func TestIntegration_SessionsCreate_AlwaysOnSendsFirstMessageDirectWithoutQueueOrConfig(t *testing.T) {
+	runtime := newSessionSyncRuntime(t, http.StatusOK)
+	h, _ := newSessionRuntimeHarness(t, runtime, nil)
+	fx := h.seed(t)
+	sb := seedAlwaysOnRuntimeSandbox(t, h, fx, runtime.server.URL, "running")
+
+	out := h.createSession(t, fx, fx.owner, "Ship the always-on hot path")
+	if out.Queued {
+		t.Fatalf("queued=%t, want false for idle always-on session", out.Queued)
+	}
+	if out.Session.SandboxID == nil || *out.Session.SandboxID != sb.ID.String() {
+		t.Fatalf("session sandbox_id=%v, want %s", out.Session.SandboxID, sb.ID)
+	}
+	if out.Session.AgentTurnStatus != model.SessionAgentTurnActive || out.Session.AgentTurnID == "" || out.Session.AgentStreamID == "" {
+		t.Fatalf("session turn metadata missing: %+v", out.Session)
+	}
+	if runtime.messageCalls != 1 || runtime.lastMessageText != "Ship the always-on hot path" {
+		t.Fatalf("runtime message calls=%d text=%q", runtime.messageCalls, runtime.lastMessageText)
+	}
+	if runtime.configCalls != 0 {
+		t.Fatalf("runtime config calls=%d, want 0 for hot first message", runtime.configCalls)
+	}
+	if runtime.lastAPIKeyEnv != agentruntime.ProxyAPIKeyEnv {
+		t.Fatalf("runtime message api_key_env=%q, want %q", runtime.lastAPIKeyEnv, agentruntime.ProxyAPIKeyEnv)
+	}
+	assertSessionQueueCount(t, h, out.Session.ID, 0)
+	assertNoSessionMessageDeliverTask(t, h)
+}
+
+func TestIntegration_SessionsSend_IdleSessionDirectSendsWithoutQueueOrConfig(t *testing.T) {
+	runtime := newSessionSyncRuntime(t, http.StatusOK)
+	h, _ := newSessionRuntimeHarness(t, runtime, nil)
+	fx := h.seed(t)
+	seedAlwaysOnRuntimeSandbox(t, h, fx, runtime.server.URL, "running")
+	created := h.createSession(t, fx, fx.owner, "First direct turn")
+	releaseSessionForNextUserTurn(t, h, created.Session.ID)
+
+	msg := h.doJSON(t, http.MethodPost, "/v1/sessions/"+created.Session.ID+"/messages", fx, fx.owner, map[string]any{
+		"text": "Second direct turn",
+	})
+	if msg.Code != http.StatusAccepted {
+		t.Fatalf("message status=%d body=%s", msg.Code, msg.Body.String())
+	}
+	out := decodeSessionMutation(t, msg)
+	if out.Queued {
+		t.Fatalf("queued=%t, want false for idle session", out.Queued)
+	}
+	if out.Session.AgentTurnStatus != model.SessionAgentTurnActive || out.Session.AgentTurnID == "" || out.Session.AgentStreamID == "" {
+		t.Fatalf("session turn metadata missing: %+v", out.Session)
+	}
+	if runtime.messageCalls != 2 || runtime.lastMessageText != "Second direct turn" {
+		t.Fatalf("runtime message calls=%d text=%q", runtime.messageCalls, runtime.lastMessageText)
+	}
+	if runtime.configCalls != 0 {
+		t.Fatalf("runtime config calls=%d, want 0 for idle direct send", runtime.configCalls)
+	}
+	assertSessionQueueCount(t, h, created.Session.ID, 0)
+}
+
+func TestIntegration_SessionsSend_ActiveSessionQueuesWithoutRuntimeCallOrConfig(t *testing.T) {
+	runtime := newSessionSyncRuntime(t, http.StatusOK)
+	h, _ := newSessionRuntimeHarness(t, runtime, nil)
+	fx := h.seed(t)
+	seedAlwaysOnRuntimeSandbox(t, h, fx, runtime.server.URL, "running")
+	created := h.createSession(t, fx, fx.owner, "First active turn")
+
+	msg := h.doJSON(t, http.MethodPost, "/v1/sessions/"+created.Session.ID+"/messages", fx, fx.owner, map[string]any{
+		"text": "Queue behind active turn",
+	})
+	if msg.Code != http.StatusAccepted {
+		t.Fatalf("message status=%d body=%s", msg.Code, msg.Body.String())
+	}
+	out := decodeSessionMutation(t, msg)
+	if !out.Queued {
+		t.Fatalf("queued=%t, want true while agent turn is active", out.Queued)
+	}
+	if runtime.messageCalls != 1 {
+		t.Fatalf("runtime message calls=%d, want only the initial direct send", runtime.messageCalls)
+	}
+	if runtime.configCalls != 0 {
+		t.Fatalf("runtime config calls=%d, want 0 for active-turn queue", runtime.configCalls)
+	}
+
+	var rows []model.SessionMessageQueue
+	if err := h.db.Where("session_id = ?", created.Session.ID).Order("sequence_number ASC").Find(&rows).Error; err != nil {
+		t.Fatalf("load queue rows: %v", err)
+	}
+	if len(rows) != 1 || rows[0].SequenceNumber != 2 || rows[0].Status != "pending" {
+		t.Fatalf("queue rows=%+v, want one pending sequence 2 row", rows)
+	}
+	assertNoSessionMessageDeliverTask(t, h)
+}
+
+func TestIntegration_SessionsCreate_StoppedAlwaysOnSandboxWakesWithoutConfigPush(t *testing.T) {
+	runtime := newSessionSyncRuntime(t, http.StatusOK)
+	h, provider := newSessionRuntimeHarness(t, runtime, nil)
+	fx := h.seed(t)
+	seedAlwaysOnRuntimeSandbox(t, h, fx, runtime.server.URL, "stopped")
+
+	out := h.createSession(t, fx, fx.owner, "Wake and send")
+	if out.Queued {
+		t.Fatalf("queued=%t, want false after wake and direct send", out.Queued)
+	}
+	if len(provider.started) != 1 {
+		t.Fatalf("provider started=%v, want one wake", provider.started)
+	}
+	if runtime.messageCalls != 1 {
+		t.Fatalf("runtime message calls=%d, want 1", runtime.messageCalls)
+	}
+	if runtime.configCalls != 0 {
+		t.Fatalf("runtime config calls=%d, want 0 when waking stopped sandbox for message", runtime.configCalls)
+	}
+	assertSessionQueueCount(t, h, out.Session.ID, 0)
+}
+
+func TestIntegration_SessionsCreate_DirectDeliveryFailureReleasesTurnWithoutQueueOrConfig(t *testing.T) {
+	runtime := newSessionSyncRuntime(t, http.StatusInternalServerError)
+	h, _ := newSessionRuntimeHarness(t, runtime, nil)
+	fx := h.seed(t)
+	seedAlwaysOnRuntimeSandbox(t, h, fx, runtime.server.URL, "running")
+
+	rr := h.doJSON(t, http.MethodPost, "/v1/sessions", fx, fx.owner, map[string]any{
+		"channel_id": fx.channel.ID.String(),
+		"text":       "Runtime should reject this hot send",
+	})
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("create session status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if runtime.messageCalls != 1 {
+		t.Fatalf("runtime message calls=%d, want 1", runtime.messageCalls)
+	}
+	if runtime.configCalls != 0 {
+		t.Fatalf("runtime config calls=%d, want 0 on direct delivery failure", runtime.configCalls)
+	}
+
+	var session model.Session
+	if err := h.db.Where("org_id = ?", fx.org.ID).First(&session).Error; err != nil {
+		t.Fatalf("load failed session: %v", err)
+	}
+	if session.AgentTurnStatus != model.SessionAgentTurnIdle || session.AgentTurnLastOutcome != model.SessionAgentTurnOutcomeFailed {
+		t.Fatalf("session turn not released after failure: %+v", session)
+	}
+	assertSessionQueueCount(t, h, session.ID.String(), 0)
+}
+
+func releaseSessionForNextUserTurn(t *testing.T, h *sessionHarness, sessionID string) {
+	t.Helper()
+	if err := h.db.Model(&model.Session{}).Where("id = ?", sessionID).Updates(map[string]any{
+		"agent_turn_status":       model.SessionAgentTurnIdle,
+		"agent_turn_id":           "",
+		"agent_stream_id":         "",
+		"agent_turn_started_at":   nil,
+		"agent_turn_last_outcome": model.SessionAgentTurnOutcomeDone,
+	}).Error; err != nil {
+		t.Fatalf("release session turn: %v", err)
+	}
+}
+
+func assertSessionQueueCount(t *testing.T, h *sessionHarness, sessionID string, want int64) {
+	t.Helper()
+	var count int64
+	if err := h.db.Model(&model.SessionMessageQueue{}).Where("session_id = ?", sessionID).Count(&count).Error; err != nil {
+		t.Fatalf("count session queue rows: %v", err)
+	}
+	if count != want {
+		t.Fatalf("queue rows=%d, want %d", count, want)
+	}
+}
+
+func assertNoSessionMessageDeliverTask(t *testing.T, h *sessionHarness) {
+	t.Helper()
+	for _, task := range h.enqueuer.Tasks() {
+		if task.TypeName == tasks.TypeSessionMessageDeliver {
+			t.Fatalf("unexpected %s task enqueued", tasks.TypeSessionMessageDeliver)
+		}
+	}
+}

--- a/internal/handler/sessions_input_responses.go
+++ b/internal/handler/sessions_input_responses.go
@@ -65,36 +65,36 @@ func (h *SessionHandler) RespondToInput(w http.ResponseWriter, r *http.Request) 
 			"option_id":  optionID,
 		},
 	}
-	var event model.SessionEvent
-	err := h.db.WithContext(r.Context()).Transaction(func(tx *gorm.DB) error {
-		if err := h.createQuestionAnsweredEvent(tx, &session, userID, requestID, text, optionID); err != nil {
-			return err
-		}
-		var err error
-		event, err = h.createUserMessageEvent(tx, &session, userID, messageText, payload)
-		if err != nil {
-			return err
-		}
-		return tx.Model(&model.Session{}).Where("id = ?", session.ID).Updates(map[string]any{
-			"updated_at":              event.EventAt,
-			"agent_turn_last_outcome": "",
-		}).Error
+	intent, err := h.createSessionMessageIntent(r.Context(), session, userID, messageText, payload, sessionMessageDeliveryOptions{
+		ClearLastOutcome: true,
+		BeforeUserMessage: func(tx *gorm.DB, locked *model.Session) error {
+			return h.createQuestionAnsweredEvent(tx, locked, userID, requestID, text, optionID)
+		},
 	})
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to queue input response"})
 		return
 	}
-	queued, err := h.dispatchOrQueueSessionDelivery(r.Context(), session.ID)
+	queued, err := h.dispatchSessionMessageIntent(r.Context(), intent)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to queue session delivery"})
+		if intent.Queued {
+			writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to queue session delivery"})
+			return
+		}
+		writeJSON(w, http.StatusBadGateway, errorResponse{Error: "failed to send input response"})
 		return
 	}
-	session.UpdatedAt = event.EventAt
-	session.AgentTurnLastOutcome = ""
+	session = intent.Session
+	if !queued {
+		if err := h.db.WithContext(r.Context()).First(&session, "id = ?", session.ID).Error; err != nil {
+			writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to load session"})
+			return
+		}
+	}
 	stats := h.statsForSessions(r.Context(), []uuid.UUID{session.ID})[session.ID]
 	writeJSON(w, http.StatusAccepted, sessionMutationResponse{
 		Session: sessionToResponse(session, stats.ParticipantCount, stats.EventCount, stats.LastEvent),
-		Event:   ptrSessionEventResponse(eventToResponse(event)),
+		Event:   ptrSessionEventResponse(eventToResponse(intent.Event)),
 		Queued:  queued,
 	})
 }

--- a/internal/handler/sessions_messages.go
+++ b/internal/handler/sessions_messages.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"gorm.io/gorm"
 
 	"github.com/usehivy/hivy/internal/model"
 )
@@ -92,38 +91,34 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 			"reasoning_effort": selectedReasoningEffort,
 		}
 	}
-	var event model.SessionEvent
-	err := h.db.WithContext(r.Context()).Transaction(func(tx *gorm.DB) error {
-		var err error
-		event, err = h.createUserMessageEvent(tx, &session, userID, text, payload)
-		if err != nil {
-			return err
-		}
-		updates := map[string]any{"updated_at": event.EventAt}
-		if selectedModel != "" {
-			updates["model"] = selectedModel
-			updates["reasoning_effort"] = selectedReasoningEffort
-		}
-		return tx.Model(&model.Session{}).Where("id = ?", session.ID).Updates(updates).Error
+	intent, err := h.createSessionMessageIntent(r.Context(), session, userID, text, payload, sessionMessageDeliveryOptions{
+		Model:           selectedModel,
+		ReasoningEffort: selectedReasoningEffort,
 	})
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to queue session message"})
 		return
 	}
-	queued, err := h.dispatchOrQueueSessionDelivery(r.Context(), session.ID)
+	queued, err := h.dispatchSessionMessageIntent(r.Context(), intent)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to queue session delivery"})
+		if intent.Queued {
+			writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to queue session delivery"})
+			return
+		}
+		writeJSON(w, http.StatusBadGateway, errorResponse{Error: "failed to send session message"})
 		return
 	}
-	session.UpdatedAt = event.EventAt
-	if selectedModel != "" {
-		session.Model = selectedModel
-		session.ReasoningEffort = selectedReasoningEffort
+	session = intent.Session
+	if !queued {
+		if err := h.db.WithContext(r.Context()).First(&session, "id = ?", session.ID).Error; err != nil {
+			writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to load session"})
+			return
+		}
 	}
 	stats := h.statsForSessions(r.Context(), []uuid.UUID{session.ID})[session.ID]
 	writeJSON(w, http.StatusAccepted, sessionMutationResponse{
 		Session: sessionToResponse(session, stats.ParticipantCount, stats.EventCount, stats.LastEvent),
-		Event:   ptrSessionEventResponse(eventToResponse(event)),
+		Event:   ptrSessionEventResponse(eventToResponse(intent.Event)),
 		Queued:  queued,
 	})
 }

--- a/internal/handler/sessions_per_session.go
+++ b/internal/handler/sessions_per_session.go
@@ -11,7 +11,6 @@ import (
 	"github.com/usehivy/hivy/internal/agentruntime"
 	"github.com/usehivy/hivy/internal/logging"
 	"github.com/usehivy/hivy/internal/model"
-	"github.com/usehivy/hivy/internal/tasks"
 )
 
 func (h *SessionHandler) provisionPerSessionSandbox(ctx context.Context, agent *model.Agent) (*model.Sandbox, error) {
@@ -36,18 +35,6 @@ func (h *SessionHandler) provisionPerSessionSandbox(ctx context.Context, agent *
 		return nil, fmt.Errorf("tag agent proxy token sandbox: %w", err)
 	}
 	return sb, nil
-}
-
-func (h *SessionHandler) dispatchInitialPerSessionDelivery(ctx context.Context, sessionID uuid.UUID) error {
-	if h == nil || h.orchestrator == nil {
-		return fmt.Errorf("session message delivery: orchestrator is required")
-	}
-	if h.compileDeps.EncKey == nil {
-		return fmt.Errorf("session message delivery: runtime encryption key is required")
-	}
-	dispatcher := tasks.NewSessionMessageDeliverHandler(h.db, h.orchestrator, h.compileDeps, h.enqueuer).WithoutProvisioning()
-	_, err := dispatcher.DispatchNext(ctx, sessionID)
-	return err
 }
 
 func (h *SessionHandler) cleanupFailedPerSessionCreate(ctx context.Context, sessionID uuid.UUID, sb *model.Sandbox) {

--- a/internal/handler/sessions_per_session_sync_helpers_test.go
+++ b/internal/handler/sessions_per_session_sync_helpers_test.go
@@ -76,6 +76,8 @@ type sessionSyncRuntime struct {
 	messageCalls    int
 	lastSessionID   string
 	lastMessageText string
+	lastModelID     string
+	lastAPIKeyEnv   string
 }
 
 func newSessionSyncRuntime(t *testing.T, messageStatus int) *sessionSyncRuntime {
@@ -110,10 +112,18 @@ func (rt *sessionSyncRuntime) handleMessage(w http.ResponseWriter, r *http.Reque
 		rt.lastSessionID = parts[1]
 	}
 	var body struct {
-		Text string `json:"text"`
+		Text            string `json:"text"`
+		ModelDefinition *struct {
+			ModelID   string `json:"model_id"`
+			APIKeyEnv string `json:"api_key_env"`
+		} `json:"model_definition"`
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
 	rt.lastMessageText = body.Text
+	if body.ModelDefinition != nil {
+		rt.lastModelID = body.ModelDefinition.ModelID
+		rt.lastAPIKeyEnv = body.ModelDefinition.APIKeyEnv
+	}
 	if rt.messageStatus >= http.StatusBadRequest {
 		http.Error(w, "runtime rejected message", rt.messageStatus)
 		return
@@ -216,6 +226,27 @@ func markSessionAgentPerSession(t *testing.T, h *sessionHarness, fx *sessionFixt
 		t.Fatalf("mark agent per-session: %v", err)
 	}
 	fx.agent.SandboxStrategy = "per_session"
+}
+
+func seedAlwaysOnRuntimeSandbox(t *testing.T, h *sessionHarness, fx sessionFixture, runtimeURL string, status string) model.Sandbox {
+	t.Helper()
+	encSecret, err := sessionTestEncKey(t).EncryptString("runtime-sync-secret-" + uuid.NewString())
+	if err != nil {
+		t.Fatalf("encrypt runtime secret: %v", err)
+	}
+	sb := model.Sandbox{
+		OrgID:                  &fx.org.ID,
+		AgentID:                &fx.agent.ID,
+		ProviderID:             sandboxpkg.ProviderMicrosandbox,
+		ExternalID:             "sync-existing-" + uuid.NewString()[:8],
+		RuntimeURL:             runtimeURL,
+		EncryptedRuntimeSecret: encSecret,
+		Status:                 status,
+	}
+	if err := h.db.Create(&sb).Error; err != nil {
+		t.Fatalf("create always-on runtime sandbox: %v", err)
+	}
+	return sb
 }
 
 func assertNoSessionCreateRows(t *testing.T, h *sessionHarness, orgID uuid.UUID) {

--- a/internal/handler/sessions_per_session_sync_test.go
+++ b/internal/handler/sessions_per_session_sync_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/usehivy/hivy/internal/agentruntime"
 	"github.com/usehivy/hivy/internal/model"
 	"github.com/usehivy/hivy/internal/tasks"
 )
@@ -41,16 +42,29 @@ func TestIntegration_SessionsCreate_PerSessionCreatesSandboxAndSendsFirstMessage
 	if runtime.messageCalls != 1 {
 		t.Fatalf("runtime message calls=%d, want 1", runtime.messageCalls)
 	}
+	if runtime.configCalls != 1 {
+		t.Fatalf("runtime config calls=%d, want 1 sandbox-create config push only", runtime.configCalls)
+	}
 	if runtime.lastSessionID != out.Session.ID || runtime.lastMessageText != "Ship the synchronous session path" {
 		t.Fatalf("runtime message session=%q text=%q", runtime.lastSessionID, runtime.lastMessageText)
 	}
-
-	var queue model.SessionMessageQueue
-	if err := h.db.First(&queue, "session_id = ?", out.Session.ID).Error; err != nil {
-		t.Fatalf("load queue row: %v", err)
+	if runtime.lastAPIKeyEnv != agentruntime.ProxyAPIKeyEnv {
+		t.Fatalf("runtime message api_key_env=%q, want %q", runtime.lastAPIKeyEnv, agentruntime.ProxyAPIKeyEnv)
 	}
-	if queue.Status != "delivered" || queue.RuntimeTurnID == "" || queue.RuntimeStreamID == "" {
-		t.Fatalf("queue not delivered synchronously: %+v", queue)
+
+	var queueCount int64
+	if err := h.db.Model(&model.SessionMessageQueue{}).Where("session_id = ?", out.Session.ID).Count(&queueCount).Error; err != nil {
+		t.Fatalf("count queue rows: %v", err)
+	}
+	if queueCount != 0 {
+		t.Fatalf("queue rows=%d, want 0 for direct initial delivery", queueCount)
+	}
+	var stored model.Session
+	if err := h.db.First(&stored, "id = ?", out.Session.ID).Error; err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+	if stored.AgentTurnStatus != model.SessionAgentTurnActive || stored.AgentTurnID == "" || stored.AgentStreamID == "" {
+		t.Fatalf("session turn not active after direct send: %+v", stored)
 	}
 	for _, task := range h.enqueuer.Tasks() {
 		if task.TypeName == tasks.TypeSessionMessageDeliver {

--- a/internal/handler/sessions_sandbox_wake_test.go
+++ b/internal/handler/sessions_sandbox_wake_test.go
@@ -13,6 +13,7 @@ func TestIntegration_SessionSandboxWakeStartsStoppedSandbox(t *testing.T) {
 	runtime := newSessionSyncRuntime(t, http.StatusOK)
 	h, provider := newSessionRuntimeHarness(t, runtime, nil)
 	fx := h.seed(t)
+	seedAlwaysOnRuntimeSandbox(t, h, fx, runtime.server.URL, "running")
 	created := h.createSession(t, fx, fx.owner, "Wake this sandbox")
 	sb := attachStoppedSessionSandbox(t, h, fx, created.Session.ID, runtime.server.URL)
 
@@ -49,6 +50,7 @@ func TestIntegration_SandboxAccessWakesStoppedSandboxBeforeMinting(t *testing.T)
 	runtime := newSessionSyncRuntime(t, http.StatusOK)
 	h, provider := newSessionRuntimeHarness(t, runtime, nil)
 	fx := h.seed(t)
+	seedAlwaysOnRuntimeSandbox(t, h, fx, runtime.server.URL, "running")
 	created := h.createSession(t, fx, fx.owner, "Access should wake")
 	sb := attachStoppedSessionSandbox(t, h, fx, created.Session.ID, runtime.server.URL)
 

--- a/internal/handler/sessions_system.go
+++ b/internal/handler/sessions_system.go
@@ -82,26 +82,24 @@ func (h *SessionHandler) createSystemSession(ctx context.Context, req systemSess
 		AgentTurnStatus:   model.SessionAgentTurnIdle,
 		IntegrationScopes: model.JSON{},
 	}
-	var event model.SessionEvent
-	err := h.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Create(&session).Error; err != nil {
-			return err
-		}
-		var err error
-		raw := req.Raw
-		event, err = h.createUserMessageEvent(tx, &session, nil, text, normalizeJSONPtr(&raw))
-		return err
-	})
+	raw := req.Raw
+	intent, err := h.createInitialSessionMessageIntent(ctx, &session, nil, text, normalizeJSONPtr(&raw))
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("create system session: %w", err)
 	}
-	if _, err := h.dispatchOrQueueSessionDelivery(ctx, session.ID); err != nil {
-		return nil, nil, true, fmt.Errorf("queue system session delivery: %w", err)
+	queued, err := h.dispatchSessionMessageIntent(ctx, intent)
+	if err != nil {
+		return nil, nil, queued, fmt.Errorf("send system session delivery: %w", err)
 	}
 	if autoName {
 		if err := h.enqueueSessionName(ctx, session.ID); err != nil {
 			logging.FromContext(ctx).WarnContext(ctx, "enqueue system session name task failed", "session_id", session.ID, "error", err)
 		}
 	}
-	return &session, &event, true, nil
+	if !queued {
+		if err := h.db.WithContext(ctx).First(&session, "id = ?", session.ID).Error; err != nil {
+			logging.FromContext(ctx).WarnContext(ctx, "reload system session after initial delivery failed", "session_id", session.ID, "error", err)
+		}
+	}
+	return &session, &intent.Event, queued, nil
 }

--- a/internal/tasks/agent_trigger_deliver.go
+++ b/internal/tasks/agent_trigger_deliver.go
@@ -36,10 +36,9 @@ func (h *AgentTriggerDispatchHandler) deliver(ctx context.Context, payload Agent
 		return err
 	}
 	if err := client.Readyz(ctx); err != nil {
-		if err := h.syncRuntime(ctx, &agent, sb, client); err != nil {
-			captureTriggerDispatchBoundary(ctx, "agent_runtime_readyz_sync", payload, trigger, "", "", err)
-			return err
-		}
+		err = fmt.Errorf("agent runtime readyz: %w", err)
+		captureTriggerDispatchBoundary(ctx, "agent_runtime_readyz", payload, trigger, "", "", err)
+		return err
 	}
 
 	compiled := h.compileMessage(payload, trigger, webhookPayload)
@@ -159,22 +158,4 @@ func (h *AgentTriggerDispatchHandler) loadAgentSandbox(ctx context.Context, agen
 		return nil, fmt.Errorf("load agent sandbox: %w", err)
 	}
 	return sb, nil
-}
-
-func (h *AgentTriggerDispatchHandler) syncRuntime(ctx context.Context, agent *model.Agent, sb *model.Sandbox, client *agentruntime.Client) error {
-	runtimeSecret, err := h.compileDeps.EncKey.DecryptString(sb.EncryptedRuntimeSecret)
-	if err != nil {
-		return fmt.Errorf("decrypt runtime secret: %w", err)
-	}
-	configUpdate, _, err := agentruntime.BuildAgentRuntimeConfigUpdate(ctx, h.compileDeps, agent, sb, runtimeSecret)
-	if err != nil {
-		return fmt.Errorf("build agent runtime config: %w", err)
-	}
-	if _, err := client.PutRuntimeConfig(ctx, configUpdate); err != nil {
-		return fmt.Errorf("agent runtime put config: %w", err)
-	}
-	if err := client.Readyz(ctx); err != nil {
-		return fmt.Errorf("agent runtime readyz: %w", err)
-	}
-	return nil
 }

--- a/internal/tasks/session_message_deliver.go
+++ b/internal/tasks/session_message_deliver.go
@@ -206,13 +206,22 @@ FOR UPDATE SKIP LOCKED`, sessionID).Scan(&row)
 }
 
 func (h *SessionMessageDeliverHandler) deliverClaim(ctx context.Context, queue *model.SessionMessageQueue) (*agentruntime.HTTPMessageResponse, error) {
-	if h.orchestrator == nil {
-		return nil, fmt.Errorf("session message delivery: orchestrator is required")
-	}
 	session := queue.Session
 	event := queue.SessionEvent
 	if session.ID == uuid.Nil || event.ID == uuid.Nil {
 		return nil, fmt.Errorf("session message delivery: queue row missing session or event")
+	}
+	return h.DeliverEvent(ctx, session, event)
+}
+
+// DeliverEvent posts a persisted session event directly to the runtime without
+// creating or updating any queue rows.
+func (h *SessionMessageDeliverHandler) DeliverEvent(ctx context.Context, session model.Session, event model.SessionEvent) (*agentruntime.HTTPMessageResponse, error) {
+	if h.orchestrator == nil {
+		return nil, fmt.Errorf("session message delivery: orchestrator is required")
+	}
+	if session.ID == uuid.Nil || event.ID == uuid.Nil {
+		return nil, fmt.Errorf("session message delivery: session and event are required")
 	}
 	var agent model.Agent
 	if err := h.db.WithContext(ctx).
@@ -220,7 +229,7 @@ func (h *SessionMessageDeliverHandler) deliverClaim(ctx context.Context, queue *
 		First(&agent).Error; err != nil {
 		return nil, fmt.Errorf("load session agent: %w", err)
 	}
-	sb, _, err := h.ensureRuntimeClient(ctx, session, &agent)
+	sb, client, err := h.ensureRuntimeClient(ctx, session, &agent)
 	if err != nil {
 		return nil, err
 	}
@@ -230,16 +239,11 @@ func (h *SessionMessageDeliverHandler) deliverClaim(ctx context.Context, queue *
 			Update("sandbox_id", sb.ID).Error; err != nil {
 			return nil, fmt.Errorf("attach session sandbox: %w", err)
 		}
+		session.SandboxID = &sb.ID
 	}
-	modelDef, err := agentruntime.PushAgentRuntimeConfigForSessionModel(
-		ctx, h.compileDeps, &agent, sb, session.ID, session.Model, session.ReasoningEffort,
-	)
+	modelDef, err := agentruntime.SessionModelDefinition(h.compileDeps, &agent, session.Model, session.ReasoningEffort)
 	if err != nil {
-		return nil, fmt.Errorf("sync session model runtime: %w", err)
-	}
-	client, err := h.orchestrator.GetRuntimeClient(ctx, sb)
-	if err != nil {
-		return nil, fmt.Errorf("get synced session runtime client: %w", err)
+		return nil, fmt.Errorf("build session model definition: %w", err)
 	}
 	msg := runtimeMessageFromEvent(session, event, modelDef)
 	resp, err := client.PostHTTPMessage(ctx, msg)

--- a/internal/tasks/session_message_deliver_runtime.go
+++ b/internal/tasks/session_message_deliver_runtime.go
@@ -87,16 +87,7 @@ func (h *SessionMessageDeliverHandler) ensureRuntimeClientUnlocked(ctx context.C
 		return nil, nil, fmt.Errorf("get runtime client: %w", err)
 	}
 	if err := client.Readyz(ctx); err != nil {
-		if !h.allowProvisioning {
-			return nil, nil, ErrSessionRuntimeNotReady
-		}
-		if err := agentruntime.PushAgentRuntimeConfig(ctx, h.compileDeps, agent, sb); err != nil {
-			return nil, nil, fmt.Errorf("sync agent runtime: %w", err)
-		}
-		client, err = h.orchestrator.GetRuntimeClient(ctx, sb)
-		if err != nil {
-			return nil, nil, fmt.Errorf("get synced runtime client: %w", err)
-		}
+		return nil, nil, fmt.Errorf("%w: runtime readyz: %v", ErrSessionRuntimeNotReady, err)
 	}
 	return sb, client, nil
 }


### PR DESCRIPTION
## Summary

- deliver new and idle session messages directly to the runtime instead of always inserting `session_message_queue` rows
- queue user messages only when the session is already on an active agent turn
- remove hot-path runtime config pushes from session message delivery and readyz repair paths
- add integration coverage for always-on first sends, idle follow-up sends, active-turn queueing, stopped sandbox wake, and runtime failure cleanup

## Root Cause

The hot session message path was doing more work than required. Every message created a queue row and the delivery path pushed full runtime config before posting the message. For always-on agents, config should already exist on sandbox creation/upgrade, so sending a first message or creating a new session should only post the message.

## Validation

- `go test ./internal/connectionaccess ./internal/handler ./internal/tasks ./internal/sandbox ./internal/mcpserver ./internal/token`
- `go test ./...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/usehivy/codesmith/hivy/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784559357&installation_id=135752923&pr_number=195&repository=usehivy%2Fhivy&return_to=https%3A%2F%2Fgithub.com%2Fusehivy%2Fhivy%2Fpull%2F195&signature=02fe448b15404cdccfe7894739012552077d60a923ae87ee3eae009ad3f32b00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now support direct message delivery without intermediate queueing for improved responsiveness
  * Added always-on session support with streamlined runtime handling

* **Bug Fixes**
  * Enhanced session turn state management and error recovery during message delivery
  * Improved reliability when sessions transition between active and idle states

* **Tests**
  * Added comprehensive integration tests validating direct delivery, queueing, and session wake scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the \"always-enqueue-then-deliver\" session message path with a direct runtime delivery model: idle sessions now post the message inline (no queue row), while active-turn sessions continue to queue. Config pushes on the hot delivery path are removed entirely, relying on sandbox creation/upgrade to have already set up the runtime.

- `sessions_delivery.go` introduces `createInitialSessionMessageIntent` / `createSessionMessageIntent` / `dispatchSessionMessageIntent` to atomically decide queue-vs-direct inside a `SELECT FOR UPDATE` transaction, and `releaseDirectSessionTurn` for failure cleanup.
- `agentruntime/session_model.go` is stripped to a pure `SessionModelDefinition` builder; proxy-token minting per session and `PushAgentRuntimeConfigForSessionModel` are removed.
- `session_message_deliver_runtime.go` and `agent_trigger_deliver.go` drop the `syncRuntime` / config-push recovery on `readyz` failure, making `ErrSessionRuntimeNotReady` unconditionally terminal (tasks retry via asynq, direct calls return 502).
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The direct-delivery path commits a message event to the database before the runtime call, and on runtime failure there is no fallback to the async queue — events can be stranded with no recovery path.

The new delivery pipeline works correctly for the happy path and is well-tested. However, the failure path for direct delivery removes the previous fallback-to-queue behavior: when `DeliverEvent` returns an error (including transient `ErrSessionRuntimeNotReady`), the committed message event is left in the DB unreachable, and the client receives a 502 with no recovery mechanism. In the old code, `ErrSessionRuntimeNotReady` was silently absorbed by falling back to `enqueueSessionDelivery`, so the message would eventually be delivered by the asynq worker. The removal of that fallback raises the risk that temporary sandbox unavailability during the direct-delivery window silently drops messages.

internal/handler/sessions_delivery.go — the error path of `dispatchSessionMessageIntent` and `releaseDirectSessionTurn` need the most scrutiny.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/handler/sessions_delivery.go | New file introducing the direct-delivery intent pipeline; contains the stranded-event risk on runtime failure and the silently-ignored cleanup error. |
| internal/agentruntime/session_model.go | Simplified to a pure model-config builder; removes proxy-token minting and config-push side effects, now always returns ProxyAPIKeyEnv for all sessions. |
| internal/tasks/session_message_deliver.go | Extracts `DeliverEvent` as a public shared method; removes the config-push step before posting, delegating that to sandbox creation. |
| internal/tasks/session_message_deliver_runtime.go | Removes the `syncRuntime` recovery path on readyz failure; now always returns ErrSessionRuntimeNotReady unconditionally when readyz fails, regardless of allowProvisioning. |
| internal/tasks/agent_trigger_deliver.go | Removes the syncRuntime recovery path on trigger delivery readyz failure; trigger tasks will now retry via asynq on runtime unavailability rather than attempting a config push. |
| internal/handler/sessions_system.go | Uses new intent pipeline; third return value now reflects actual queued/direct semantics instead of always returning true — affects caller logging behavior. |
| internal/handler/sessions_create.go | Migrated to intent-based delivery; for always-on agents the session is now created with agent_turn_status=active inside the transaction, committed before the runtime call. |
| internal/handler/sessions_direct_delivery_test.go | New integration test file covering the five key delivery scenarios: first-send, idle follow-up, active-turn queue, stopped sandbox wake, and direct delivery failure cleanup. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /sessions or /messages] --> B[createInitialSessionMessageIntent\nor createSessionMessageIntent]
    B --> C{runtimeDeliveryConfigured?}
    C -- No --> D[Create event + queue row\nin transaction]
    D --> E[enqueueSessionDelivery → asynq task]
    C -- Yes --> F{Session\nagent_turn_status?}
    F -- Active --> G[Create event + queue row\nin transaction]
    G --> H[DispatchQueue=false\nNo new task — active turn\nwill trigger next dispatch]
    F -- Idle --> I[Create event only, no queue row\nMark session active in transaction]
    I --> J[dispatchSessionMessageIntent\n→ DeliverEvent]
    J --> K{Runtime call\nresult?}
    K -- Success --> L[recordDirectSessionDelivery\nUpdate turn_id, stream_id]
    L --> M[Return 201/202 queued=false]
    K -- Failure --> N[releaseDirectSessionTurn\nSet idle + outcome=failed]
    N --> O[Return 502 — event stranded\nno queue fallback]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[POST /sessions or /messages] --> B[createInitialSessionMessageIntent\nor createSessionMessageIntent]
    B --> C{runtimeDeliveryConfigured?}
    C -- No --> D[Create event + queue row\nin transaction]
    D --> E[enqueueSessionDelivery → asynq task]
    C -- Yes --> F{Session\nagent_turn_status?}
    F -- Active --> G[Create event + queue row\nin transaction]
    G --> H[DispatchQueue=false\nNo new task — active turn\nwill trigger next dispatch]
    F -- Idle --> I[Create event only, no queue row\nMark session active in transaction]
    I --> J[dispatchSessionMessageIntent\n→ DeliverEvent]
    J --> K{Runtime call\nresult?}
    K -- Success --> L[recordDirectSessionDelivery\nUpdate turn_id, stream_id]
    L --> M[Return 201/202 queued=false]
    K -- Failure --> N[releaseDirectSessionTurn\nSet idle + outcome=failed]
    N --> O[Return 502 — event stranded\nno queue fallback]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/handler/sessions_system.go`, line 983-986 ([link](https://github.com/usehivy/hivy/blob/1862a1e94e741ac469be9349b9d97bdbac0d9bf5/internal/handler/sessions_system.go#L983-L986)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`createSystemSession` third return value semantics changed — caller affected**

   Previously `createSystemSession` always returned `queued = true` on success. Now it returns the actual `queued` value, which is `false` when direct delivery succeeds. The only current caller in `plugin_install_sync_handler.go` maps this value to `created` and gates the `"plugin service discovery dispatched"` log on it — so successfully direct-delivered system sessions no longer emit that log entry. Worth verifying whether any observability pipelines interpret this field as "a delivery was initiated" vs "was placed on the queue".

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fhandler%2Fsessions_system.go%0ALine%3A%20983-986%0A%0AComment%3A%0A**%60createSystemSession%60%20third%20return%20value%20semantics%20changed%20%E2%80%94%20caller%20affected**%0A%0APreviously%20%60createSystemSession%60%20always%20returned%20%60queued%20%3D%20true%60%20on%20success.%20Now%20it%20returns%20the%20actual%20%60queued%60%20value%2C%20which%20is%20%60false%60%20when%20direct%20delivery%20succeeds.%20The%20only%20current%20caller%20in%20%60plugin_install_sync_handler.go%60%20maps%20this%20value%20to%20%60created%60%20and%20gates%20the%20%60%22plugin%20service%20discovery%20dispatched%22%60%20log%20on%20it%20%E2%80%94%20so%20successfully%20direct-delivered%20system%20sessions%20no%20longer%20emit%20that%20log%20entry.%20Worth%20verifying%20whether%20any%20observability%20pipelines%20interpret%20this%20field%20as%20%22a%20delivery%20was%20initiated%22%20vs%20%22was%20placed%20on%20the%20queue%22.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=usehivy%2Fhivy&pr=195&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22usehivy%2Fhivy%22%20on%20the%20existing%20branch%20%22codex%2Fdirect-session-delivery%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fdirect-session-delivery%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fhandler%2Fsessions_system.go%0ALine%3A%20983-986%0A%0AComment%3A%0A**%60createSystemSession%60%20third%20return%20value%20semantics%20changed%20%E2%80%94%20caller%20affected**%0A%0APreviously%20%60createSystemSession%60%20always%20returned%20%60queued%20%3D%20true%60%20on%20success.%20Now%20it%20returns%20the%20actual%20%60queued%60%20value%2C%20which%20is%20%60false%60%20when%20direct%20delivery%20succeeds.%20The%20only%20current%20caller%20in%20%60plugin_install_sync_handler.go%60%20maps%20this%20value%20to%20%60created%60%20and%20gates%20the%20%60%22plugin%20service%20discovery%20dispatched%22%60%20log%20on%20it%20%E2%80%94%20so%20successfully%20direct-delivered%20system%20sessions%20no%20longer%20emit%20that%20log%20entry.%20Worth%20verifying%20whether%20any%20observability%20pipelines%20interpret%20this%20field%20as%20%22a%20delivery%20was%20initiated%22%20vs%20%22was%20placed%20on%20the%20queue%22.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=usehivy%2Fhivy&pr=195&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ainternal%2Fhandler%2Fsessions_delivery.go%3A158-161%0A**Stranded%20message%20event%20on%20direct%20delivery%20failure%20%E2%80%94%20no%20fallback%20enqueue**%0A%0AWhen%20%60DeliverEvent%60%20fails%20%28including%20%60ErrSessionRuntimeNotReady%60%29%2C%20%60releaseDirectSessionTurn%60%20resets%20the%20session%20to%20idle%20and%20the%20caller%20returns%20a%20502.%20But%20the%20message%20%60SessionEvent%60%20row%20was%20already%20committed%20to%20the%20database%20by%20%60createInitialSessionMessageIntent%60%20%2F%20%60createSessionMessageIntent%60%20without%20a%20corresponding%20queue%20row.%20If%20the%20client%20doesn't%20retry%20with%20the%20same%20session%20%28it%20usually%20can't%20for%20a%20%60Create%60%20502%2C%20since%20it%20never%20received%20the%20session%20ID%29%2C%20that%20event%20is%20orphaned%20%E2%80%94%20never%20delivered%2C%20never%20queued.%0A%0AThe%20previous%20code%20handled%20%60ErrSessionRuntimeNotReady%60%20in%20%60dispatchOrQueueSessionDelivery%60%20by%20falling%20back%20to%20%60h.enqueueSessionDelivery%60%2C%20ensuring%20the%20message%20would%20be%20picked%20up%20by%20the%20asynq%20worker.%20The%20new%20path%20has%20no%20such%20fallback.%20If%20the%20always-on%20sandbox%20is%20temporarily%20unavailable%20during%20a%20window%20of%20direct-delivery%20traffic%2C%20messages%20silently%20vanish%20from%20the%20user's%20perspective%20while%20persisting%20as%20unreachable%20DB%20rows.%0A%0AConsider%20enqueuing%20a%20%60TypeSessionMessageDeliver%60%20task%20%28and%20creating%20the%20queue%20row%29%20inside%20the%20error%20path%20of%20%60dispatchSessionMessageIntent%60%20when%20the%20failure%20is%20%60ErrSessionRuntimeNotReady%60%2C%20preserving%20the%20retry%20behavior%20for%20transient%20runtime%20unavailability.%0A%0A%23%23%23%20Issue%202%20of%203%0Ainternal%2Fhandler%2Fsessions_delivery.go%3A159-160%0A**Silently%20discarded%20cleanup%20error%20can%20leave%20sessions%20permanently%20stuck**%0A%0AThe%20%60_%60%20on%20%60releaseDirectSessionTurn%60%20means%20if%20the%20DB%20update%20fails%20%28transient%20connectivity%2C%20deadlock%29%2C%20the%20session%20stays%20with%20%60agent_turn_status%20%3D%20active%60%20and%20no%20further%20messages%20can%20be%20directly%20delivered%20to%20it%20%E2%80%94%20every%20subsequent%20call%20will%20queue%20behind%20a%20phantom%20active%20turn.%20Adding%20at%20minimum%20a%20structured%20log%20entry%20here%20would%20let%20operators%20detect%20and%20manually%20recover%20affected%20sessions.%0A%0A%23%23%23%20Issue%203%20of%203%0Ainternal%2Fhandler%2Fsessions_system.go%3A983-986%0A**%60createSystemSession%60%20third%20return%20value%20semantics%20changed%20%E2%80%94%20caller%20affected**%0A%0APreviously%20%60createSystemSession%60%20always%20returned%20%60queued%20%3D%20true%60%20on%20success.%20Now%20it%20returns%20the%20actual%20%60queued%60%20value%2C%20which%20is%20%60false%60%20when%20direct%20delivery%20succeeds.%20The%20only%20current%20caller%20in%20%60plugin_install_sync_handler.go%60%20maps%20this%20value%20to%20%60created%60%20and%20gates%20the%20%60%22plugin%20service%20discovery%20dispatched%22%60%20log%20on%20it%20%E2%80%94%20so%20successfully%20direct-delivered%20system%20sessions%20no%20longer%20emit%20that%20log%20entry.%20Worth%20verifying%20whether%20any%20observability%20pipelines%20interpret%20this%20field%20as%20%22a%20delivery%20was%20initiated%22%20vs%20%22was%20placed%20on%20the%20queue%22.%0A%0A&repo=usehivy%2Fhivy&pr=195&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22usehivy%2Fhivy%22%20on%20the%20existing%20branch%20%22codex%2Fdirect-session-delivery%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fdirect-session-delivery%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ainternal%2Fhandler%2Fsessions_delivery.go%3A158-161%0A**Stranded%20message%20event%20on%20direct%20delivery%20failure%20%E2%80%94%20no%20fallback%20enqueue**%0A%0AWhen%20%60DeliverEvent%60%20fails%20%28including%20%60ErrSessionRuntimeNotReady%60%29%2C%20%60releaseDirectSessionTurn%60%20resets%20the%20session%20to%20idle%20and%20the%20caller%20returns%20a%20502.%20But%20the%20message%20%60SessionEvent%60%20row%20was%20already%20committed%20to%20the%20database%20by%20%60createInitialSessionMessageIntent%60%20%2F%20%60createSessionMessageIntent%60%20without%20a%20corresponding%20queue%20row.%20If%20the%20client%20doesn't%20retry%20with%20the%20same%20session%20%28it%20usually%20can't%20for%20a%20%60Create%60%20502%2C%20since%20it%20never%20received%20the%20session%20ID%29%2C%20that%20event%20is%20orphaned%20%E2%80%94%20never%20delivered%2C%20never%20queued.%0A%0AThe%20previous%20code%20handled%20%60ErrSessionRuntimeNotReady%60%20in%20%60dispatchOrQueueSessionDelivery%60%20by%20falling%20back%20to%20%60h.enqueueSessionDelivery%60%2C%20ensuring%20the%20message%20would%20be%20picked%20up%20by%20the%20asynq%20worker.%20The%20new%20path%20has%20no%20such%20fallback.%20If%20the%20always-on%20sandbox%20is%20temporarily%20unavailable%20during%20a%20window%20of%20direct-delivery%20traffic%2C%20messages%20silently%20vanish%20from%20the%20user's%20perspective%20while%20persisting%20as%20unreachable%20DB%20rows.%0A%0AConsider%20enqueuing%20a%20%60TypeSessionMessageDeliver%60%20task%20%28and%20creating%20the%20queue%20row%29%20inside%20the%20error%20path%20of%20%60dispatchSessionMessageIntent%60%20when%20the%20failure%20is%20%60ErrSessionRuntimeNotReady%60%2C%20preserving%20the%20retry%20behavior%20for%20transient%20runtime%20unavailability.%0A%0A%23%23%23%20Issue%202%20of%203%0Ainternal%2Fhandler%2Fsessions_delivery.go%3A159-160%0A**Silently%20discarded%20cleanup%20error%20can%20leave%20sessions%20permanently%20stuck**%0A%0AThe%20%60_%60%20on%20%60releaseDirectSessionTurn%60%20means%20if%20the%20DB%20update%20fails%20%28transient%20connectivity%2C%20deadlock%29%2C%20the%20session%20stays%20with%20%60agent_turn_status%20%3D%20active%60%20and%20no%20further%20messages%20can%20be%20directly%20delivered%20to%20it%20%E2%80%94%20every%20subsequent%20call%20will%20queue%20behind%20a%20phantom%20active%20turn.%20Adding%20at%20minimum%20a%20structured%20log%20entry%20here%20would%20let%20operators%20detect%20and%20manually%20recover%20affected%20sessions.%0A%0A%23%23%23%20Issue%203%20of%203%0Ainternal%2Fhandler%2Fsessions_system.go%3A983-986%0A**%60createSystemSession%60%20third%20return%20value%20semantics%20changed%20%E2%80%94%20caller%20affected**%0A%0APreviously%20%60createSystemSession%60%20always%20returned%20%60queued%20%3D%20true%60%20on%20success.%20Now%20it%20returns%20the%20actual%20%60queued%60%20value%2C%20which%20is%20%60false%60%20when%20direct%20delivery%20succeeds.%20The%20only%20current%20caller%20in%20%60plugin_install_sync_handler.go%60%20maps%20this%20value%20to%20%60created%60%20and%20gates%20the%20%60%22plugin%20service%20discovery%20dispatched%22%60%20log%20on%20it%20%E2%80%94%20so%20successfully%20direct-delivered%20system%20sessions%20no%20longer%20emit%20that%20log%20entry.%20Worth%20verifying%20whether%20any%20observability%20pipelines%20interpret%20this%20field%20as%20%22a%20delivery%20was%20initiated%22%20vs%20%22was%20placed%20on%20the%20queue%22.%0A%0A&repo=usehivy%2Fhivy&pr=195&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(sessions): direct deliver idle messa..."](https://github.com/usehivy/hivy/commit/1862a1e94e741ac469be9349b9d97bdbac0d9bf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38814339)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->